### PR TITLE
Fix the article series and related

### DIFF
--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -139,14 +139,15 @@ const Article = props => {
                 <ArticleSeries />
             </section>
 
-            <footer>
+            {/* TODO: Fix related data shape once stable  */}
+            {/* <footer>
                 <ul>
                     {meta.related.map(rel => {
                         const relatedText = rel.children[0].value;
                         return <li key={relatedText}>{relatedText}</li>;
                     })}
                 </ul>
-            </footer>
+            </footer> */}
         </Layout>
     );
 };


### PR DESCRIPTION
This PR fixes two page breaking issues:
1. If a series is defined on an article but it does not live in the `.toml` file.
2. Article related shape changed, so our placeholder code had to be updated.