### PR TITLE
cap images to 100% width by default

### DIFF
--- a/src/components/dev-hub/layout.js
+++ b/src/components/dev-hub/layout.js
@@ -35,6 +35,9 @@ const globalStyles = css`
             padding: ${size.medium};
         }
     }
+    img {
+        max-width: 100%;
+    }
 `;
 
 const GlobalWrapper = styled('div')`


### PR DESCRIPTION
Saw some overflow for images in the article

![image](https://user-images.githubusercontent.com/514026/75362655-11c25880-5887-11ea-8112-3d2931596275.png)
