### PR TITLE
update codeblocks

### DIFF
--- a/src/components/dev-hub/codeblock.js
+++ b/src/components/dev-hub/codeblock.js
@@ -64,7 +64,9 @@ const CodeBlock = ({ nodeData: { lang = null, value }, ...props }) => {
     return (
         <CodeContainer>
             <StyledCode
-                language={lang ? lang : 'auto'}
+                // remove this lang !== 'csp' hack once LG supports cs
+                // https://github.com/highlightjs/highlight.js/blob/master/SUPPORTED_LANGUAGES.md
+                language={lang && lang !== 'csp' ? lang : 'auto'}
                 numdigits={numDigits}
                 showLineNumbers
                 variant="dark"

--- a/src/components/dev-hub/theme.js
+++ b/src/components/dev-hub/theme.js
@@ -43,7 +43,7 @@ const size = {
     large: '32px',
     xlarge: '64px',
     xxlarge: '120px',
-    maxContentWidth: '740px',
+    maxContentWidth: '780px',
     maxWidth: '1440px',
     /** @type {function(string): number} */
     stripUnit(unit) {

--- a/src/pages/storybook.js
+++ b/src/pages/storybook.js
@@ -217,24 +217,45 @@ function greeting(entity) {
   return \`Hello, \${entity}!\`;
 }
 
-console.log(greeting('World'));`;
+genericFunction(greeting('World'));`;
 
 const codeSample = `
 function greeting(entity) {
   return \`Hello, \${entity}!\`;
 }
 
-console.log(greeting('World'));console.log(greeting('World'));
+genericFunction(greeting('World'));genericFunction(greeting('World'));
 function greeting(entity) {
   return \`Hello, \${entity}!\`;
 }
 
-console.log(greeting('World'));
+genericFunction(greeting('World'));
 function greeting(entity) {
   return \`Hello, \${entity}!\`;
 }
 
-console.log(greeting('World'));`;
+genericFunction(greeting('World'));
+
+`;
+
+const cSharpCodeSample = `
+using System;
+using System.Collections.Generic;
+
+namespace CSharpTutorials
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            string message = "Hello World!!";
+            // collections can't be created inside a transaction so create it first await database.CreateCollectionAsync("products");
+            Console.WriteLine(message);
+        }
+    }
+}
+`;
+
 const BlogTagListStory = ({ short }) => {
     const blogTags = short
         ? [
@@ -393,6 +414,7 @@ export default () => (
             </CodeArticle>
             <br />
             <CodeBlock nodeData={{ value: codeSample }} />
+            <CodeBlock nodeData={{ value: cSharpCodeSample, lang: 'csp' }} />
             <SectionHeader>Links</SectionHeader>
             <Link href="#">Hello World</Link>
             <Link href="#" tertiary>


### PR DESCRIPTION
Quick hack to map c-sharp to 'auto'. Leafy-green will put out a fix to us the correct `cs` lang, but for now 'auto' should correctly highlight.

Also increased the content width to ensure we have at least 80 char width for code blocks which is a hard requirement.

Finally I remove the `console.log`s from the code block samples so we wouldn't confuse them with our actual logs when it comes time to remove them