### PR TITLE
Handle top level TOML series definitions

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -6,13 +6,14 @@ const { Stitch, AnonymousCredential } = require('mongodb-stitch-server-sdk');
 const {
     validateEnvVariables,
 } = require('./src/utils/setup/validate-env-variables');
+const { getMetadata } = require('./src/utils/get-metadata');
 const { getNestedValue } = require('./src/utils/get-nested-value');
 const {
     getTagPageUriComponent,
 } = require('./src/utils/get-tag-page-uri-component');
-const { getTemplate } = require('./src/utils/get-template');
 const { getPageSlug } = require('./src/utils/get-page-slug');
-const { getMetadata } = require('./src/utils/get-metadata');
+const { getSeriesArticles } = require('./src/utils/get-series-articles');
+const { getTemplate } = require('./src/utils/get-template');
 
 // Consolidated metadata object used to identify build and env variables
 const metadata = getMetadata();
@@ -231,6 +232,7 @@ exports.createPages = async ({ actions }) => {
         constructDbFilter(),
     ]);
 
+    const allSeries = metadata.pageGroups;
     PAGES.forEach(page => {
         const pageNodes = RESOLVED_REF_DOC_MAPPING[page];
 
@@ -243,11 +245,13 @@ exports.createPages = async ({ actions }) => {
                 const relatedPages = getRelatedPagesWithImages(pageNodes);
                 pageNodes['query_fields'].related = relatedPages;
             }
+            const seriesArticles = getSeriesArticles(allSeries, slug);
             createPage({
                 path: slug,
                 component: path.resolve(`./src/templates/${template}.js`),
                 context: {
                     metadata: metadata,
+                    seriesArticles,
                     slug,
                     snootyStitchId: SNOOTY_STITCH_ID,
                     __refDocMapping: pageNodes,

--- a/src/components/dev-hub/series.js
+++ b/src/components/dev-hub/series.js
@@ -34,8 +34,8 @@ const activeLiStyles = css`
     font-size: 22px;
     &:after {
         /* Adjust the background bullet position for the bull's eye text */
-        font-size: 38px;
-        top: -2px;
+        font-size: 54px;
+        top: 1px;
     }
 `;
 
@@ -111,12 +111,12 @@ const BulletIcon = styled('div')`
         background-clip: text;
         content: '\u2022';
         left: 0;
-        font-size: ${BULLET_SIZE}px;
+        font-size: ${fontSize.jumbo};
         height: 100%;
         margin-right: ${size.small};
         position: absolute;
         text-align: left;
-        top: 0px;
+        top: 3px;
         vertical-align: top;
         width: ${BULLET_BOX_WIDTH};
         z-index: ${layer.superBack};
@@ -146,7 +146,7 @@ const SeriesList = styled('ul')`
             ),
             ${BORDER_GRADIENT};
         background-size: ${size.medium} 2px, cover;
-        bottom: ${BULLET_SIZE / 2}px;
+        bottom: calc(${BULLET_SIZE / 2}px + 2px);
         content: '';
         left: 7px;
         position: absolute;

--- a/src/components/dev-hub/series.js
+++ b/src/components/dev-hub/series.js
@@ -96,7 +96,7 @@ const BulletIcon = styled('div')`
     display: inline-block;
     font-size: ${BULLET_SIZE}px;
     line-height: ${lineHeight.tiny};
-    margin-top: 2px;
+    margin-top: 3px;
     margin-right: 30px;
     position: relative;
     text-align: left;
@@ -146,7 +146,7 @@ const SeriesList = styled('ul')`
             ),
             ${BORDER_GRADIENT};
         background-size: ${size.medium} 2px, cover;
-        bottom: calc(${BULLET_SIZE / 2}px + 2px);
+        bottom: ${BULLET_SIZE / 2 + 2}px;
         content: '';
         left: 7px;
         position: absolute;

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -67,31 +67,38 @@ const getContent = nodes => {
 // TODO: series will no longer be defined in the article rST, this must be looked up from allSeries in createPages beforehand
 // This assumes each article belongs to at most one series
 const ArticleSeries = ({
-    allSeries,
-    currentArticleSeries,
+    allSeriesForArticle,
     currentSlug,
     slugTitleMapping,
 }) => {
+    console.log(allSeriesForArticle);
     // Handle if this article is not in a series or no series are defined
-    if (!allSeries || !currentArticleSeries) return null;
-    const relevantSeries = allSeries[currentArticleSeries];
+    if (!allSeriesForArticle) return null;
     // Handle if this series is not defined in the top-level content TOML file
-    if (!relevantSeries || !relevantSeries.length) return null;
-    const mappedSeries = relevantSeries.map(s => {
-        const articleTitle = dlv(slugTitleMapping, [s, 0, 'value'], s);
-        return {
-            slug: s,
-            title: articleTitle,
-        };
-    });
-    return (
+    const getMappedSeries = seriesSlugs => {
+        if (!seriesSlugs || !seriesSlugs.length) return null;
+        const mappedSeries = seriesSlugs.map(slug => {
+            const articleTitle = dlv(
+                slugTitleMapping,
+                [slug, 0, 'value'],
+                slug
+            );
+            return {
+                slug,
+                title: articleTitle,
+            };
+        });
+        return mappedSeries;
+    };
+
+    return Object.keys(allSeriesForArticle).map(series => (
         <>
-            <Series name={currentArticleSeries} currentStep={currentSlug}>
-                {mappedSeries}
+            <Series name={series} currentStep={currentSlug}>
+                {getMappedSeries(allSeriesForArticle[series])}
             </Series>
             <br />
         </>
-    );
+    ));
 };
 
 const ArticleContent = styled('article')`
@@ -105,8 +112,9 @@ const Article = props => {
     const {
         pageContext: {
             __refDocMapping,
+            seriesArticles,
             slug: thisPage,
-            metadata: { pageGroups: allSeries, slugToTitle: slugTitleMapping },
+            metadata: { slugToTitle: slugTitleMapping },
         },
         ...rest
     } = props;
@@ -147,8 +155,7 @@ const Article = props => {
                 />
                 <ArticleShareFooter tags={tagList} />
                 <ArticleSeries
-                    allSeries={allSeries}
-                    currentArticleSeries={meta.series}
+                    allSeriesForArticle={seriesArticles}
                     currentSlug={slugTitleMapping[thisPage][0].value}
                     slugTitleMapping={slugTitleMapping}
                 />

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -64,13 +64,7 @@ const getContent = nodes => {
     return nodesWeActuallyWant;
 };
 
-// TODO: series will no longer be defined in the article rST, this must be looked up from allSeries in createPages beforehand
-// This assumes each article belongs to at most one series
-const ArticleSeries = ({
-    allSeriesForArticle,
-    currentSlug,
-    slugTitleMapping,
-}) => {
+const ArticleSeries = ({ allSeriesForArticle, slugTitleMapping, title }) => {
     console.log(allSeriesForArticle);
     // Handle if this article is not in a series or no series are defined
     if (!allSeriesForArticle) return null;
@@ -93,7 +87,7 @@ const ArticleSeries = ({
 
     return Object.keys(allSeriesForArticle).map(series => (
         <>
-            <Series name={series} currentStep={currentSlug}>
+            <Series name={series} currentStep={title}>
                 {getMappedSeries(allSeriesForArticle[series])}
             </Series>
             <br />
@@ -132,6 +126,8 @@ const Article = props => {
         });
     }
     const tagList = getTagLinksFromMeta(meta);
+    const articleTitle = dlv(meta.title, [0, 'value'], thisPage);
+
     return (
         <Layout>
             <Helmet>
@@ -156,8 +152,8 @@ const Article = props => {
                 <ArticleShareFooter tags={tagList} />
                 <ArticleSeries
                     allSeriesForArticle={seriesArticles}
-                    currentSlug={slugTitleMapping[thisPage][0].value}
                     slugTitleMapping={slugTitleMapping}
+                    title={articleTitle}
                 />
             </ArticleContent>
 

--- a/src/utils/get-series-articles.js
+++ b/src/utils/get-series-articles.js
@@ -4,7 +4,9 @@ const getSeriesArticles = (allSeries, slug) => {
     const series = Object.keys(allSeries);
     const seriesForThisArticle = {};
     series.forEach(s => {
-        if (allSeries[s].includes(slug)) seriesForThisArticle[s] = allSeries[s];
+        if (allSeries[s].includes(slug)) {
+            seriesForThisArticle[s] = allSeries[s];
+        }
     });
     return seriesForThisArticle;
 };

--- a/src/utils/get-series-articles.js
+++ b/src/utils/get-series-articles.js
@@ -6,7 +6,6 @@ const getSeriesArticles = (allSeries, slug) => {
     series.forEach(s => {
         if (allSeries[s].includes(slug)) seriesForThisArticle[s] = allSeries[s];
     });
-    console.log(seriesForThisArticle);
     return seriesForThisArticle;
 };
 

--- a/src/utils/get-series-articles.js
+++ b/src/utils/get-series-articles.js
@@ -1,0 +1,13 @@
+// given a page slug, find all occurrances in "allSeries"
+const getSeriesArticles = (allSeries, slug) => {
+    if (!allSeries || !slug) return [];
+    const series = Object.keys(allSeries);
+    const seriesForThisArticle = {};
+    series.forEach(s => {
+        if (allSeries[s].includes(slug)) seriesForThisArticle[s] = allSeries[s];
+    });
+    console.log(seriesForThisArticle);
+    return seriesForThisArticle;
+};
+
+module.exports.getSeriesArticles = getSeriesArticles;

--- a/tests/unit/get-series-articles.test.js
+++ b/tests/unit/get-series-articles.test.js
@@ -1,0 +1,24 @@
+import { getSeriesArticles } from '../../src/utils/get-series-articles';
+
+it('should correctly determine which series an article belongs to', () => {
+    const allSeries = {
+        seriesABC: ['slugA', 'slugB', 'slugC'],
+        seriesAC: ['slugA', 'slugC'],
+        seriesB: ['slugB'],
+        seriesD: [],
+    };
+    expect(Object.keys(getSeriesArticles(allSeries, 'slugA'))).toEqual([
+        'seriesABC',
+        'seriesAC',
+    ]);
+    expect(Object.keys(getSeriesArticles(allSeries, 'slugB'))).toEqual([
+        'seriesABC',
+        'seriesB',
+    ]);
+    expect(Object.keys(getSeriesArticles(allSeries, 'slugC'))).toEqual([
+        'seriesABC',
+        'seriesAC',
+    ]);
+    expect(Object.keys(getSeriesArticles(allSeries, 'slugD'))).toEqual([]);
+    expect(Object.keys(getSeriesArticles(allSeries, ''))).toEqual([]);
+});

--- a/tests/unit/get-series-articles.test.js
+++ b/tests/unit/get-series-articles.test.js
@@ -11,6 +11,9 @@ it('should correctly determine which series an article belongs to', () => {
         'seriesABC',
         'seriesAC',
     ]);
+    expect(getSeriesArticles(allSeries, 'slugA')['seriesAC']).toEqual(
+        allSeries['seriesAC']
+    );
     expect(Object.keys(getSeriesArticles(allSeries, 'slugB'))).toEqual([
         'seriesABC',
         'seriesB',


### PR DESCRIPTION
This PR supports the top-level TOML means of defining a series by adding some build-time logic to the `createPages` step. Given data that can look like:

```
    const allSeries = {
        'test-articles': [
            'article/article',
            'quickstart/nodejs-how-to-connect-to-your-database',
        ],
        'test-articles-two': [
            'article/active-active-application-architectures-with-mongodb',
            'quickstart/nodejs-how-to-connect-to-your-database',
            'how-to/working-with-mongodb-stitch-through-the-mongo-shell',
        ],
    };
```

this PR handles attaching relevant data about each series an article is in to its context at build-time.

I also added support for articles in multiple series, and updated the stylings for series a bit to match updated styles.

![Screen Shot 2020-03-02 at 11 30 59 AM](https://user-images.githubusercontent.com/9064401/75697725-7f9dc400-5c7b-11ea-84c7-2189fe7f35bf.png)
