### PR TITLE
inherit parent font size for links

### DIFF
--- a/src/components/dev-hub/link.js
+++ b/src/components/dev-hub/link.js
@@ -50,7 +50,7 @@ const tertiaryLinkStyling = css`
 
 const linkStyling = css`
     color: #fff;
-    font-size: ${fontSize.small};
+    font-size: inherit;
     text-decoration: underline;
     &:visited {
         color: #fff;

--- a/src/components/dev-hub/link.js
+++ b/src/components/dev-hub/link.js
@@ -58,9 +58,6 @@ const linkStyling = css`
     &:hover {
         color: ${colorMap.darkGreen};
     }
-    @media ${screenSize.upToMedium} {
-        font-size: ${fontSize.tiny};
-    }
 `;
 
 const StyledLink = styled('a')`


### PR DESCRIPTION
I'm not sure if this breaks any assumptions we had about link size somewhere, but by default links should be the same size as their surrounding text