### PR TITLE
Support Author as Object Type

### DIFF
--- a/src/components/dev-hub/blog-post-title-area.js
+++ b/src/components/dev-hub/blog-post-title-area.js
@@ -28,7 +28,6 @@ const DateText = styled(P)`
 const BlogPostTitleArea = ({
     articleImage,
     author,
-    authorImage,
     breadcrumb,
     title,
     originalDate,
@@ -42,7 +41,10 @@ const BlogPostTitleArea = ({
                 <BlogTagList tags={tags} />
             </PostMetaLine>
             {author && (
-                <BylineBlock author={author} authorImage={authorImage} />
+                <BylineBlock
+                    authorName={author.name}
+                    authorImage={author.image}
+                />
             )}
         </HeroBanner>
     );

--- a/src/components/dev-hub/byline-block.js
+++ b/src/components/dev-hub/byline-block.js
@@ -66,14 +66,20 @@ const ByLine = styled('div')`
     }
 `;
 
-const BylineBlock = ({ authorName, authorImage }) => {
+const BylineBlock = ({ authorName = '', authorImage }) => {
+    const authorLink = `/author/${encodeURIComponent(
+        authorName
+            .toLowerCase()
+            .split(' ')
+            .join('-')
+    )}`;
     return (
         <ByLine>
             <AuthorImage>
                 <img src={withPrefix(authorImage)} alt={authorName} />
             </AuthorImage>
             <AuthorText collapse>
-                By <AuthorLink to="#">{authorName}</AuthorLink>
+                By <AuthorLink to={authorLink}>{authorName}</AuthorLink>
             </AuthorText>
         </ByLine>
     );

--- a/src/components/dev-hub/byline-block.js
+++ b/src/components/dev-hub/byline-block.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { withPrefix } from 'gatsby';
 import styled from '@emotion/styled';
 import Link from './link';
 import { P } from './text';
@@ -65,14 +66,14 @@ const ByLine = styled('div')`
     }
 `;
 
-const BylineBlock = ({ author, authorImage }) => {
+const BylineBlock = ({ authorName, authorImage }) => {
     return (
         <ByLine>
             <AuthorImage>
-                <img src={authorImage} alt={author} />
+                <img src={withPrefix(authorImage)} alt={authorName} />
             </AuthorImage>
             <AuthorText collapse>
-                By <AuthorLink to="#">{author}</AuthorLink>
+                By <AuthorLink to="#">{authorName}</AuthorLink>
             </AuthorText>
         </ByLine>
     );

--- a/src/pages/storybook.js
+++ b/src/pages/storybook.js
@@ -304,7 +304,10 @@ export default () => (
                 ]}
             >
                 <H1>DevHub Component "Storybook"</H1>
-                <BylineBlock author="UP Team" authorImage={MockAuthorImage} />
+                <BylineBlock
+                    authorName="UP Team"
+                    authorImage={MockAuthorImage}
+                />
             </HeroBanner>
             <SectionHeader>Text</SectionHeader>
             <H1>Heading 1</H1>

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -131,8 +131,6 @@ const Article = props => {
             <BlogPostTitleArea
                 articleImage={withPrefix(meta['atf-image'])}
                 author={meta.author}
-                // TODO: Get author image from the parser
-                authorImage={meta.authorImage || ARTICLE_PLACEHOLDER}
                 breadcrumb={articleBreadcrumbs}
                 originalDate={meta.pubdate}
                 tags={tagList}


### PR DESCRIPTION
We were not getting the author's image previously. Sophie and I worked ou this new structure for the author in article metadata:

```
// meta object
{
  author:
    {
      name: 'Author Name',
      image: '/path/to/image.jpg'
    },
  ...rest
}
```

This PR changes `article.js` and child components to expect author as an object.