### PR TITLE
Replace encodeURI and non-alphanum chars with regex check

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -7,6 +7,9 @@ const {
     validateEnvVariables,
 } = require('./src/utils/setup/validate-env-variables');
 const { getNestedValue } = require('./src/utils/get-nested-value');
+const {
+    getTagPageUriComponent,
+} = require('./src/utils/get-tag-page-uri-component');
 const { getTemplate } = require('./src/utils/get-template');
 const { getPageSlug } = require('./src/utils/get-page-slug');
 const { getMetadata } = require('./src/utils/get-metadata');
@@ -142,13 +145,7 @@ const createTagPageType = async (createPage, pageMetadata, stitchType) => {
         // Some bad data for authors doesn't follow this structure, so ignore it
         if (!name) return null;
         else {
-            const urlSuffix = isAuthor
-                ? name
-                      .toLowerCase()
-                      .split(' ')
-                      .join('-')
-                      .replace(/\W/g, '-')
-                : name.toLowerCase().replace(/\W/g, '-');
+            const urlSuffix = getTagPageUriComponent(name);
             const newPage = {
                 type: pageType,
                 name: name,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -143,13 +143,12 @@ const createTagPageType = async (createPage, pageMetadata, stitchType) => {
         if (!name) return null;
         else {
             const urlSuffix = isAuthor
-                ? encodeURIComponent(
-                      name
-                          .toLowerCase()
-                          .split(' ')
-                          .join('-')
-                  )
-                : encodeURIComponent(name.toLowerCase());
+                ? name
+                      .toLowerCase()
+                      .split(' ')
+                      .join('-')
+                      .replace(/\W/g, '-')
+                : name.toLowerCase().replace(/\W/g, '-');
             const newPage = {
                 type: pageType,
                 name: name,

--- a/src/components/dev-hub/byline-block.js
+++ b/src/components/dev-hub/byline-block.js
@@ -11,6 +11,7 @@ import {
     fontSize,
     size,
 } from './theme';
+import { getTagPageUriComponent } from '../../utils/get-tag-page-uri-component';
 import { createShadowElement } from './utils';
 import DEFAULT_AUTHOR_IMAGE from '../../images/2x/Default-Profile@2x.png';
 
@@ -71,11 +72,7 @@ const BylineBlock = ({
     authorName = '',
     authorImage = DEFAULT_AUTHOR_IMAGE,
 }) => {
-    const authorLink = `/author/${authorName
-        .toLowerCase()
-        .split(' ')
-        .join('-')
-        .replace(/\W|\./, '-')}`;
+    const authorLink = `/author/${getTagPageUriComponent(authorName)}`;
     return (
         <ByLine>
             <AuthorImage>

--- a/src/components/dev-hub/byline-block.js
+++ b/src/components/dev-hub/byline-block.js
@@ -71,12 +71,11 @@ const BylineBlock = ({
     authorName = '',
     authorImage = DEFAULT_AUTHOR_IMAGE,
 }) => {
-    const authorLink = `/author/${encodeURIComponent(
-        authorName
-            .toLowerCase()
-            .split(' ')
-            .join('-')
-    )}`;
+    const authorLink = `/author/${authorName
+        .toLowerCase()
+        .split(' ')
+        .join('-')
+        .replace(/\W|\./, '-')}`;
     return (
         <ByLine>
             <AuthorImage>

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -119,7 +119,7 @@ const Article = props => {
     if (meta.type && meta.type.length) {
         articleBreadcrumbs.push({
             label: meta.type[0].toUpperCase() + meta.type.substring(1),
-            target: `/type/${meta.type}`,
+            target: `/type/${meta.type.toLowerCase().replace(/\W/g, '-')}`,
         });
     }
     const tagList = getTagLinksFromMeta(meta);

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -13,6 +13,7 @@ import { size } from '../components/dev-hub/theme';
 import Series from '../components/dev-hub/series';
 import { getNestedText } from '../utils/get-nested-text';
 import { getTagLinksFromMeta } from '../utils/get-tag-links-from-meta';
+import { getTagPageUriComponent } from '../utils/get-tag-page-uri-component';
 
 let articleTitle = '';
 
@@ -119,7 +120,7 @@ const Article = props => {
     if (meta.type && meta.type.length) {
         articleBreadcrumbs.push({
             label: meta.type[0].toUpperCase() + meta.type.substring(1),
-            target: `/type/${meta.type.toLowerCase().replace(/\W/g, '-')}`,
+            target: `/type/${getTagPageUriComponent(meta.type)}`,
         });
     }
     const tagList = getTagLinksFromMeta(meta);

--- a/src/utils/get-tag-page-uri-component.js
+++ b/src/utils/get-tag-page-uri-component.js
@@ -1,0 +1,5 @@
+const getTagPageUriComponent = tagPageUri =>
+    tagPageUri.toLowerCase().replace(/\W/g, '-');
+
+// TODO: Investigate using ES6 exports with Gatsby
+module.exports.getTagPageUriComponent = getTagPageUriComponent;

--- a/src/utils/map-tag-type-to-url.js
+++ b/src/utils/map-tag-type-to-url.js
@@ -1,8 +1,10 @@
+import { getTagPageUriComponent } from './get-tag-page-uri-component';
+
 export const mapTagTypeToUrl = (tags, tagType) => {
     // Allow tag type to be omitted in article rST
     if (!tags || !tags.length) return [];
     return tags.map(t => ({
         label: t,
-        to: `/${tagType}/${t.toLowerCase().replace(/\W/g, '-')}`,
+        to: `/${tagType}/${getTagPageUriComponent(t)}`,
     }));
 };

--- a/src/utils/map-tag-type-to-url.js
+++ b/src/utils/map-tag-type-to-url.js
@@ -3,6 +3,6 @@ export const mapTagTypeToUrl = (tags, tagType) => {
     if (!tags || !tags.length) return [];
     return tags.map(t => ({
         label: t,
-        to: `/${tagType}/${t.toLowerCase()}`,
+        to: `/${tagType}/${t.toLowerCase().replace(/\W/g, '-')}`,
     }));
 };


### PR DESCRIPTION
This PR fixes encodeURI issues with Gatsby by instead replacing non-alphanumeric characters in a url with dashes, so:

mongo 4.4 --> mongo-4-4
.net --> -net
c# --> c-
etc.