### PR TITLE
Drop text size for nav on mobile

### DIFF
--- a/src/components/dev-hub/global-nav.js
+++ b/src/components/dev-hub/global-nav.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import Link from './link';
-import { colorMap, lineHeight, screenSize, size } from './theme';
+import { colorMap, fontSize, lineHeight, screenSize, size } from './theme';
 import Leaf from './icons/mdb-leaf';
 
 const GlobalNav = styled('nav')`
@@ -31,6 +31,8 @@ const NavLink = styled(Link)`
         background-color: ${colorMap.devBlack};
     }
     @media ${screenSize.upToMedium} {
+        font-size: ${fontSize.tiny};
+        line-height: ${lineHeight.xlarge};
         padding: ${size.small} ${size.default};
     }
 `;


### PR DESCRIPTION
The nav on mobile was wrapping onto a newline because the text was 18pt. I dropped it to 14pt and it does not wrap.

This PR:
![Screen Shot 2020-03-02 at 4 49 10 PM](https://user-images.githubusercontent.com/9064401/75721164-dfa96000-5ca5-11ea-97c2-c276ac7e2a73.png)

Before:
![Screen Shot 2020-03-02 at 4 49 26 PM](https://user-images.githubusercontent.com/9064401/75721165-dfa96000-5ca5-11ea-864e-230f5c0713e9.png)
