### PR TITLE
new tab for external links

### DIFF
--- a/src/components/RefRole.js
+++ b/src/components/RefRole.js
@@ -7,7 +7,7 @@ const RefRole = ({ nodeData: { children, fileid, target, url }, slug }) => {
     // Render intersphinx target links
     if (url) {
         return (
-            <Link to={url} className="reference external">
+            <Link to={url} className="ref-role-inter">
                 {children.map((node, i) => (
                     <ComponentFactory key={i} nodeData={node} />
                 ))}
@@ -18,7 +18,7 @@ const RefRole = ({ nodeData: { children, fileid, target, url }, slug }) => {
     // Render internal target links
     const link = fileid === slug ? `#${target}` : `${fileid}#${target}`;
     return (
-        <Link href={link}>
+        <Link href={link} className="ref-role-anchor">
             <span>
                 {children.map((node, i) => (
                     <ComponentFactory key={i} nodeData={node} />

--- a/src/components/Reference.js
+++ b/src/components/Reference.js
@@ -4,7 +4,7 @@ import Link from './Link';
 import { getNestedValue } from '../utils/get-nested-value';
 
 const Reference = ({ nodeData }) => (
-    <Link className="reference external" to={nodeData.refuri}>
+    <Link className="reference" to={nodeData.refuri} target="_blank">
         {getNestedValue(['children', 0, 'value'], nodeData)}
     </Link>
 );


### PR DESCRIPTION
I had some confusion on the difference between RefRole and Reference

RefRole is used for on page anchors and inter-document linking. Reference is basically any link.

We'll handle all links with an http/https prefix as external and open in a new tab for now. We can be smarter about this in the future