### PR TITLE
add all option for filter

### DIFF
--- a/src/components/dev-hub/filter-bar.js
+++ b/src/components/dev-hub/filter-bar.js
@@ -52,7 +52,7 @@ const SelectWrapper = styled('div')`
 // These objects are then zipped into an array of arrays
 const callStitch = async (metadata, key, callback) => {
     const res = await callStitchFunction('getValuesByKey', metadata, key);
-    callback(zipObjects(res));
+    callback([['all', 'All'], ...zipObjects(res)]);
 };
 
 export default React.memo(

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -59,12 +59,13 @@ const callStitch = async (metadata, key, callback) => {
 };
 // strip out the 'All' param from the url and the stitch function key
 const stripAllParam = filterValue => {
-    Object.keys(filterValue).map(key => {
-        if (filterValue[key] === 'all') {
-            delete filterValue[key];
+    const newFilter = {};
+    Object.keys(filterValue).forEach(key => {
+        if (filterValue[key] !== 'all') {
+            newFilter[key] = filterValue[key];
         }
     });
-    return filterValue;
+    return newFilter;
 };
 export default ({ location }) => {
     const metadata = useSiteMetadata();
@@ -76,7 +77,7 @@ export default ({ location }) => {
         const filter = stripAllParam(filterValue);
         const searchParams = buildQueryString(filter);
         // if the search params are empty, push the pathname state in order to remove params
-        window.history.pushState(
+        window.history.replaceState(
             {},
             '',
             searchParams === '' ? pathname : searchParams


### PR DESCRIPTION
This PR adds the 'All' option to the filter dropdowns. For now, I did not put a number next the all the option because in order to get that value i would have to make the call for all articles (regardless of the filter) and then count them.

I personally think it looks okay as is, but If we want a number next to all, I'm thinking we should add that to the stitch function that returns the other values.
![Screen Shot 2020-02-27 at 1 46 42 PM](https://user-images.githubusercontent.com/43755359/75475894-9f757500-5967-11ea-81b0-3f7d4d0858cd.png)
