### PR TITLE
Codeblock Button and Language Changes

### DIFF
--- a/src/components/dev-hub/button.js
+++ b/src/components/dev-hub/button.js
@@ -179,9 +179,9 @@ const getArrow = ({ pagination, primary, secondary }) => {
  * @property {string?} props.to
  */
 
-const Button = ({ children, href, play, to, ...props }) => {
+const Button = ({ children, href, play, to, hasArrow = true, ...props }) => {
     const isButton = !!(props.primary || props.secondary || play);
-    const arrow = getArrow(props);
+    const arrow = hasArrow ? getArrow(props) : null;
     if (href || to || !isButton) {
         // If the Button has a `to` or a `href` prop, then it renders as a `Link` element,
         const AsLink = StyledButton.withComponent(Link);

--- a/src/components/dev-hub/codeblock.js
+++ b/src/components/dev-hub/codeblock.js
@@ -55,7 +55,7 @@ const StyledCode = styled(Code)`
     }
 `;
 
-const CodeBlock = ({ nodeData: { value }, ...props }) => {
+const CodeBlock = ({ nodeData: { lang = null, value }, ...props }) => {
     // We wish to up padding based on the number of lines based on the size of the max number length
     const numLines = useMemo(() => value.split(/\r|\n/).length, [value]);
     const numDigits = useMemo(() => Math.floor(Math.log10(numLines) + 1), [
@@ -64,7 +64,7 @@ const CodeBlock = ({ nodeData: { value }, ...props }) => {
     return (
         <CodeContainer>
             <StyledCode
-                language="auto"
+                language={lang ? lang : 'auto'}
                 numdigits={numDigits}
                 showLineNumbers
                 variant="dark"

--- a/src/components/dev-hub/codeblock.js
+++ b/src/components/dev-hub/codeblock.js
@@ -55,7 +55,7 @@ const StyledCode = styled(Code)`
     }
 `;
 
-const CodeBlock = ({ nodeData: { lang = null, value }, ...props }) => {
+const CodeBlock = ({ nodeData: { value }, ...props }) => {
     // We wish to up padding based on the number of lines based on the size of the max number length
     const numLines = useMemo(() => value.split(/\r|\n/).length, [value]);
     const numDigits = useMemo(() => Math.floor(Math.log10(numLines) + 1), [
@@ -64,7 +64,7 @@ const CodeBlock = ({ nodeData: { lang = null, value }, ...props }) => {
     return (
         <CodeContainer>
             <StyledCode
-                language={lang ? lang : 'auto'}
+                language="auto"
                 numdigits={numDigits}
                 showLineNumbers
                 variant="dark"

--- a/src/components/dev-hub/copy-button.js
+++ b/src/components/dev-hub/copy-button.js
@@ -98,7 +98,12 @@ const CopyButton = ({
     }, [copyString, feedbackString, feedbackTimeout, nodesToString, timeoutId]);
 
     return (
-        <StyledCopyButton secondary type="button" onClick={onClick}>
+        <StyledCopyButton
+            secondary
+            hasArrow={false}
+            type="button"
+            onClick={onClick}
+        >
             {feedbackMessage}
         </StyledCopyButton>
     );


### PR DESCRIPTION
This PR does two things for the codeblock:

- Writers are trying to put in language options that don't match with the leafygreen codeblock languages (i.e., writers put in `csharp` when leafygreen wants `csp`). Sue is going to determine a mapping from writer language to leafygreen language and then we can add that in. For now, setting the language to `auto` resolves this.
- Adds a prop to the `Button` to disable the arrow