### PR TITLE
Related Internal Articles

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const dlv = require('dlv');
 const fs = require('fs').promises;
 const mkdirp = require('mkdirp');
 const { Stitch, AnonymousCredential } = require('mongodb-stitch-server-sdk');
@@ -84,6 +85,18 @@ const constructDbFilter = () => ({
     commit_hash: process.env.COMMIT_HASH || { $exists: false },
 });
 
+const getRelatedPagesWithImages = pageNodes => {
+    const related = dlv(pageNodes, 'query_fields.related', []);
+    let relatedPageInfo = [];
+    if (related.length) {
+        relatedPageInfo = related.map(r => ({
+            image: dlv(RESOLVED_REF_DOC_MAPPING, [r.target, 'atf-image'], null),
+            ...r,
+        }));
+    }
+    return relatedPageInfo;
+};
+
 exports.sourceNodes = async () => {
     // setup env variables
     const envResults = validateEnvVariables();
@@ -148,6 +161,10 @@ exports.createPages = async ({ actions }) => {
                 getNestedValue(['ast', 'options', 'template'], pageNodes)
             );
             const slug = getPageSlug(page);
+            if (pageNodes.query_fields) {
+                const relatedPages = getRelatedPagesWithImages(pageNodes);
+                pageNodes['query_fields'].related = relatedPages;
+            }
             createPage({
                 path: slug,
                 component: path.resolve(`./src/templates/${template}.js`),

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -87,17 +87,14 @@ const constructDbFilter = () => ({
 
 const getRelatedPagesWithImages = pageNodes => {
     const related = dlv(pageNodes, 'query_fields.related', []);
-    let relatedPageInfo = [];
-    if (related.length) {
-        relatedPageInfo = related.map(r => ({
-            image: dlv(
-                RESOLVED_REF_DOC_MAPPING,
-                [r.target, 'query_fields', 'atf-image'],
-                null
-            ),
-            ...r,
-        }));
-    }
+    const relatedPageInfo = related.map(r => ({
+        image: dlv(
+            RESOLVED_REF_DOC_MAPPING,
+            [r.target, 'query_fields', 'atf-image'],
+            null
+        ),
+        ...r,
+    }));
     return relatedPageInfo;
 };
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -90,7 +90,11 @@ const getRelatedPagesWithImages = pageNodes => {
     let relatedPageInfo = [];
     if (related.length) {
         relatedPageInfo = related.map(r => ({
-            image: dlv(RESOLVED_REF_DOC_MAPPING, [r.target, 'atf-image'], null),
+            image: dlv(
+                RESOLVED_REF_DOC_MAPPING,
+                [r.target, 'query_fields', 'atf-image'],
+                null
+            ),
             ...r,
         }));
     }

--- a/src/components/dev-hub/related-articles.js
+++ b/src/components/dev-hub/related-articles.js
@@ -27,11 +27,13 @@ const RelatedArticles = ({ related, slugTitleMapping }) => {
                     const target = r.target;
                     const slug = r.target && r.target.slice(1, r.target.length);
                     const image = r.image || ARTICLE_PLACEHOLDER;
-                    const title = dlv(
-                        slugTitleMapping,
-                        [slug, 0, 'value'],
-                        'Title Not Found'
-                    );
+                    const title = dlv(slugTitleMapping, [slug, 0, 'value'], '');
+                    if (title === '') {
+                        console.error(
+                            `No title found for this article ${slug}`,
+                            slugTitleMapping
+                        );
+                    }
                     /* TODO: Case on doc to link internal vs external */
                     return (
                         <Card

--- a/src/components/dev-hub/related-articles.js
+++ b/src/components/dev-hub/related-articles.js
@@ -6,14 +6,12 @@ import Card from './card';
 import { H4 } from './text';
 import { colorMap, screenSize, size } from './theme';
 
-const DESKTOP_HEIGHT = '575px';
-const MAX_CARD_WIDTH = 260;
+const MAX_CARD_WIDTH = 270;
 
 const RelatedContainer = styled('div')`
     background-color: ${colorMap.devBlack};
     padding: 30px;
     @media ${screenSize.mediumAndUp} {
-        height: ${DESKTOP_HEIGHT};
         padding: 70px ${size.xxlarge};
     }
 `;
@@ -22,23 +20,23 @@ const RelatedCards = styled('div')`
     display: flex;
     @media ${screenSize.upToMedium} {
         flex-direction: column;
-        > a {
+        > a,
+        > div {
             margin: 0 auto;
-            padding-left: 0;
-            padding-right: 0;
         }
     }
     @media ${screenSize.mediumAndUp} {
-        > a {
+        > a,
+        > div {
             padding-left: 0;
             padding-right: 0;
             margin-left: ${size.medium};
             margin-right: ${size.medium};
         }
-        > a:first-of-type {
+        > :first-child {
             margin-left: 0;
         }
-        > a:last-of-type {
+        > :last-child {
             margin-right: 0;
         }
     }

--- a/src/components/dev-hub/related-articles.js
+++ b/src/components/dev-hub/related-articles.js
@@ -4,17 +4,35 @@ import styled from '@emotion/styled';
 import ARTICLE_PLACEHOLDER from '../../images/1x/MDB-and-Node.js.png';
 import Card from './card';
 import { H4 } from './text';
-import { colorMap } from './theme';
+import { colorMap, screenSize } from './theme';
 
 const RelatedContainer = styled('div')`
     background-color: ${colorMap.devBlack};
     padding: 70px 120px;
-    margin: 0 auto;
-    height: 575px;
+    @media ${screenSize.mediumAndUp} {
+        height: 575px;
+    }
 `;
 
 const RelatedCards = styled('div')`
     display: flex;
+    @media ${screenSize.upToMedium} {
+        flex-direction: column;
+    }
+    @media ${screenSize.mediumAndUp} {
+        > a {
+            padding-left: 0;
+            padding-right: 0;
+            margin-left: 20px;
+            margin-right: 20px;
+        }
+        > a:first-of-type {
+            margin-left: 0;
+        }
+        > a:last-of-type {
+            margin-right: 0;
+        }
+    }
 `;
 
 const RelatedArticles = ({ related, slugTitleMapping }) => {
@@ -41,7 +59,7 @@ const RelatedArticles = ({ related, slugTitleMapping }) => {
                             href={target}
                             maxDescriptionLines={2}
                             title={title}
-                            maxWidth={260}
+                            // maxWidth={260}
                         />
                     );
                 })}

--- a/src/components/dev-hub/related-articles.js
+++ b/src/components/dev-hub/related-articles.js
@@ -48,7 +48,7 @@ const RelatedArticles = ({ related, slugTitleMapping }) => {
         <RelatedContainer>
             <H4>Related</H4>
             <RelatedCards>
-                {related.map(r => {
+                {related.map((r, i) => {
                     const target = r.target;
                     const slug = r.target && r.target.slice(1, r.target.length);
                     const image = r.image || ARTICLE_PLACEHOLDER;
@@ -62,6 +62,8 @@ const RelatedArticles = ({ related, slugTitleMapping }) => {
                     /* TODO: Case on doc to link internal vs external */
                     return (
                         <Card
+                            // Title may be undefined, so tacking on index keeps unique
+                            key={`${title}-${i}`}
                             image={image}
                             href={target}
                             maxDescriptionLines={2}

--- a/src/components/dev-hub/related-articles.js
+++ b/src/components/dev-hub/related-articles.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import dlv from 'dlv';
+import styled from '@emotion/styled';
+import ARTICLE_PLACEHOLDER from '../../images/1x/MDB-and-Node.js.png';
+import Card from './card';
+import { H4 } from './text';
+import { colorMap } from './theme';
+
+const RelatedContainer = styled('div')`
+    background-color: ${colorMap.devBlack};
+    padding: 70px 120px;
+    margin: 0 auto;
+    height: 575px;
+`;
+
+const RelatedCards = styled('div')`
+    display: flex;
+`;
+
+const RelatedArticles = ({ related, slugTitleMapping }) => {
+    if (!related || !related.length) return null;
+    return (
+        <RelatedContainer>
+            <H4>Related</H4>
+            <RelatedCards>
+                {related.map(r => {
+                    const target = r.target;
+                    const slug = r.target && r.target.slice(1, r.target.length);
+                    const image = r.image || ARTICLE_PLACEHOLDER;
+                    const title = dlv(
+                        slugTitleMapping,
+                        [slug, 0, 'value'],
+                        'Title Not Found'
+                    );
+                    /* TODO: Case on doc to link internal vs external */
+                    return (
+                        <Card
+                            image={image}
+                            href={target}
+                            maxDescriptionLines={2}
+                            title={title}
+                            maxWidth={260}
+                        />
+                    );
+                })}
+            </RelatedCards>
+        </RelatedContainer>
+    );
+};
+
+export default RelatedArticles;

--- a/src/components/dev-hub/related-articles.js
+++ b/src/components/dev-hub/related-articles.js
@@ -4,13 +4,17 @@ import styled from '@emotion/styled';
 import ARTICLE_PLACEHOLDER from '../../images/1x/MDB-and-Node.js.png';
 import Card from './card';
 import { H4 } from './text';
-import { colorMap, screenSize } from './theme';
+import { colorMap, screenSize, size } from './theme';
+
+const DESKTOP_HEIGHT = '575px';
+const MAX_CARD_WIDTH = 260;
 
 const RelatedContainer = styled('div')`
     background-color: ${colorMap.devBlack};
-    padding: 70px 120px;
+    padding: 30px;
     @media ${screenSize.mediumAndUp} {
-        height: 575px;
+        height: ${DESKTOP_HEIGHT};
+        padding: 70px ${size.xxlarge};
     }
 `;
 
@@ -18,13 +22,18 @@ const RelatedCards = styled('div')`
     display: flex;
     @media ${screenSize.upToMedium} {
         flex-direction: column;
+        > a {
+            margin: 0 auto;
+            padding-left: 0;
+            padding-right: 0;
+        }
     }
     @media ${screenSize.mediumAndUp} {
         > a {
             padding-left: 0;
             padding-right: 0;
-            margin-left: 20px;
-            margin-right: 20px;
+            margin-left: ${size.medium};
+            margin-right: ${size.medium};
         }
         > a:first-of-type {
             margin-left: 0;
@@ -59,7 +68,7 @@ const RelatedArticles = ({ related, slugTitleMapping }) => {
                             href={target}
                             maxDescriptionLines={2}
                             title={title}
-                            // maxWidth={260}
+                            maxWidth={MAX_CARD_WIDTH}
                         />
                     );
                 })}

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -5,10 +5,9 @@ import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import DocumentBody from '../components/DocumentBody';
 import BlogPostTitleArea from '../components/dev-hub/blog-post-title-area';
-import Card from '../components/dev-hub/card';
 import Layout from '../components/dev-hub/layout';
-import { H4 } from '../components/dev-hub/text';
-import { colorMap, size } from '../components/dev-hub/theme';
+import RelatedArticles from '../components/dev-hub/related-articles';
+import { size } from '../components/dev-hub/theme';
 import ARTICLE_PLACEHOLDER from '../../src/images/1x/MDB-and-Node.js.png';
 import Series from '../components/dev-hub/series';
 import { getNestedText } from '../utils/get-nested-text';
@@ -90,48 +89,6 @@ const ArticleSeries = ({
             </Series>
             <br />
         </>
-    );
-};
-
-const RelatedContainer = styled('div')`
-    background-color: ${colorMap.devBlack};
-    padding: 70px 120px;
-    margin: 0 auto;
-    height: 575px;
-`;
-
-const RelatedCards = styled('div')`
-    display: flex;
-`;
-
-const RelatedArticles = ({ related, slugTitleMapping }) => {
-    if (!related || !related.length) return null;
-    return (
-        <RelatedContainer>
-            <H4>Related</H4>
-            <RelatedCards>
-                {related.map(r => {
-                    const target = r.target;
-                    const slug = r.target && r.target.slice(1, r.target.length);
-                    const image = r.image || ARTICLE_PLACEHOLDER;
-                    const title = dlv(
-                        slugTitleMapping,
-                        [slug, 0, 'value'],
-                        'Title Not Found'
-                    );
-                    /* TODO: Case on doc to link internal vs external */
-                    return (
-                        <Card
-                            image={image}
-                            href={target}
-                            maxDescriptionLines={2}
-                            title={title}
-                            maxWidth={260}
-                        />
-                    );
-                })}
-            </RelatedCards>
-        </RelatedContainer>
     );
 };
 

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -4,12 +4,14 @@ import { withPrefix } from 'gatsby';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import ComponentFactory from '../components/ComponentFactory';
+import { useSiteMetadata } from '../hooks/use-site-metadata';
+import { callStitchFunction } from '../utils/stitch';
 import DocumentBody from '../components/DocumentBody';
 import BlogPostTitleArea from '../components/dev-hub/blog-post-title-area';
 import Card from '../components/dev-hub/card';
 import Layout from '../components/dev-hub/layout';
 import { H4 } from '../components/dev-hub/text';
-import { colorMap, size } from '../components/dev-hub/theme';
+import { colorMap, screenSize, size } from '../components/dev-hub/theme';
 import ARTICLE_PLACEHOLDER from '../../src/images/1x/MDB-and-Node.js.png';
 import Series from '../components/dev-hub/series';
 import { getNestedText } from '../utils/get-nested-text';
@@ -98,6 +100,11 @@ const RelatedContainer = styled('div')`
     background-color: ${colorMap.devBlack};
     padding: 70px 120px;
     margin: 0 auto;
+    height: 575px;
+`;
+
+const RelatedCards = styled('div')`
+    display: flex;
 `;
 
 const RelatedArticles = ({ related, slugTitleMapping }) => {
@@ -105,21 +112,28 @@ const RelatedArticles = ({ related, slugTitleMapping }) => {
     return (
         <RelatedContainer>
             <H4>Related</H4>
-            <div style={{ display: 'flex' }}>
+            <RelatedCards>
                 {related.map(r => {
                     const target = r.target;
-                    const slug = r.target.slice(1, r.target.length);
+                    const slug = r.target && r.target.slice(1, r.target.length);
+                    const image = r.image || ARTICLE_PLACEHOLDER;
+                    const title = dlv(
+                        slugTitleMapping,
+                        [slug, 0, 'value'],
+                        'Title Not Found'
+                    );
                     /* TODO: Case on doc to link internal vs external */
                     return (
                         <Card
-                            image={ARTICLE_PLACEHOLDER}
+                            image={image}
                             href={target}
                             maxDescriptionLines={2}
-                            title={slugTitleMapping[slug][0].value}
+                            title={title}
+                            maxWidth={260}
                         />
                     );
                 })}
-            </div>
+            </RelatedCards>
         </RelatedContainer>
     );
 };
@@ -187,6 +201,21 @@ const Article = props => {
             <RelatedArticles
                 related={[
                     {
+                        image: null,
+                        type: 'role',
+                        position: {
+                            start: {
+                                line: 51,
+                            },
+                        },
+                        domain: '',
+                        name: 'doc',
+                        target:
+                            '/quickstart/nodejs-how-to-connect-to-your-database',
+                        children: [],
+                    },
+                    {
+                        image: null,
                         type: 'role',
                         position: {
                             start: {
@@ -202,20 +231,6 @@ const Article = props => {
                 ]}
                 slugTitleMapping={slugTitleMapping}
             />
-            {/* TODO: Fix related data shape once stable  */}
-            {/* <footer>
-                <ul>
-                    {meta.related.map((rel, i) => {
-                        const test = {
-                            type: 'role',
-                            name: ':doc:',
-                            target:
-                                '/quickstart/nodejs-how-to-connect-to-your-database',
-                        };
-                        return <ComponentFactory nodeData={test} key={i} />;
-                    })}
-                </ul>
-            </footer> */}
         </Layout>
     );
 };
@@ -234,3 +249,22 @@ Article.propTypes = {
 };
 
 export default Article;
+
+/*
+[
+                    {
+                        image: null,
+                        type: 'role',
+                        position: {
+                            start: {
+                                line: 51,
+                            },
+                        },
+                        domain: '',
+                        name: 'doc',
+                        target:
+                            '/quickstart/nodejs-how-to-connect-to-your-database',
+                        children: [],
+                    },
+                ]
+*/

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -153,36 +153,7 @@ const Article = props => {
             </ArticleContent>
 
             <RelatedArticles
-                related={[
-                    {
-                        image: null,
-                        type: 'role',
-                        position: {
-                            start: {
-                                line: 51,
-                            },
-                        },
-                        domain: '',
-                        name: 'doc',
-                        target:
-                            '/quickstart/nodejs-how-to-connect-to-your-database',
-                        children: [],
-                    },
-                    {
-                        image: null,
-                        type: 'role',
-                        position: {
-                            start: {
-                                line: 51,
-                            },
-                        },
-                        domain: '',
-                        name: 'doc',
-                        target:
-                            '/quickstart/nodejs-how-to-connect-to-your-database',
-                        children: [],
-                    },
-                ]}
+                related={meta.related}
                 slugTitleMapping={slugTitleMapping}
             />
         </Layout>

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -3,15 +3,12 @@ import dlv from 'dlv';
 import { withPrefix } from 'gatsby';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import ComponentFactory from '../components/ComponentFactory';
-import { useSiteMetadata } from '../hooks/use-site-metadata';
-import { callStitchFunction } from '../utils/stitch';
 import DocumentBody from '../components/DocumentBody';
 import BlogPostTitleArea from '../components/dev-hub/blog-post-title-area';
 import Card from '../components/dev-hub/card';
 import Layout from '../components/dev-hub/layout';
 import { H4 } from '../components/dev-hub/text';
-import { colorMap, screenSize, size } from '../components/dev-hub/theme';
+import { colorMap, size } from '../components/dev-hub/theme';
 import ARTICLE_PLACEHOLDER from '../../src/images/1x/MDB-and-Node.js.png';
 import Series from '../components/dev-hub/series';
 import { getNestedText } from '../utils/get-nested-text';
@@ -199,36 +196,7 @@ const Article = props => {
             </ArticleContent>
 
             <RelatedArticles
-                related={[
-                    {
-                        image: null,
-                        type: 'role',
-                        position: {
-                            start: {
-                                line: 51,
-                            },
-                        },
-                        domain: '',
-                        name: 'doc',
-                        target:
-                            '/quickstart/nodejs-how-to-connect-to-your-database',
-                        children: [],
-                    },
-                    {
-                        image: null,
-                        type: 'role',
-                        position: {
-                            start: {
-                                line: 51,
-                            },
-                        },
-                        domain: '',
-                        name: 'doc',
-                        target:
-                            '/quickstart/nodejs-how-to-connect-to-your-database',
-                        children: [],
-                    },
-                ]}
+                related={meta.related}
                 slugTitleMapping={slugTitleMapping}
             />
         </Layout>
@@ -249,22 +217,3 @@ Article.propTypes = {
 };
 
 export default Article;
-
-/*
-[
-                    {
-                        image: null,
-                        type: 'role',
-                        position: {
-                            start: {
-                                line: 51,
-                            },
-                        },
-                        domain: '',
-                        name: 'doc',
-                        target:
-                            '/quickstart/nodejs-how-to-connect-to-your-database',
-                        children: [],
-                    },
-                ]
-*/

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -3,10 +3,13 @@ import dlv from 'dlv';
 import { withPrefix } from 'gatsby';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
+import ComponentFactory from '../components/ComponentFactory';
 import DocumentBody from '../components/DocumentBody';
 import BlogPostTitleArea from '../components/dev-hub/blog-post-title-area';
+import Card from '../components/dev-hub/card';
 import Layout from '../components/dev-hub/layout';
-import { size } from '../components/dev-hub/theme';
+import { H4 } from '../components/dev-hub/text';
+import { colorMap, size } from '../components/dev-hub/theme';
 import ARTICLE_PLACEHOLDER from '../../src/images/1x/MDB-and-Node.js.png';
 import Series from '../components/dev-hub/series';
 import { getNestedText } from '../utils/get-nested-text';
@@ -91,6 +94,36 @@ const ArticleSeries = ({
     );
 };
 
+const RelatedContainer = styled('div')`
+    background-color: ${colorMap.devBlack};
+    padding: 70px 120px;
+    margin: 0 auto;
+`;
+
+const RelatedArticles = ({ related, slugTitleMapping }) => {
+    if (!related || !related.length) return null;
+    return (
+        <RelatedContainer>
+            <H4>Related</H4>
+            <div style={{ display: 'flex' }}>
+                {related.map(r => {
+                    const target = r.target;
+                    const slug = r.target.slice(1, r.target.length);
+                    /* TODO: Case on doc to link internal vs external */
+                    return (
+                        <Card
+                            image={ARTICLE_PLACEHOLDER}
+                            href={target}
+                            maxDescriptionLines={2}
+                            title={slugTitleMapping[slug][0].value}
+                        />
+                    );
+                })}
+            </div>
+        </RelatedContainer>
+    );
+};
+
 const ArticleContent = styled('article')`
     margin: 0 auto;
     max-width: ${size.maxContentWidth};
@@ -151,12 +184,35 @@ const Article = props => {
                 />
             </ArticleContent>
 
+            <RelatedArticles
+                related={[
+                    {
+                        type: 'role',
+                        position: {
+                            start: {
+                                line: 51,
+                            },
+                        },
+                        domain: '',
+                        name: 'doc',
+                        target:
+                            '/quickstart/nodejs-how-to-connect-to-your-database',
+                        children: [],
+                    },
+                ]}
+                slugTitleMapping={slugTitleMapping}
+            />
             {/* TODO: Fix related data shape once stable  */}
             {/* <footer>
                 <ul>
-                    {meta.related.map(rel => {
-                        const relatedText = rel.children[0].value;
-                        return <li key={relatedText}>{relatedText}</li>;
+                    {meta.related.map((rel, i) => {
+                        const test = {
+                            type: 'role',
+                            name: ':doc:',
+                            target:
+                                '/quickstart/nodejs-how-to-connect-to-your-database',
+                        };
+                        return <ComponentFactory nodeData={test} key={i} />;
                     })}
                 </ul>
             </footer> */}

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -196,7 +196,36 @@ const Article = props => {
             </ArticleContent>
 
             <RelatedArticles
-                related={meta.related}
+                related={[
+                    {
+                        image: null,
+                        type: 'role',
+                        position: {
+                            start: {
+                                line: 51,
+                            },
+                        },
+                        domain: '',
+                        name: 'doc',
+                        target:
+                            '/quickstart/nodejs-how-to-connect-to-your-database',
+                        children: [],
+                    },
+                    {
+                        image: null,
+                        type: 'role',
+                        position: {
+                            start: {
+                                line: 51,
+                            },
+                        },
+                        domain: '',
+                        name: 'doc',
+                        target:
+                            '/quickstart/nodejs-how-to-connect-to-your-database',
+                        children: [],
+                    },
+                ]}
                 slugTitleMapping={slugTitleMapping}
             />
         </Layout>

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -153,64 +153,7 @@ const Article = props => {
             </ArticleContent>
 
             <RelatedArticles
-                related={[
-                    {
-                        image: null,
-                        type: 'role',
-                        position: {
-                            start: {
-                                line: 51,
-                            },
-                        },
-                        domain: '',
-                        name: 'doc',
-                        target:
-                            '/quickstart/nodejs-how-to-connect-to-your-database',
-                        children: [],
-                    },
-                    {
-                        image: null,
-                        type: 'role',
-                        position: {
-                            start: {
-                                line: 51,
-                            },
-                        },
-                        domain: '',
-                        name: 'doc',
-                        target:
-                            '/quickstart/nodejs-how-to-connect-to-your-database',
-                        children: [],
-                    },
-                    {
-                        image: null,
-                        type: 'role',
-                        position: {
-                            start: {
-                                line: 51,
-                            },
-                        },
-                        domain: '',
-                        name: 'doc',
-                        target:
-                            '/quickstart/nodejs-how-to-connect-to-your-database',
-                        children: [],
-                    },
-                    {
-                        image: null,
-                        type: 'role',
-                        position: {
-                            start: {
-                                line: 51,
-                            },
-                        },
-                        domain: '',
-                        name: 'doc',
-                        target:
-                            '/quickstart/nodejs-how-to-connect-to-your-database',
-                        children: [],
-                    },
-                ]}
+                related={meta.related}
                 slugTitleMapping={slugTitleMapping}
             />
         </Layout>

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -153,7 +153,64 @@ const Article = props => {
             </ArticleContent>
 
             <RelatedArticles
-                related={meta.related}
+                related={[
+                    {
+                        image: null,
+                        type: 'role',
+                        position: {
+                            start: {
+                                line: 51,
+                            },
+                        },
+                        domain: '',
+                        name: 'doc',
+                        target:
+                            '/quickstart/nodejs-how-to-connect-to-your-database',
+                        children: [],
+                    },
+                    {
+                        image: null,
+                        type: 'role',
+                        position: {
+                            start: {
+                                line: 51,
+                            },
+                        },
+                        domain: '',
+                        name: 'doc',
+                        target:
+                            '/quickstart/nodejs-how-to-connect-to-your-database',
+                        children: [],
+                    },
+                    {
+                        image: null,
+                        type: 'role',
+                        position: {
+                            start: {
+                                line: 51,
+                            },
+                        },
+                        domain: '',
+                        name: 'doc',
+                        target:
+                            '/quickstart/nodejs-how-to-connect-to-your-database',
+                        children: [],
+                    },
+                    {
+                        image: null,
+                        type: 'role',
+                        position: {
+                            start: {
+                                line: 51,
+                            },
+                        },
+                        domain: '',
+                        name: 'doc',
+                        target:
+                            '/quickstart/nodejs-how-to-connect-to-your-database',
+                        children: [],
+                    },
+                ]}
                 slugTitleMapping={slugTitleMapping}
             />
         </Layout>


### PR DESCRIPTION
This PR is not to be merged yet, it is a WIP for how I want to tackle related articles.

We get `meta.related` back, which (once the parser is updated), will return an array of nodes (not strings as it is with some test data). These nodes could be links to other articles or external based on the wiki.

We don't get the images for internal articles back with this node, so this WIP suggests adding it in `createPages` if it exists, and using a placeholder otherwise (still need to move the placeholder into createPages). This way we can safely add the image to the related node and reference it every time.

Curious if this approach is best? I left samples of the internal reference doc nodes in `article.js`. I don't think Role Docs would be useful here?

<img width="1347" alt="Screen Shot 2020-02-26 at 11 17 07 AM" src="https://user-images.githubusercontent.com/9064401/75364682-176d6d80-588a-11ea-80de-abcfec0d3887.png">
