### PR TITLE
Render default image without withPrefix if no image exists

### DIFF
--- a/src/components/dev-hub/byline-block.js
+++ b/src/components/dev-hub/byline-block.js
@@ -68,15 +68,20 @@ const ByLine = styled('div')`
     }
 `;
 
-const BylineBlock = ({
-    authorName = '',
-    authorImage = DEFAULT_AUTHOR_IMAGE,
-}) => {
+const BylineBlock = ({ authorImage, authorName = '' }) => {
+    const hasImage = !!authorImage;
     const authorLink = `/author/${getTagPageUriComponent(authorName)}`;
     return (
         <ByLine>
             <AuthorImage>
-                <img src={withPrefix(authorImage)} alt={authorName} />
+                <img
+                    src={
+                        hasImage
+                            ? withPrefix(authorImage)
+                            : DEFAULT_AUTHOR_IMAGE
+                    }
+                    alt={authorName}
+                />
             </AuthorImage>
             <AuthorText collapse>
                 By <AuthorLink to={authorLink}>{authorName}</AuthorLink>

--- a/src/components/dev-hub/byline-block.js
+++ b/src/components/dev-hub/byline-block.js
@@ -69,14 +69,13 @@ const ByLine = styled('div')`
 `;
 
 const BylineBlock = ({ authorImage, authorName = '' }) => {
-    const hasImage = !!authorImage;
     const authorLink = `/author/${getTagPageUriComponent(authorName)}`;
     return (
         <ByLine>
             <AuthorImage>
                 <img
                     src={
-                        hasImage
+                        !!authorImage
                             ? withPrefix(authorImage)
                             : DEFAULT_AUTHOR_IMAGE
                     }

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -124,7 +124,6 @@ const Article = props => {
         });
     }
     const tagList = getTagLinksFromMeta(meta);
-
     return (
         <Layout>
             <Helmet>


### PR DESCRIPTION
The default author images were accidentally being fed into `withPrefix`, which prevented them from being used properly (since we don't need a prefix for the default image here).

This PR adds a case to check if we are using the default image before using the `withPrefix` function.