### PR TITLE
Use background for author images and refactor into component

### DIFF
--- a/src/components/dev-hub/author-image.js
+++ b/src/components/dev-hub/author-image.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+import { gradientMap, screenSize, size } from './theme';
+import { createShadowElement } from './utils';
+import DEFAULT_AUTHOR_IMAGE from '../../images/2x/Default-Profile@2x.png';
+
+const DEFAULT_GRADIENT_POSITION_OFFSET = 6;
+const DEFAULT_IMAGE_HEIGHT = 50;
+
+const imageStyles = background => css`
+    background-image: ${background
+        ? `url(${background})`
+        : `url(${DEFAULT_AUTHOR_IMAGE})`};
+    background-position: center center;
+    background-size: auto 100%;
+`;
+
+const AuthorImageContainer = styled('div')`
+    position: relative;
+    &:before {
+        ${({ gradientOffset }) =>
+            createShadowElement(
+                gradientMap.greenTealOffset,
+                size.large,
+                0,
+                -gradientOffset
+            )};
+        height: ${({ height, gradientOffset }) => height + gradientOffset}px;
+        width: ${({ width, gradientOffset }) => width + gradientOffset}px;
+        z-index: unset;
+    }
+`;
+
+const CircularImage = styled('div')`
+    @media ${screenSize.upToMedium} {
+        display: none;
+    }
+    margin-right: ${size.medium};
+    position: relative;
+    border-radius: 50%;
+    height: ${({ height }) => height}px;
+    width: ${({ width }) => width}px;
+    ${({ image }) => imageStyles(image)};
+`;
+
+const AuthorImage = ({
+    image,
+    gradientOffset = DEFAULT_GRADIENT_POSITION_OFFSET,
+    height = DEFAULT_IMAGE_HEIGHT,
+    width = DEFAULT_IMAGE_HEIGHT,
+    ...props
+}) => (
+    <AuthorImageContainer
+        gradientOffset={gradientOffset}
+        height={height}
+        width={width}
+        {...props}
+    >
+        <CircularImage height={height} width={width} image={image} />
+    </AuthorImageContainer>
+);
+
+export default AuthorImage;

--- a/src/components/dev-hub/author-image.js
+++ b/src/components/dev-hub/author-image.js
@@ -24,8 +24,8 @@ const hideImageOnMobile = css`
 `;
 
 const AuthorImageContainer = styled('div')`
-    position: relative;
     height: ${({ height, gradientOffset }) => height + gradientOffset}px;
+    position: relative;
     width: ${({ width, gradientOffset }) => width + gradientOffset}px;
     &:before {
         ${({ gradientOffset }) =>

--- a/src/components/dev-hub/author-image.js
+++ b/src/components/dev-hub/author-image.js
@@ -17,8 +17,16 @@ const imageStyles = background => css`
     background-size: auto 100%;
 `;
 
+const hideImageOnMobile = css`
+    @media ${screenSize.upToMedium} {
+        display: none;
+    }
+`;
+
 const AuthorImageContainer = styled('div')`
     position: relative;
