### PR TITLE
Reference External Articles

### DIFF
--- a/src/components/dev-hub/related-articles.js
+++ b/src/components/dev-hub/related-articles.js
@@ -43,14 +43,10 @@ const RelatedCards = styled('div')`
 `;
 
 const getCardParamsFromRelatedType = (relatedArticle, slugTitleMapping) => {
-    const name = relatedArticle.name;
+    const name = relatedArticle.name
+        ? relatedArticle.name
+        : relatedArticle.type;
     switch (name) {
-        case 'reference':
-            return {
-                image: ARTICLE_PLACEHOLDER,
-                target: relatedArticle.refuri,
-                title: dlv(relatedArticle, ['children', 0, 'value'], ''),
-            };
         case 'doc':
             const target = relatedArticle.target;
             const slug = target && target.slice(1, target.length);
@@ -63,6 +59,18 @@ const getCardParamsFromRelatedType = (relatedArticle, slugTitleMapping) => {
                 );
             }
             return { image, target, title };
+        case 'literal':
+            return {
+                image: ARTICLE_PLACEHOLDER,
+                target: null,
+                title: dlv(relatedArticle, ['children', 0, 'value'], ''),
+            };
+        case 'reference':
+            return {
+                image: ARTICLE_PLACEHOLDER,
+                target: relatedArticle.refuri,
+                title: dlv(relatedArticle, ['children', 0, 'value'], ''),
+            };
         default:
             console.error(`Related article type not implemented: ${name}`);
             return { title: null, image: null, target: null };

--- a/src/components/dev-hub/related-articles.js
+++ b/src/components/dev-hub/related-articles.js
@@ -43,6 +43,7 @@ const RelatedCards = styled('div')`
 `;
 
 const getCardParamsFromRelatedType = (relatedArticle, slugTitleMapping) => {
+    console.log(relatedArticle);
     const name = relatedArticle.name
         ? relatedArticle.name
         : relatedArticle.type;

--- a/src/components/dev-hub/related-articles.js
+++ b/src/components/dev-hub/related-articles.js
@@ -42,6 +42,33 @@ const RelatedCards = styled('div')`
     }
 `;
 
+const getCardParamsFromRelatedType = (relatedArticle, slugTitleMapping) => {
+    const name = relatedArticle.name;
+    switch (name) {
+        case 'reference':
+            return {
+                image: ARTICLE_PLACEHOLDER,
+                target: relatedArticle.refUri,
+                title: dlv(relatedArticle, ['children', 0, 'value'], ''),
+            };
+        case 'doc':
+            const target = relatedArticle.target;
+            const slug = target && target.slice(1, target.length);
+            const image = relatedArticle.image || ARTICLE_PLACEHOLDER;
+            const title = dlv(slugTitleMapping, [slug, 0, 'value'], '');
+            if (title === '') {
+                console.error(
+                    `No title found for this internal article ${slug}`,
+                    slugTitleMapping
+                );
+            }
+            return { image, target, title };
+        default:
+            console.error(`Related article type not implemented: ${name}`);
+            return { title: null, image: null, target: null };
+    }
+};
+
 const RelatedArticles = ({ related, slugTitleMapping }) => {
     if (!related || !related.length) return null;
     return (
@@ -49,16 +76,12 @@ const RelatedArticles = ({ related, slugTitleMapping }) => {
             <H4>Related</H4>
             <RelatedCards>
                 {related.map((r, i) => {
-                    const target = r.target;
-                    const slug = r.target && r.target.slice(1, r.target.length);
-                    const image = r.image || ARTICLE_PLACEHOLDER;
-                    const title = dlv(slugTitleMapping, [slug, 0, 'value'], '');
-                    if (title === '') {
-                        console.error(
-                            `No title found for this article ${slug}`,
-                            slugTitleMapping
-                        );
-                    }
+                    const {
+                        image,
+                        target,
+                        title,
+                    } = getCardParamsFromRelatedType(r, slugTitleMapping);
+
                     /* TODO: Case on doc to link internal vs external */
                     return (
                         <Card

--- a/src/components/dev-hub/related-articles.js
+++ b/src/components/dev-hub/related-articles.js
@@ -48,7 +48,7 @@ const getCardParamsFromRelatedType = (relatedArticle, slugTitleMapping) => {
         case 'reference':
             return {
                 image: ARTICLE_PLACEHOLDER,
-                target: relatedArticle.refUri,
+                target: relatedArticle.refuri,
                 title: dlv(relatedArticle, ['children', 0, 'value'], ''),
             };
         case 'doc':


### PR DESCRIPTION
This PR adds logic to support external links on related articles. It [looks like the writers are trying to do so](https://github.com/ljhaywar/devhub-content/blob/node-changestreams/source/quickstart/nodejs-change-streams-triggers.txt) at this point.

The type here is a `Reference`, so I went off the structure from the `Reference` component to get the needed fields.