### PR TITLE
Tag Page Routes

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -137,12 +137,11 @@ const createTagPageType = async (createPage, pageMetadata, stitchType) => {
         pages: pageData[i],
     }));
 
-    const PAGES = [];
-
-    itemsWithPageData.forEach(page => {
+    const pageList = itemsWithPageData.map(page => {
         const name = isAuthor ? page.item._id.name : page.item._id;
         // Some bad data for authors doesn't follow this structure, so ignore it
-        if (name) {
+        if (!name) return null;
+        else {
             const urlSuffix = isAuthor
                 ? encodeURIComponent(
                       name
@@ -160,21 +159,23 @@ const createTagPageType = async (createPage, pageMetadata, stitchType) => {
             if (isAuthor) {
                 newPage['author_image'] = page.item._id.image;
             }
-            PAGES.push(newPage);
+            return newPage;
         }
     });
 
-    PAGES.forEach(page => {
-        console.log(page.slug);
-        createPage({
-            path: page.slug,
-            component: path.resolve(`./src/templates/tag.js`),
-            context: {
-                metadata: pageMetadata,
-                snootyStitchId: SNOOTY_STITCH_ID,
-                ...page,
-            },
-        });
+    pageList.forEach(page => {
+        if (page) {
+            console.log(page.slug);
+            createPage({
+                path: page.slug,
+                component: path.resolve(`./src/templates/tag.js`),
+                context: {
+                    metadata: pageMetadata,
+                    snootyStitchId: SNOOTY_STITCH_ID,
+                    ...page,
+                },
+            });
+        }
     });
 };
 
@@ -228,7 +229,7 @@ exports.sourceNodes = async () => {
 
 exports.createPages = async ({ actions }) => {
     const { createPage } = actions;
-    const pageMetadata = await stitchClient.callFunction('fetchDocument', [
+    const metadata = await stitchClient.callFunction('fetchDocument', [
         DB,
         METADATA_COLLECTION,
         constructDbFilter(),
@@ -250,7 +251,7 @@ exports.createPages = async ({ actions }) => {
                 path: slug,
                 component: path.resolve(`./src/templates/${template}.js`),
                 context: {
-                    metadata: pageMetadata,
+                    metadata: metadata,
                     slug,
                     snootyStitchId: SNOOTY_STITCH_ID,
                     __refDocMapping: pageNodes,
@@ -260,11 +261,11 @@ exports.createPages = async ({ actions }) => {
     });
 
     await Promise.all([
-        createTagPageType(createPage, pageMetadata, 'author'),
-        createTagPageType(createPage, pageMetadata, 'languages'),
-        createTagPageType(createPage, pageMetadata, 'products'),
-        createTagPageType(createPage, pageMetadata, 'tags'),
-        createTagPageType(createPage, pageMetadata, 'type'),
+        createTagPageType(createPage, metadata, 'author'),
+        createTagPageType(createPage, metadata, 'languages'),
+        createTagPageType(createPage, metadata, 'products'),
+        createTagPageType(createPage, metadata, 'tags'),
+        createTagPageType(createPage, metadata, 'type'),
     ]);
 };
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -129,12 +129,15 @@ const createTagPageType = async (createPage, pageMetadata, stitchType) => {
     const pageData = await Promise.all(requests);
 
     // Once requests finish, map the item with name (and optional image) to the response's return value
-    const allData = res.map((r, i) => ({ item: r, pages: pageData[i] }));
+    const itemsWithPageData = res.map((r, i) => ({
+        item: r,
+        pages: pageData[i],
+    }));
 
     const PAGES = [];
 
-    allData.forEach(p => {
-        const name = isAuthor ? p.item._id.name : p.item._id;
+    itemsWithPageData.forEach(page => {
+        const name = isAuthor ? page.item._id.name : page.item._id;
         // Some bad data for authors doesn't follow this structure, so ignore it
         if (name) {
             const urlSuffix = isAuthor
@@ -149,24 +152,24 @@ const createTagPageType = async (createPage, pageMetadata, stitchType) => {
                 type: pageType,
                 name: name,
                 slug: `/${pageType}/${urlSuffix}`,
-                pages: p.pages,
+                pages: page.pages,
             };
             if (isAuthor) {
-                newPage['author_image'] = p.item._id.image;
+                newPage['author_image'] = page.item._id.image;
             }
             PAGES.push(newPage);
         }
     });
 
-    PAGES.forEach(p => {
-        console.log(p.slug);
+    PAGES.forEach(page => {
+        console.log(page.slug);
         createPage({
-            path: p.slug,
+            path: page.slug,
             component: path.resolve(`./src/templates/tag.js`),
             context: {
                 metadata: pageMetadata,
                 snootyStitchId: SNOOTY_STITCH_ID,
-                ...p,
+                ...page,
             },
         });
     });

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -128,6 +128,7 @@ const createTagPageType = async (createPage, pageMetadata, stitchType) => {
 
     const pageData = await Promise.all(requests);
 
+    // Once requests finish, map the item with name (and optional image) to the response's return value
     const allData = res.map((r, i) => ({ item: r, pages: pageData[i] }));
 
     const PAGES = [];
@@ -143,7 +144,7 @@ const createTagPageType = async (createPage, pageMetadata, stitchType) => {
                           .split(' ')
                           .join('-')
                   )
-                : name.toLowerCase();
+                : encodeURIComponent(name.toLowerCase());
             const newPage = {
                 type: pageType,
                 name: name,

--- a/src/components/dev-hub/layout.js
+++ b/src/components/dev-hub/layout.js
@@ -40,6 +40,11 @@ const globalStyles = css`
     }
 `;
 
+const Main = styled('main')`
+    /* ensure content takes up full space between header & footer*/
+    min-height: calc(100vh - 300px);
+`;
+
 const GlobalWrapper = styled('div')`
     display: flex;
     flex-direction: column;
@@ -61,7 +66,7 @@ export default ({ children }) => (
     <GlobalWrapper>
         <Global styles={globalStyles} />
         <GlobalNav />
-        <main>{children}</main>
+        <Main>{children}</Main>
         <GlobalFooter />
     </GlobalWrapper>
 );

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -25,6 +25,7 @@ const TagTitle = styled('div')`
 
     ${P} {
         color: ${colorMap.greyLightThree};
+        font-size: ${fontSize.tiny};
         margin: 0;
         padding: 0;
     }

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -54,7 +54,7 @@ const ArticleContent = styled('article')`
 `;
 
 const constructArticles = data =>
-    data.reduce((accum, item) => accum.push({ ...item.query_fields }), []);
+    data.reduce((accum, item) => accum.concat({ ...item.query_fields }), []);
 
 const Tag = props => {
     const {

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -11,6 +11,7 @@ import {
     screenSize,
     size,
     colorMap,
+    fontSize,
 } from '../components/dev-hub/theme';
 import { createShadowElement } from '../components/dev-hub/utils';
 
@@ -53,10 +54,26 @@ const AuthorImage = styled('div')`
     }
 
 `;
+const AuthorName = styled('div')`
+    ${P} {
+        color: ${colorMap.greyLightThree};
+        font-size: ${fontSize.tiny};
+    }
+
+    ${H2} {
+        font-size: ${fontSize.xlarge};
+    }
+`;
+
 const AuthorByline = styled('div')`
     display: flex;
     flex-direction: row;
     justify-content: start;
+`;
+
+const AuthorHero = styled('div')`
+    display: flex;
+    flex-direction: row;
 `;
 
 const ArticleContent = styled('article')`
@@ -74,13 +91,20 @@ const constructArticles = data =>
 
 const Tag = props => {
     const {
-        pageContext: { pages, author_image, name, slug, type },
+        pageContext: {
+            bio,
+            pages,
+            author_image,
+            location,
+            name,
+            slug,
+            title,
+            type,
+        },
     } = props;
     const isAuthor = type === 'author';
     const articles = constructArticles(pages);
     const capitalizedBreadcrumb = name.charAt(0).toUpperCase() + name.slice(1);
-    console.log('props: ', props);
-    console.log("articles: ', ", articles);
     return (
         <Layout>
             <HeroBanner
@@ -97,12 +121,22 @@ const Tag = props => {
                     </TagTitle>
                 )}
                 {isAuthor && (
-                    <AuthorByline>
-                        <AuthorImage>
-                            <img src={author_image} alt={name} />
-                        </AuthorImage>
-                        <H2>{name}</H2>
-                    </AuthorByline>
+                    <AuthorHero>
+                        <AuthorByline>
+                            <AuthorImage>
+                                <img src={author_image} alt={name} />
+                            </AuthorImage>
+                            <AuthorName>
+                                <H2>{name}</H2>
+                                {title && location && (
+                                    <P>
+                                        {title} - {location}
+                                    </P>
+                                )}
+                            </AuthorName>
+                        </AuthorByline>
+                        {bio && <P>{bio}</P>}
+                    </AuthorHero>
                 )}
             </HeroBanner>
 
@@ -123,9 +157,13 @@ Tag.propTypes = {
                 tags: PropTypes.arrayOf(PropTypes.string),
             }),
         }),
+        // TODO: Some of these fields are not yet part of author's data (ex: bio, location, title)
         author_image: PropTypes.string,
+        bio: PropTypes.string,
+        location: PropTypes.string,
         name: PropTypes.string.isRequired,
         slug: PropTypes.string.isRequired,
+        title: PropTypes.string,
         type: PropTypes.string.isRequired,
     }),
 };

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -1,0 +1,125 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import PropTypes from 'prop-types';
+import CardList from '../components/dev-hub/card-list';
+import HeroBanner from '../components/dev-hub/hero-banner';
+import Layout from '../components/dev-hub/layout';
+import { H2, H3, P } from '../components/dev-hub/text';
+import {
+    gradientMap,
+    layer,
+    screenSize,
+    size,
+} from '../components/dev-hub/theme';
+import { createShadowElement } from '../components/dev-hub/utils';
+
+const BYLINE_HEIGHT_OFFSET = 6;
+const BYLINE_IMAGE_HEIGHT = 50;
+
+const AuthorImage = styled('div')`
+    @media ${screenSize.upToMedium} {
+      display: none;
+    }
+    height: ${BYLINE_IMAGE_HEIGHT}px;
+    margin-right: ${size.medium};
+    position: relative;
+    z-index: ${layer.front};
+    > img {
+        border-radius: 50%;
+        height: ${BYLINE_IMAGE_HEIGHT}px;
+    }
+    &:before {
+        ${createShadowElement(
+            gradientMap.greenTealOffset,
+            size.large,
+            0,
+            -BYLINE_HEIGHT_OFFSET
+        )}
+        height: ${BYLINE_IMAGE_HEIGHT + BYLINE_HEIGHT_OFFSET}px;
+        width: ${BYLINE_IMAGE_HEIGHT + BYLINE_HEIGHT_OFFSET}px;
+    }
+
+`;
+const AuthorByline = styled('div')`
+    display: flex;
+    flex-direction: row;
+    justify-content: start;
+`;
+
+const ArticleContent = styled('article')`
+    margin: 0 auto;
+    max-width: ${size.maxContentWidth};
+    padding-left: ${size.small};
+    padding-right: ${size.small};
+`;
+
+const constructArticles = data =>
+    data.reduce((accum, item) => accum.push({ ...item.query_fields }), []);
+
+// TODO change name of this
+const Tag = props => {
+    const {
+        pathContext: {
+            pages,
+            author_image,
+            name,
+            // slug,
+            type,
+        },
+    } = props;
+    const isAuthor = type === 'author';
+    const articles = constructArticles(pages);
+    console.log('props: ', props);
+    return (
+        <Layout>
+            <HeroBanner
+                breadcrumb={[
+                    { label: 'Home', to: '/' },
+                    { label: 'Learn', to: '/learn' },
+                ]}
+            >
+                {!isAuthor && (
+                    <div>
+                        <P>Tagged in</P>
+                        <H2>{name}</H2>
+                    </div>
+                )}
+                {isAuthor && (
+                    <AuthorByline>
+                        <AuthorImage>
+                            <img src={author_image} alt={name} />
+                        </AuthorImage>
+                        <H2>{name}</H2>
+                    </AuthorByline>
+                )}
+            </HeroBanner>
+
+            <ArticleContent>
+                {isAuthor && <H3>Articles by {name}</H3>}
+                <CardList items={articles} />
+            </ArticleContent>
+        </Layout>
+    );
+};
+
+Tag.propTypes = {
+    pathContext: PropTypes.shape({
+        pages: PropTypes.arrayOf({
+            query_field: PropTypes.shape({
+                author: PropTypes.string,
+                // below prop comes back as 'atf-image'
+                // from RST. Writing it in PropTypes in this casing
+                // will throw an error
+                atf_image: PropTypes.string,
+                languages: PropTypes.arrayOf(PropTypes.string),
+                tags: PropTypes.arrayOf(PropTypes.string),
+            }),
+        }),
+        author_image: PropTypes.string,
+        name: PropTypes.string.isRequired,
+        slug: PropTypes.string.isRequired,
+        type: PropTypes.string.isRequired,
+    }),
+};
+
+export default Tag;

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -10,11 +10,24 @@ import {
     layer,
     screenSize,
     size,
+    colorMap,
 } from '../components/dev-hub/theme';
 import { createShadowElement } from '../components/dev-hub/utils';
 
 const BYLINE_HEIGHT_OFFSET = 6;
 const BYLINE_IMAGE_HEIGHT = 50;
+
+const TagTitle = styled('div')`
+    ${H2} {
+        text-transform: capitalize;
+    }
+
+    ${P} {
+        color: ${colorMap.greyLightThree};
+        margin: 0;
+        padding: 0;
+    }
+`;
 
 const AuthorImage = styled('div')`
     @media ${screenSize.upToMedium} {
@@ -47,11 +60,17 @@ const AuthorByline = styled('div')`
 `;
 
 const ArticleContent = styled('article')`
-    padding: 80px ${size.xlarge};
+    padding: 80px ${size.xxlarge};
+    @media ${screenSize.upToLarge} {
+        padding: ${size.large} ${size.medium};
+    }
 `;
 
 const constructArticles = data =>
-    data.reduce((accum, item) => accum.concat({ ...item.query_fields }), []);
+    data.reduce(
+        (accum, item) => accum.concat({ ...item.query_fields, _id: item._id }),
+        []
+    );
 
 const Tag = props => {
     const {
@@ -59,21 +78,23 @@ const Tag = props => {
     } = props;
     const isAuthor = type === 'author';
     const articles = constructArticles(pages);
+    const capitalizedBreadcrumb = name.charAt(0).toUpperCase() + name.slice(1);
     console.log('props: ', props);
+    console.log("articles: ', ", articles);
     return (
         <Layout>
             <HeroBanner
                 breadcrumb={[
                     { label: 'Home', to: '/' },
                     { label: 'Learn', to: '/learn' },
-                    { label: name, to: slug },
+                    { label: capitalizedBreadcrumb, to: slug },
                 ]}
             >
                 {!isAuthor && (
-                    <div>
-                        <P>Tagged in</P>
+                    <TagTitle>
+                        <P>TAGGED IN</P>
                         <H2>{name}</H2>
-                    </div>
+                    </TagTitle>
                 )}
                 {isAuthor && (
                     <AuthorByline>
@@ -98,10 +119,6 @@ Tag.propTypes = {
         pages: PropTypes.arrayOf({
             query_field: PropTypes.shape({
                 author: PropTypes.string,
-                // below prop comes back as 'atf-image'
-                // from RST. Writing it in PropTypes in this casing
-                // will throw an error
-                atf_image: PropTypes.string,
                 languages: PropTypes.arrayOf(PropTypes.string),
                 tags: PropTypes.arrayOf(PropTypes.string),
             }),

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -47,10 +47,7 @@ const AuthorByline = styled('div')`
 `;
 
 const ArticleContent = styled('article')`
-    margin: 0 auto;
-    max-width: ${size.maxContentWidth};
-    padding-left: ${size.small};
-    padding-right: ${size.small};
+    padding: 80px ${size.xlarge};
 `;
 
 const constructArticles = data =>

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -56,10 +56,9 @@ const ArticleContent = styled('article')`
 const constructArticles = data =>
     data.reduce((accum, item) => accum.push({ ...item.query_fields }), []);
 
-// TODO change name of this
 const Tag = props => {
     const {
-        pathContext: {
+        pageContext: {
             pages,
             author_image,
             name,
@@ -103,7 +102,7 @@ const Tag = props => {
 };
 
 Tag.propTypes = {
-    pathContext: PropTypes.shape({
+    pageContext: PropTypes.shape({
         pages: PropTypes.arrayOf({
             query_field: PropTypes.shape({
                 author: PropTypes.string,

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -58,13 +58,7 @@ const constructArticles = data =>
 
 const Tag = props => {
     const {
-        pageContext: {
-            pages,
-            author_image,
-            name,
-            // slug,
-            type,
-        },
+        pageContext: { pages, author_image, name, slug, type },
     } = props;
     const isAuthor = type === 'author';
     const articles = constructArticles(pages);
@@ -75,6 +69,7 @@ const Tag = props => {
                 breadcrumb={[
                     { label: 'Home', to: '/' },
                     { label: 'Learn', to: '/learn' },
+                    { label: name, to: slug },
                 ]}
             >
                 {!isAuthor && (


### PR DESCRIPTION
This PR adds logic to pull and generate pages for tags and tag-like things (authors, languages, products, and types).

The data is passed to the `tag.js` template in `context`.

~Still WIP, trying to clean up unnecessary iteration, but happy for any feedback too.~