### PR TITLE
Article Series

### DIFF
--- a/src/components/dev-hub/series.js
+++ b/src/components/dev-hub/series.js
@@ -1,0 +1,147 @@
+import React from 'react';
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+import Link from './link';
+import { H3, P } from './text';
+import {
+    colorMap,
+    fontSize,
+    gradientMap,
+    layer,
+    screenSize,
+    size,
+} from './theme';
+
+const BULLET_BOX_WIDTH = '14px';
+const BULLET_SIZE = '22px';
+
+const activeLiStyles = css`
+    content: '\u29BF';
+    font-size: ${fontSize.default};
+`;
+
+const activeLinkStyles = css`
+    font-weight: bold;
+`;
+
+const Breadcrumb = styled('li')`
+    margin-bottom: 0;
+    padding-bottom: ${size.small};
+    position: relative;
+    width: 100%;
+    z-index: ${layer.back};
+    /* Create gradient bullet */
+    :before {
+        background: ${gradientMap.magentaSalmonSherbet};
+        background-clip: text;
+        content: '\u25E6';
+        display: inline-block;
+        font-size: ${BULLET_SIZE};
+        margin-right: ${size.small};
+        text-align: center;
+        width: ${BULLET_BOX_WIDTH};
+        z-index: ${layer.front};
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        ${({ active }) => active && activeLiStyles}
+    }
+
+    /* Create overflowing line to next element */
+    /* TODO: Allow text-overflow ellipsis but allow line below to next bullet */
+    :not(:last-of-type):after {
+        position: absolute;
+        content: '';
+        background-image: linear-gradient(
+                0deg,
+                transparent,
+                transparent 50%,
+                ${colorMap.greyDarkTwo} 50%,
+                ${colorMap.greyDarkTwo} 100%
+            ),
+            ${gradientMap.magentaSalmonSherbet};
+        background-size: ${size.medium} 3px, 100% 3px;
+        border-image-repeat: round;
+        left: 6px;
+        top: ${size.medium};
+        height: 30px;
+        width: 1px;
+        z-index: ${layer.superBack};
+    }
+`;
+
+const DescriptiveText = styled(P)`
+    color: ${colorMap.greyLightThree};
+    font-size: ${fontSize.tiny};
+`;
+
+const SeriesBreadcrumbs = styled('div')`
+    border-radius: 0 ${size.small} ${size.small} 0;
+    background-color: ${colorMap.greyDarkTwo};
+    flex: 1;
+    margin: 0;
+    padding: ${size.large};
+    /* TODO: fix overflow to allow ellipsis and line to next bullet */
+    overflow: hidden;
+    white-space: nowrap;
+    @media ${screenSize.upToMedium} {
+        border-radius: 0 0 ${size.small} ${size.small};
+        padding: ${size.medium};
+    }
+`;
+
+const SeriesContainer = styled('div')`
+    display: flex;
+    @media ${screenSize.upToMedium} {
+        flex-direction: column;
+    }
+`;
+
+const SeriesLink = styled(Link)`
+    font-family: 'Fira Mono', monospace;
+    font-size: ${fontSize.default};
+    text-decoration: none;
+    ${({ active }) => active && activeLinkStyles};
+`;
+
+const SeriesList = styled('ul')`
+    list-style: none;
+    padding-left: 0;
+`;
+
+const SeriesNameContainer = styled('div')`
+    background-color: ${colorMap.greyDarkThree};
+    border-radius: ${size.small} 0 0 ${size.small};
+    padding: ${size.large};
+    flex: 1;
+    @media ${screenSize.upToMedium} {
+        border-radius: ${size.small} ${size.small} 0 0;
+        padding: ${size.medium};
+    }
+`;
+
+const Series = ({ children, currentStep, name }) => {
+    return (
+        <SeriesContainer>
+            <SeriesNameContainer>
+                <DescriptiveText>More from this series</DescriptiveText>
+                <H3>{name}</H3>
+            </SeriesNameContainer>
+            <SeriesBreadcrumbs>
+                <SeriesList>
+                    {children.map(({ title, slug }) => (
+                        <Breadcrumb active={title === currentStep}>
+                            <SeriesLink
+                                active={title === currentStep}
+                                to={slug}
+                            >
+                                {title}
+                            </SeriesLink>
+                        </Breadcrumb>
+                    ))}
+                </SeriesList>
+            </SeriesBreadcrumbs>
+        </SeriesContainer>
+    );
+};
+
+export default Series;

--- a/src/pages/storybook.js
+++ b/src/pages/storybook.js
@@ -25,6 +25,7 @@ import {
     screenSize,
     gradientMap,
 } from '../components/dev-hub/theme';
+import Series from '../components/dev-hub/series';
 import Button from '../components/dev-hub/button';
 import ShareIcon from '../components/dev-hub/icons/share-icon';
 import FacebookIcon from '../components/dev-hub/icons/facebook-icon';
@@ -160,6 +161,18 @@ const SelectStory = ({ narrow }) => {
             value={value}
             onChange={handleValueChange}
         />
+    );
+};
+const SeriesStory = () => {
+    const series = [
+        { title: 'Step 1', slug: '#' },
+        { title: 'Step 2', slug: '#' },
+        { title: 'Step 3', slug: '#' },
+    ];
+    return (
+        <Series name="Storybook Series" currentStep="Step 2">
+            {series}
+        </Series>
     );
 };
 const BreadcrumbStory = () => {
@@ -404,6 +417,8 @@ export default () => (
                     </P>
                 </Swatch>
             ))}
+            <SectionHeader>Article Series</SectionHeader>
+            <SeriesStory />
             <SectionHeader>ToolTip/Content Menus</SectionHeader>
             <Row>
                 <TableOfContentsStory />


### PR DESCRIPTION
_Got verbal approval offline to merge, there are some things we can cleanup Monday for the Article Series component_

This PR adds the `Series` component, which allows series of articles to reference each other. This is ready to use for the writers.

I added a simple story for this component and made sure it properly links to various slugs. The data I used for testing this was in the snooty-prod DB (Sue helped me get some data to work with, changes I was trying to make were not showing locally with the default `.env.development`, I can demo this on Monday in-flight).

One aspect to fix later is wrapping long titles. I tried hiding overflow, which then also hid the line connecting bullets.

<img width="1227" alt="Screen Shot 2020-02-21 at 9 52 37 PM" src="https://user-images.githubusercontent.com/9064401/75085181-8185bb80-54f4-11ea-8fd0-e2f5de9d7f2c.png">

Storybook Desktop
<img width="1378" alt="Screen Shot 2020-02-21 at 9 28 03 PM" src="https://user-images.githubusercontent.com/9064401/75085188-8a768d00-54f4-11ea-8b01-32a81b2e4885.png">

Storybook Mobile
<img width="671" alt="Screen Shot 2020-02-21 at 9 32 56 PM" src="https://user-images.githubusercontent.com/9064401/75085189-8a768d00-54f4-11ea-8135-3cdf54992a33.png">

Wrapping Text Issue (Trying to hide overflow also hides the left line connecting bullets)
<img width="1227" alt="Screen Shot 2020-02-21 at 9 24 00 PM" src="https://user-images.githubusercontent.com/9064401/75085196-9a8e6c80-54f4-11ea-8669-788205bd9a7a.png">


