### PR TITLE
Article Hero Cleanup

### DIFF
--- a/src/components/dev-hub/blog-post-title-area.js
+++ b/src/components/dev-hub/blog-post-title-area.js
@@ -27,12 +27,12 @@ const DateText = styled(P)`
 
 const BlogPostTitleArea = ({
     articleImage,
+    author,
     authorImage,
     breadcrumb,
     title,
     originalDate,
     tags,
-    author,
 }) => {
     return (
         <HeroBanner background={articleImage} breadcrumb={breadcrumb}>
@@ -41,7 +41,9 @@ const BlogPostTitleArea = ({
                 {originalDate && <DateText collapse>{originalDate}</DateText>}
                 <BlogTagList tags={tags} />
             </PostMetaLine>
-            <BylineBlock author={author} authorImage={authorImage} />
+            {author && (
+                <BylineBlock author={author} authorImage={authorImage} />
+            )}
         </HeroBanner>
     );
 };

--- a/src/components/dev-hub/blog-tag-list.js
+++ b/src/components/dev-hub/blog-tag-list.js
@@ -59,7 +59,7 @@ const BlogTag = ({ children, ...props }) => (
 );
 
 // eslint-disable-next-line no-unused-vars
-const BlogTagList = ({ tags = [], tagLinkBase }) => {
+const BlogTagList = ({ tags = [], tagLinkBase = '/tag' }) => {
     // TODO: add in article link below once finalized
     // const getArticleLink = tagName => `${tagLinkBase}/${tagName}`
     const canExpand = tags.length >= MINIMUM_EXPANDABLE_SIZE;

--- a/src/components/dev-hub/blog-tag-list.js
+++ b/src/components/dev-hub/blog-tag-list.js
@@ -58,31 +58,27 @@ const BlogTag = ({ children, ...props }) => (
     </TagListItem>
 );
 
-// eslint-disable-next-line no-unused-vars
-const BlogTagList = ({ tags = [], tagLinkBase = '/tag' }) => {
-    // TODO: add in article link below once finalized
-    // const getArticleLink = tagName => `${tagLinkBase}/${tagName}`
+const BlogTagList = ({ tags = [] }) => {
     const canExpand = tags.length >= MINIMUM_EXPANDABLE_SIZE;
     // By default any list of blog tags under the minimum expandable size is already expanded
     const [isExpanded, setIsExpanded] = useState(!canExpand);
     const expandList = useCallback(() => setIsExpanded(true), []);
-    const tagData = getTagData(tags, tagLinkBase);
     if (!tags.length) {
         return null;
     }
     return (
         <TagList>
             {isExpanded &&
-                tagData.map(t => (
-                    <BlogTag key={t.text} to={t.to}>
-                        {t.text}
+                tags.map(t => (
+                    <BlogTag key={t.label} to={t.to}>
+                        {t.label}
                     </BlogTag>
                 ))}
             {!isExpanded && canExpand && (
                 <>
                     {/* Since this can expand, we know value[0] and value[1] exist */}
-                    <BlogTag to={tagData[0].to}>{tagData[0].text}</BlogTag>
-                    <BlogTag to={tagData[1].to}>{tagData[1].text}</BlogTag>
+                    <BlogTag to={tags[0].to}>{tags[0].label}</BlogTag>
+                    <BlogTag to={tags[1].to}>{tags[1].label}</BlogTag>
                     <BlogTag onClick={expandList}>...</BlogTag>
                 </>
             )}

--- a/src/components/dev-hub/card.js
+++ b/src/components/dev-hub/card.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
+import { mapTagTypeToUrl } from '../../utils/map-tag-type-to-url';
 import { animationSpeed, colorMap, size, fontSize } from './theme';
 import { H5, P } from './text';
 import Link from './link';
@@ -142,7 +143,7 @@ const Card = ({
                 )}
             </div>
 
-            {tags && <TagList tags={tags} />}
+            {tags && <TagList tags={mapTagTypeToUrl(tags, 'tag')} />}
         </ContentWrapper>
     );
 };

--- a/src/pages/storybook.js
+++ b/src/pages/storybook.js
@@ -241,14 +241,14 @@ console.log(greeting('World'));`;
 const BlogTagListStory = ({ short }) => {
     const blogTags = short
         ? [
-              { text: 'Kerberos', to: '#' },
-              { text: 'Golang', to: '#' },
+              { label: 'Kerberos', to: '#' },
+              { label: 'Golang', to: '#' },
           ]
         : [
-              { text: 'Kerberos', to: '#' },
-              { text: 'Golang', to: '#' },
-              { text: 'Python', to: '#' },
-              { text: 'Another Tag', to: '#' },
+              { label: 'Kerberos', to: '#' },
+              { label: 'Golang', to: '#' },
+              { label: 'Python', to: '#' },
+              { label: 'Another Tag', to: '#' },
           ];
     return <BlogTagList tags={blogTags} />;
 };

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -115,9 +115,13 @@ const Article = props => {
     if (meta.type && meta.type.length) {
         articleBreadcrumbs.push({
             label: meta.type[0].toUpperCase() + meta.type.substring(1),
-            target: `/tag/${meta.type}`,
+            target: `/type/${meta.type}`,
         });
     }
+    const tagList = meta.tags.map(t => ({
+        label: t,
+        to: `/tag/${t}`,
+    }));
     console.log({ childNodes });
     console.log({ contentNodes });
     console.log({ meta });
@@ -127,14 +131,13 @@ const Article = props => {
         <Layout>
             <BlogPostTitleArea
                 // TODO: Pull real image once available
-                // articleImage={meta['atf-image']}
-                articleImage={ARTICLE_PLACEHOLDER}
+                articleImage={meta['atf-image'] || ARTICLE_PLACEHOLDER}
                 author={meta.author}
                 // TODO: Get author image from the parser
                 authorImage={meta.authorImage || ARTICLE_PLACEHOLDER}
                 breadcrumb={articleBreadcrumbs}
                 originalDate={meta.pubdate}
-                tags={meta.tags}
+                tags={tagList}
                 title={articleTitle}
             />
 

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import dlv from 'dlv';
+import { withPrefix } from 'gatsby';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import DocumentBody from '../components/DocumentBody';
@@ -128,8 +129,7 @@ const Article = props => {
     return (
         <Layout>
             <BlogPostTitleArea
-                // TODO: Pull real image once available
-                articleImage={meta['atf-image'] || ARTICLE_PLACEHOLDER}
+                articleImage={withPrefix(meta['atf-image'])}
                 author={meta.author}
                 // TODO: Get author image from the parser
                 authorImage={meta.authorImage || ARTICLE_PLACEHOLDER}

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -108,6 +108,16 @@ const Article = props => {
     const childNodes = dlv(__refDocMapping, 'ast.children', []);
     const contentNodes = getContent(childNodes);
     const meta = dlv(__refDocMapping, 'query_fields');
+    const articleBreadcrumbs = [
+        { label: 'Home', target: '/' },
+        { label: 'Learn', target: '/learn' },
+    ];
+    if (meta.type && meta.type.length) {
+        articleBreadcrumbs.push({
+            label: meta.type[0].toUpperCase() + meta.type.substring(1),
+            target: `/tag/${meta.type}`,
+        });
+    }
     console.log({ childNodes });
     console.log({ contentNodes });
     console.log({ meta });
@@ -122,11 +132,7 @@ const Article = props => {
                 author={meta.author}
                 // TODO: Get author image from the parser
                 authorImage={meta.authorImage || ARTICLE_PLACEHOLDER}
-                breadcrumb={[
-                    { label: 'Home', target: '/' },
-                    { label: 'Learn', target: '/learn' },
-                    { label: 'Quick Start', target: '#' },
-                ]}
+                breadcrumb={articleBreadcrumbs}
                 originalDate={meta.pubdate}
                 tags={[...meta.tags, ...meta.languages, ...meta.products]}
                 title={articleTitle}

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -134,7 +134,7 @@ const Article = props => {
                 authorImage={meta.authorImage || ARTICLE_PLACEHOLDER}
                 breadcrumb={articleBreadcrumbs}
                 originalDate={meta.pubdate}
-                tags={[...meta.tags, ...meta.languages, ...meta.products]}
+                tags={meta.tags}
                 title={articleTitle}
             />
 

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -9,6 +9,7 @@ import { size } from '../components/dev-hub/theme';
 import ARTICLE_PLACEHOLDER from '../../src/images/1x/MDB-and-Node.js.png';
 import Series from '../components/dev-hub/series';
 import { getNestedText } from '../utils/get-nested-text';
+import { getTagLinksFromMeta } from '../utils/get-tag-links-from-meta';
 
 let articleTitle = '';
 
@@ -118,10 +119,7 @@ const Article = props => {
             target: `/type/${meta.type}`,
         });
     }
-    const tagList = meta.tags.map(t => ({
-        label: t,
-        to: `/tag/${t}`,
-    }));
+    const tagList = getTagLinksFromMeta(meta);
     console.log({ childNodes });
     console.log({ contentNodes });
     console.log({ meta });

--- a/src/utils/get-tag-links-from-meta.js
+++ b/src/utils/get-tag-links-from-meta.js
@@ -1,0 +1,20 @@
+export const getTagLinksFromMeta = meta => {
+    const mappedTags = mapTagTypeToUrl(meta.tags, 'tag');
+    const mappedLanguageTags = mapTagTypeToUrl(meta.languages, 'language');
+    const mappedProductTags = mapTagTypeToUrl(meta.products, 'product');
+    const allTags = [
+        ...mappedTags,
+        ...mappedLanguageTags,
+        ...mappedProductTags,
+    ];
+    return allTags;
+};
+
+const mapTagTypeToUrl = (tags, tagType) => {
+    // Allow tag type to be omitted in article rST
+    if (!tags || !tags.length) return [];
+    return tags.map(t => ({
+        label: t,
+        to: `/${tagType}/${t}`,
+    }));
+};

--- a/src/utils/get-tag-links-from-meta.js
+++ b/src/utils/get-tag-links-from-meta.js
@@ -1,3 +1,5 @@
+import { mapTagTypeToUrl } from './map-tag-type-to-url';
+
 export const getTagLinksFromMeta = meta => {
     const mappedTags = mapTagTypeToUrl(meta.tags, 'tag');
     const mappedLanguageTags = mapTagTypeToUrl(meta.languages, 'language');
@@ -8,13 +10,4 @@ export const getTagLinksFromMeta = meta => {
         ...mappedProductTags,
     ];
     return allTags;
-};
-
-const mapTagTypeToUrl = (tags, tagType) => {
-    // Allow tag type to be omitted in article rST
-    if (!tags || !tags.length) return [];
-    return tags.map(t => ({
-        label: t,
-        to: `/${tagType}/${t}`,
-    }));
 };

--- a/src/utils/map-tag-type-to-url.js
+++ b/src/utils/map-tag-type-to-url.js
@@ -1,0 +1,8 @@
+export const mapTagTypeToUrl = (tags, tagType) => {
+    // Allow tag type to be omitted in article rST
+    if (!tags || !tags.length) return [];
+    return tags.map(t => ({
+        label: t,
+        to: `/${tagType}/${t}`,
+    }));
+};


### PR DESCRIPTION
This PR:

- Removes the hardcoding on breadcrumbs and will add another breadcrumb if `meta.type` is supplied, with a link to that page assuming it is going to be `/tag/${meta.type}` for now.
- Removes products and languages from the header tag list and adds `/tag` to the link so they also link to the expected page