### PR TITLE
check for streams and videos

### DIFF
--- a/src/components/dev-hub/notification.js
+++ b/src/components/dev-hub/notification.js
@@ -44,11 +44,12 @@ const LiveNowBadgeContainer = styled('div')`
     }
 `;
 
-const NotificationText = styled('div')`
+const NotificationLink = styled('a')`
     align-items: center;
     color: ${colorMap.devWhite};
     display: flex;
     margin-left: auto;
+    text-decoration: none;
 `;
 
 const StyledNotification = styled('div')`
@@ -67,29 +68,32 @@ const StyledNotification = styled('div')`
 `;
 
 // TODO case on different notification types
-// eslint-disable-next-line no-unused-vars
-const Notification = ({ link = null, notificationType = 'twitch' }) => {
-    // TODO add async call to twitch
+// TODO handle non link notifications
+const Notification = ({
+    link = null,
+    title,
+    /* , notificationType = 'twitch' */
+}) => {
     const [isVisible, setIsVisible] = useState(true);
     const dismissNotification = useCallback(() => setIsVisible(false), [
         setIsVisible,
     ]);
+    if (!isVisible || !title) {
+        return null;
+    }
     return (
-        isVisible && (
-            <StyledNotification>
-                <NotificationText>
-                    <LiveNowBadgeContainer>Live Now</LiveNowBadgeContainer>
-                    <P collapse>
-                        Building the world’s first IoT kitty litter box — Join
-                        us on Twitch!
-                    </P>
-                </NotificationText>
-                <CloseIcon collapse onClick={dismissNotification} />
-            </StyledNotification>
-        )
+        <StyledNotification>
+            <NotificationLink
+                href={link}
+                target="_blank"
+                rel="noreferrer noopener"
+            >
+                <LiveNowBadgeContainer>Live Now</LiveNowBadgeContainer>
+                <P collapse>{title}</P>
+            </NotificationLink>
+            <CloseIcon collapse onClick={dismissNotification} />
+        </StyledNotification>
     );
 };
-
-Notification.displayName = 'Notification';
 
 export default Notification;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -21,6 +21,7 @@ import meetupsImage from '../images/1x/Meetups.png';
 import buildImage from '../images/1x/Build.png';
 import GradientUnderline from '../components/dev-hub/gradient-underline';
 import homepageBackground from '../images/1x/homepage-background.png';
+import useTwitchApi from '../utils/use-twitch-api';
 
 const MEDIA_WIDTH = '550';
 
@@ -91,10 +92,20 @@ const DescriptiveText = styled(P)`
     margin-bottom: ${size.medium};
 `;
 export default () => {
+    // TODO enable for launch
+    // const { error, live, pending, videos } = useTwitchApi();
     return (
         <Layout>
             <BackgroundImage>
-                <Notification />
+                {/* 
+                // TODO enable for launch
+                {live && (
+                    <Notification
+                        link={live.url}
+                        title={live.title}
+                    />
+                )} 
+                */}
                 <Hero>
                     <Heading>
                         {`ideas.find({"attributes":`}

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -1,0 +1,30 @@
+const credentials = 'same-origin';
+
+/**
+ * @param {Object} response
+ * @property {function} response.json
+ * @returns {Object} json response
+ */
+const responseJSON = response => response.json();
+/**
+ * @param {Object} response
+ * @property {boolean} response.ok
+ * @returns {boolean} unsuccessful response
+ */
+const isBadResponse = response => !response || (response && !response.ok);
+
+/**
+ *
+ * @param {String} url
+ * @returns {Promise} json response
+ */
+export const get = async (url, headers = {}) => {
+    const response = await fetch(url, {
+        credentials,
+        headers,
+    });
+    if (isBadResponse(response)) {
+        throw new Error(response);
+    }
+    return await responseJSON(response);
+};

--- a/src/utils/use-twitch-api.js
+++ b/src/utils/use-twitch-api.js
@@ -1,0 +1,53 @@
+import { useState, useEffect, useCallback } from 'react';
+import { get } from './request';
+
+const TWITCH_API_ENDPOINT = 'https://api.twitch.tv/helix/';
+const CLIENT_ID = '041r2glmgub2pt357ss0la44j2sz95';
+const MDB_CHANNEL_ID = '467752938';
+const STREAMS_URL = `${TWITCH_API_ENDPOINT}streams?user_id=${MDB_CHANNEL_ID}`;
+const video_URL = `${TWITCH_API_ENDPOINT}videos?user_id=${MDB_CHANNEL_ID}&first=`;
+
+const headers = { 'Client-ID': CLIENT_ID };
+
+/**
+ * @param {Object} config
+ * @param {boolean=} config.getStream
+ * @param {number=} config.videoLimit number of previous videos to return
+ * @returns {Object} {error, stream, pending, videos}
+ */
+export default ({ getStream = true, videoLimit = 1 } = {}) => {
+    const [error, setError] = useState(null);
+    const [stream, setStream] = useState(null);
+    const [pending, setPending] = useState(true);
+    const [videos, setVideos] = useState(null);
+
+    const callTwitch = useCallback(async () => {
+        setPending(true);
+        let currentStream = null;
+        // Get stream
+        if (getStream) {
+            const streamResp = await get(STREAMS_URL, headers);
+            // since we're only interested in one channel just get the first
+            currentStream = streamResp.data[0];
+            setStream(currentStream);
+        }
+        //get videos
+        if (!currentStream && videoLimit) {
+            const videoResp = await get(video_URL + videoLimit, headers);
+            // return the whole array of videos, but ignore pagination for now
+            setVideos(videoResp.data);
+        }
+        try {
+        } catch (error) {
+            console.error(error);
+            setError(error);
+        }
+        setPending(false);
+    }, [getStream, videoLimit]);
+
+    useEffect(() => {
+        callTwitch();
+    }, [callTwitch]);
+
+    return { error, stream, pending, videos };
+};

--- a/src/utils/use-twitch-api.js
+++ b/src/utils/use-twitch-api.js
@@ -24,20 +24,20 @@ export default ({ getStream = true, videoLimit = 1 } = {}) => {
     const callTwitch = useCallback(async () => {
         setPending(true);
         let currentStream = null;
-        // Get stream
-        if (getStream) {
-            const streamResp = await get(STREAMS_URL, headers);
-            // since we're only interested in one channel just get the first
-            currentStream = streamResp.data[0];
-            setStream(currentStream);
-        }
-        //get videos
-        if (!currentStream && videoLimit) {
-            const videoResp = await get(video_URL + videoLimit, headers);
-            // return the whole array of videos, but ignore pagination for now
-            setVideos(videoResp.data);
-        }
         try {
+            // Get stream
+            if (getStream) {
+                const streamResp = await get(STREAMS_URL, headers);
+                // since we're only interested in one channel just get the first
+                currentStream = streamResp.data[0];
+                setStream(currentStream);
+            }
+            //get videos
+            if (!currentStream && videoLimit) {
+                const videoResp = await get(video_URL + videoLimit, headers);
+                // return the whole array of videos, but ignore pagination for now
+                setVideos(videoResp.data);
+            }
         } catch (error) {
             console.error(error);
             setError(error);


### PR DESCRIPTION
If the mongodb channel is streaming we'll return that data otherwise we'll check for the last recorded video. That will potentially be used as the Twitch feature on the homepage.

I think removing the error and pending state would be more efficient while we're not using them, but we can comment them out when enable the API calls before launch if needed.

