### PR TITLE
Add overflow wrap to literal values

### DIFF
--- a/src/components/Literal.js
+++ b/src/components/Literal.js
@@ -1,10 +1,15 @@
 import React from 'react';
+import { css } from '@emotion/core';
 import PropTypes from 'prop-types';
 import { getNestedValue } from '../utils/get-nested-value';
 
+const breakWordOverflow = css`
+    overflow-wrap: break-word;
+`;
+
 const Literal = ({ nodeData }) => (
     <code className="docutils literal notranslate">
-        <span className="pre">
+        <span className="pre" css={breakWordOverflow}>
             {getNestedValue(['children', 0, 'value'], nodeData)}
         </span>
     </code>


### PR DESCRIPTION
This PR fixes literal values extending out of the defined width to avoid breaking words. We want to break the word to provide a consistent max width.

Before:
![Screen Shot 2020-02-28 at 3 15 45 PM](https://user-images.githubusercontent.com/9064401/75584271-61e31b80-5a3d-11ea-9af3-9f9a4bd6636e.png)

After:
![Screen Shot 2020-02-28 at 3 17 44 PM](https://user-images.githubusercontent.com/9064401/75584328-817a4400-5a3d-11ea-91f7-1c5ea2a0235c.png)