+    height: ${({ height, gradientOffset }) => height + gradientOffset}px;
+    width: ${({ width, gradientOffset }) => width + gradientOffset}px;
     &:before {
         ${({ gradientOffset }) =>
             createShadowElement(
@@ -31,12 +39,10 @@ const AuthorImageContainer = styled('div')`
         width: ${({ width, gradientOffset }) => width + gradientOffset}px;
         z-index: unset;
     }
+    ${({ hideOnMobile }) => hideOnMobile && hideImageOnMobile}
 `;
 
 const CircularImage = styled('div')`
-    @media ${screenSize.upToMedium} {
-        display: none;
-    }
     border-radius: 50%;
     height: ${({ height }) => height}px;
     margin-right: ${size.medium};
@@ -48,11 +54,13 @@ const CircularImage = styled('div')`
 const AuthorImage = ({
     image,
     gradientOffset = DEFAULT_GRADIENT_POSITION_OFFSET,
+    hideOnMobile = true,
     height = DEFAULT_IMAGE_HEIGHT,
     width = DEFAULT_IMAGE_HEIGHT,
     ...props
 }) => (
     <AuthorImageContainer
+        hideOnMobile={hideOnMobile}
         gradientOffset={gradientOffset}
         height={height}
         width={width}

--- a/src/components/dev-hub/author-image.js
+++ b/src/components/dev-hub/author-image.js
@@ -36,10 +36,10 @@ const CircularImage = styled('div')`
     @media ${screenSize.upToMedium} {
         display: none;
     }
-    margin-right: ${size.medium};
-    position: relative;
     border-radius: 50%;
     height: ${({ height }) => height}px;
+    margin-right: ${size.medium};
+    position: relative;
     width: ${({ width }) => width}px;
     ${({ image }) => imageStyles(image)};
 `;

--- a/src/components/dev-hub/author-image.js
+++ b/src/components/dev-hub/author-image.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
+import { withPrefix } from 'gatsby';
 import { gradientMap, screenSize, size } from './theme';
 import { createShadowElement } from './utils';
 import DEFAULT_AUTHOR_IMAGE from '../../images/2x/Default-Profile@2x.png';
@@ -10,7 +11,7 @@ const DEFAULT_IMAGE_HEIGHT = 50;
 
 const imageStyles = background => css`
     background-image: ${background
-        ? `url(${background})`
+        ? `url(${withPrefix(background)})`
         : `url(${DEFAULT_AUTHOR_IMAGE})`};
     background-position: center center;
     background-size: auto 100%;

--- a/src/components/dev-hub/byline-block.js
+++ b/src/components/dev-hub/byline-block.js
@@ -1,46 +1,10 @@
 import React from 'react';
-import { withPrefix } from 'gatsby';
 import styled from '@emotion/styled';
 import Link from './link';
 import { P } from './text';
-import {
-    colorMap,
-    layer,
-    gradientMap,
-    screenSize,
-    fontSize,
-    size,
-} from './theme';
+import { colorMap, screenSize, fontSize } from './theme';
 import { getTagPageUriComponent } from '../../utils/get-tag-page-uri-component';
-import { createShadowElement } from './utils';
-import DEFAULT_AUTHOR_IMAGE from '../../images/2x/Default-Profile@2x.png';
-
-const BYLINE_HEIGHT_OFFSET = 6;
-const BYLINE_IMAGE_HEIGHT = 50;
-
-const AuthorImage = styled('div')`
-    @media ${screenSize.upToMedium} {
-      display: none;
-    }
-    height: ${BYLINE_IMAGE_HEIGHT}px;
-    margin-right: ${size.medium};
-    position: relative;
-    z-index: ${layer.front};
-    > img {
-        border-radius: 50%;
-        height: ${BYLINE_IMAGE_HEIGHT}px;
-    }
-    &:before {
-        ${createShadowElement(
-            gradientMap.greenTealOffset,
-            size.large,
-            0,
-            -BYLINE_HEIGHT_OFFSET
-        )}
-        height: ${BYLINE_IMAGE_HEIGHT + BYLINE_HEIGHT_OFFSET}px;
-        width: ${BYLINE_IMAGE_HEIGHT + BYLINE_HEIGHT_OFFSET}px;
-    }
-`;
+import AuthorImage from './author-image';
 
 const AuthorLink = styled(Link)`
     font-size: ${fontSize.tiny};
@@ -72,16 +36,7 @@ const BylineBlock = ({ authorImage, authorName = '' }) => {
     const authorLink = `/author/${getTagPageUriComponent(authorName)}`;
     return (
         <ByLine>
-            <AuthorImage>
-                <img
-                    src={
-                        !!authorImage
-                            ? withPrefix(authorImage)
-                            : DEFAULT_AUTHOR_IMAGE
-                    }
-                    alt={authorName}
-                />
-            </AuthorImage>
+            <AuthorImage image={authorImage} />
             <AuthorText collapse>
                 By <AuthorLink to={authorLink}>{authorName}</AuthorLink>
             </AuthorText>

--- a/src/components/dev-hub/byline-block.js
+++ b/src/components/dev-hub/byline-block.js
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import Link from './link';
 import { P } from './text';
-import { colorMap, screenSize, fontSize } from './theme';
+import { colorMap, fontSize, screenSize, size } from './theme';
 import { getTagPageUriComponent } from '../../utils/get-tag-page-uri-component';
 import AuthorImage from './author-image';
 
@@ -32,11 +32,15 @@ const ByLine = styled('div')`
     }
 `;
 
+const StyledAuthorImage = styled(AuthorImage)`
+    margin-right: ${size.small};
+`;
+
 const BylineBlock = ({ authorImage, authorName = '' }) => {
     const authorLink = `/author/${getTagPageUriComponent(authorName)}`;
     return (
         <ByLine>
-            <AuthorImage image={authorImage} />
+            <StyledAuthorImage image={authorImage} />
             <AuthorText collapse>
                 By <AuthorLink to={authorLink}>{authorName}</AuthorLink>
             </AuthorText>

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -53,6 +53,10 @@ const ArticleContent = styled('article')`
     }
 `;
 
+const SyledAuthorImage = styled(AuthorImage)`
+    margin-right: ${size.medium};
+`;
+
 const constructArticles = data =>
     data.reduce(
         (accum, item) => accum.concat({ ...item.query_fields, _id: item._id }),
@@ -93,7 +97,7 @@ const Tag = props => {
                 {isAuthor && (
                     <AuthorHero>
                         <AuthorByline>
-                            <AuthorImage image={author_image} />
+                            <SyledAuthorImage image={author_image} />
                             <AuthorName>
                                 <H2>{name}</H2>
                                 {title && location && (

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -2,22 +2,17 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import PropTypes from 'prop-types';
+import AuthorImage from '../components/dev-hub/author-image';
 import CardList from '../components/dev-hub/card-list';
 import HeroBanner from '../components/dev-hub/hero-banner';
 import Layout from '../components/dev-hub/layout';
 import { H2, H3, P, P3 } from '../components/dev-hub/text';
 import {
-    gradientMap,
-    layer,
     screenSize,
     size,
     colorMap,
     fontSize,
 } from '../components/dev-hub/theme';
-import { createShadowElement } from '../components/dev-hub/utils';
-
-const BYLINE_HEIGHT_OFFSET = 6;
-const BYLINE_IMAGE_HEIGHT = 50;
 
 const toTitleCase = css`
     text-transform: capitalize;
@@ -30,30 +25,6 @@ const SubHead = styled(P3)`
     text-transform: uppercase;
 `;
 
-const AuthorImage = styled('div')`
-    @media ${screenSize.upToMedium} {
-      display: none;
-    }
-    height: ${BYLINE_IMAGE_HEIGHT}px;
-    margin-right: ${size.medium};
-    position: relative;
-    z-index: ${layer.front};
-    > img {
-        border-radius: 50%;
-        height: ${BYLINE_IMAGE_HEIGHT}px;
-    }
-    &:before {
-        ${createShadowElement(
-            gradientMap.greenTealOffset,
-            size.large,
-            0,
-            -BYLINE_HEIGHT_OFFSET
-        )}
-        height: ${BYLINE_IMAGE_HEIGHT + BYLINE_HEIGHT_OFFSET}px;
-        width: ${BYLINE_IMAGE_HEIGHT + BYLINE_HEIGHT_OFFSET}px;
-    }
-
-`;
 const AuthorName = styled('div')`
     ${P3} {
         color: ${colorMap.greyLightThree};
@@ -122,9 +93,7 @@ const Tag = props => {
                 {isAuthor && (
                     <AuthorHero>
                         <AuthorByline>
-                            <AuthorImage>
-                                <img src={author_image} alt={name} />
-                            </AuthorImage>
+                            <AuthorImage image={author_image} />
                             <AuthorName>
                                 <H2>{name}</H2>
                                 {title && location && (


### PR DESCRIPTION
Sophie has updated her article repo, so re-creating pages will now show author images! This also has been updated in the parser and should be fixed soon for everyone in new builds.

This PR adds some styling support for the author images and refactors the author image work from the Byline Block and Tag pages out into a reusable component.

![Screen Shot 2020-03-02 at 2 45 32 PM](https://user-images.githubusercontent.com/9064401/75711490-7f5df280-5c94-11ea-8fab-28361007e4f4.png)
