### PR TITLE
Remove arrow from codeblock copy button

### DIFF
--- a/src/components/dev-hub/button.js
+++ b/src/components/dev-hub/button.js
@@ -168,9 +168,9 @@ const StyledButton = styled('button')`
  * @property {string?} props.to
  */
 
-const Button = ({ children, href, play, to, ...props }) => {
+const Button = ({ children, href, play, to, showArrow = true, ...props }) => {
     const isButton = !!(props.primary || props.secondary || play);
-    const rightArrow = (props.primary || props.secondary) && (
+    const rightArrow = (props.primary || props.secondary) && showArrow && (
         <span> &rarr;</span>
     );
     if (href || to || !isButton) {

--- a/src/components/dev-hub/copy-button.js
+++ b/src/components/dev-hub/copy-button.js
@@ -98,7 +98,12 @@ const CopyButton = ({
     }, [copyString, feedbackString, feedbackTimeout, nodesToString, timeoutId]);
 
     return (
-        <StyledCopyButton secondary type="button" onClick={onClick}>
+        <StyledCopyButton
+            secondary
+            showArrow={false}
+            type="button"
+            onClick={onClick}
+        >
             {feedbackMessage}
         </StyledCopyButton>
     );


### PR DESCRIPTION
With the new button style, codeblock copy buttons also got the right arrow but should not have it. This PR adds a default prop to toggle this arrow off if need be.