### PR TITLE
Article Updated Date

### DIFF
--- a/src/components/dev-hub/blog-post-title-area.js
+++ b/src/components/dev-hub/blog-post-title-area.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import BlogTagList from './blog-tag-list';
 import { H2, P } from './text';
@@ -18,10 +19,28 @@ const PostMetaLine = styled('div')`
     }
 `;
 
+const bulletStyling = css`
+    @media ${screenSize.xSmallAndUp} {
+        &:before {
+            content: '\u2022';
+            margin-right: ${size.tiny};
+        }
+    }
+`;
+
 const DateText = styled(P)`
-    margin-right: ${size.medium};
+    margin-right: ${size.tiny};
     @media ${screenSize.upToLarge} {
         font-size: ${fontSize.xsmall};
+    }
+    ${({ withBullet }) => withBullet && bulletStyling};
+`;
+
+const DateTextContainer = styled('div')`
+    margin-right: ${size.medium};
+    display: flex;
+    @media ${screenSize.upToXSmall} {
+        flex-direction: column;
     }
 `;
 
@@ -29,15 +48,25 @@ const BlogPostTitleArea = ({
     articleImage,
     author,
     breadcrumb,
-    title,
     originalDate,
     tags,
+    title,
+    updatedDate,
 }) => {
     return (
         <HeroBanner background={articleImage} breadcrumb={breadcrumb}>
             <H2 collapse>{title}</H2>
             <PostMetaLine>
-                {originalDate && <DateText collapse>{originalDate}</DateText>}
+                <DateTextContainer>
+                    {originalDate && (
+                        <DateText collapse>{originalDate}</DateText>
+                    )}
+                    {updatedDate && (
+                        <DateText withBullet collapse>
+                            Updated {updatedDate}
+                        </DateText>
+                    )}
+                </DateTextContainer>
                 <BlogTagList tags={tags} />
             </PostMetaLine>
             {author && (

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -134,7 +134,6 @@ const Article = props => {
                 originalDate={meta.pubdate}
                 tags={tagList}
                 title={articleTitle}
-                // TODO: Verify field name with Sophie
                 updatedDate={meta.updatedDate}
             />
 

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -134,6 +134,8 @@ const Article = props => {
                 originalDate={meta.pubdate}
                 tags={tagList}
                 title={articleTitle}
+                // TODO: Verify field name with Sophie
+                updatedDate={meta.updatedDate}
             />
 
             <ArticleContent>


### PR DESCRIPTION
This PR adds support for the "Updated Date" field for an article. I need to double check with Sophie the exact name of this field.

![Screen Shot 2020-02-27 at 6 04 26 PM](https://user-images.githubusercontent.com/9064401/75495146-d3fb2800-598b-11ea-93c2-28ba1dcf35e1.png)

On extremely small screens, let's stack the text to avoid odd wraps.

![Screen Shot 2020-02-27 at 6 04 36 PM](https://user-images.githubusercontent.com/9064401/75495148-d3fb2800-598b-11ea-83f3-36435f684342.png)
