### PR TITLE
Jb/twitch video

### DIFF
--- a/src/components/dev-hub/video-embed.js
+++ b/src/components/dev-hub/video-embed.js
@@ -37,7 +37,11 @@ const getVideoUrl = (provider, videoId) => {
     }
 };
 
-const VideoEmbed = ({ nodeData: { argument, name: provider }, ...props }) => {
+const VideoEmbed = ({
+    autoplay,
+    nodeData: { argument, name: provider },
+    ...props
+}) => {
     const videoId = argument[0].value;
     const value = getVideoUrl(provider, videoId);
     const isYoutube = provider === 'youtube';
@@ -50,6 +54,11 @@ const VideoEmbed = ({ nodeData: { argument, name: provider }, ...props }) => {
                             autohide: 1,
                             modestbranding: 1,
                             rel: 0,
+                        },
+                    },
+                    twitch: {
+                        options: {
+                            autoplay,
                         },
                     },
                 }}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,12 +3,8 @@ import styled from '@emotion/styled';
 import Card from '../components/dev-hub/card';
 import MediaBlock from '../components/dev-hub/media-block';
 import Layout from '../components/dev-hub/layout';
-<<<<<<< HEAD
-import { H1, H2, P, SubHeader } from '../components/dev-hub/text';
-=======
 import Notification from '../components/dev-hub/notification';
 import { H1, H2, P, SubHeader, H5 } from '../components/dev-hub/text';
->>>>>>> Implement latest twitch video player into home page
 import {
     colorMap,
     gradientMap,
@@ -25,14 +21,9 @@ import buildImage from '../images/1x/Build.png';
 import GradientUnderline from '../components/dev-hub/gradient-underline';
 import homepageBackground from '../images/1x/homepage-background.png';
 import ProjectSignUpForm from '../components/dev-hub/project-sign-up-form';
-<<<<<<< HEAD
-// import Notification from '../components/dev-hub/notification';
-// import useTwitchApi from '../utils/use-twitch-api';
-=======
 import useTwitchApi from '../utils/use-twitch-api';
 import { Modal } from '../components/dev-hub/modal';
 import VideoEmbed from '../components/dev-hub/video-embed';
->>>>>>> Implement latest twitch video player into home page
 
 const MEDIA_WIDTH = '550';
 
@@ -112,49 +103,44 @@ const ThumbnailButton = styled(Button)`
     top: 35%;
 `;
 
-const Thumbnail = ({ thumbnailUrl = buildImage, videoId, ...props }) => (
-    <ThumbnailCard maxWidth={MEDIA_WIDTH} image={buildImage}>
-        <Modal
-            dialogContainerStyle={{
-                height: '90%',
-                padding: `0 ${size.large}`,
-                width: '90%',
-            }}
-            transparent
-            triggerComponent={<ThumbnailButton play />}
-        >
-            <VideoEmbed
-                nodeData={{
-                    argument: [{ value: videoId }],
-                    name: 'twitch',
+const Thumbnail = ({ video }) => {
+    let thumbnailUrl = buildImage;
+    if (video.thumbnail_url) {
+        thumbnailUrl = video.thumbnail_url.replace('%{height}', MEDIA_WIDTH);
+        thumbnailUrl = thumbnailUrl.replace('%{width}', MEDIA_WIDTH);
+    }
+
+    return (
+        <ThumbnailCard maxWidth={MEDIA_WIDTH} image={thumbnailUrl}>
+            <Modal
+                dialogContainerStyle={{
+                    height: '90%',
+                    padding: `0 ${size.large}`,
+                    width: '90%',
                 }}
-            />
-        </Modal>
-        <H5>{props.title}</H5>
-    </ThumbnailCard>
-);
+                transparent
+                triggerComponent={<ThumbnailButton play />}
+            >
+                <VideoEmbed
+                    nodeData={{
+                        argument: [{ value: video.id }],
+                        name: 'twitch',
+                    }}
+                />
+            </Modal>
+            <H5>{video.title}</H5>
+        </ThumbnailCard>
+    );
+};
 
 export default () => {
-    // TODO enable for launch
     const { error, stream, pending, videos } = useTwitchApi();
     const twitchVideo = useMemo(() => {
         if (stream) return stream;
         if (videos && videos.length) return videos[0];
         return null;
     }, [stream, videos]);
-    const thumbnailUrl = useMemo(() => {
-        if (twitchVideo) {
-            const nail = twitchVideo.thumbnail_url;
-            let newUrl = nail.replace('%{height}', MEDIA_WIDTH);
-            newUrl = newUrl.replace(
-                '%{width}',
-                `${MEDIA_WIDTH}x${MEDIA_WIDTH}`
-            );
-            return newUrl;
-        } else {
-            return null;
-        }
-    }, [twitchVideo]);
+
     return (
         <Layout>
             <BackgroundImage>
@@ -205,20 +191,7 @@ export default () => {
                 <FeatureSection altBackground>
                     <MediaBlock
                         mediaComponent={
-<<<<<<< HEAD
-                            <Card
-                                maxWidth={MEDIA_WIDTH}
-                                image={greenPatternImage}
-                            ></Card>
-=======
-                            twitchVideo && (
-                                <Thumbnail
-                                    videoId={twitchVideo.id}
-                                    thumbnailUrl={thumbnailUrl}
-                                    title={twitchVideo.title}
-                                />
-                            )
->>>>>>> Implement latest twitch video player into home page
+                            twitchVideo && <Thumbnail video={twitchVideo} />
                         }
                     >
                         <SectionContent>
@@ -233,22 +206,11 @@ export default () => {
                                 Every Friday at noon EST come watch our
                                 developers make the MongoDB platform come alive.
                             </DescriptiveText>
-<<<<<<< HEAD
-                            <Button
-                                secondary
-                                href="https://www.twitch.tv/mongodb"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                            >
-                                Watch
-                            </Button>
-=======
                             {twitchVideo && (
                                 <Button secondary href={twitchVideo.url}>
                                     Watch
                                 </Button>
                             )}
->>>>>>> Implement latest twitch video player into home page
                         </SectionContent>
                     </MediaBlock>
                 </FeatureSection>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,9 +1,14 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import styled from '@emotion/styled';
 import Card from '../components/dev-hub/card';
 import MediaBlock from '../components/dev-hub/media-block';
 import Layout from '../components/dev-hub/layout';
+<<<<<<< HEAD
 import { H1, H2, P, SubHeader } from '../components/dev-hub/text';
+=======
+import Notification from '../components/dev-hub/notification';
+import { H1, H2, P, SubHeader, H5 } from '../components/dev-hub/text';
+>>>>>>> Implement latest twitch video player into home page
 import {
     colorMap,
     gradientMap,
@@ -20,8 +25,14 @@ import buildImage from '../images/1x/Build.png';
 import GradientUnderline from '../components/dev-hub/gradient-underline';
 import homepageBackground from '../images/1x/homepage-background.png';
 import ProjectSignUpForm from '../components/dev-hub/project-sign-up-form';
+<<<<<<< HEAD
 // import Notification from '../components/dev-hub/notification';
 // import useTwitchApi from '../utils/use-twitch-api';
+=======
+import useTwitchApi from '../utils/use-twitch-api';
+import { Modal } from '../components/dev-hub/modal';
+import VideoEmbed from '../components/dev-hub/video-embed';
+>>>>>>> Implement latest twitch video player into home page
 
 const MEDIA_WIDTH = '550';
 
@@ -90,18 +101,69 @@ const DescriptiveText = styled(P)`
     color: ${colorMap.greyLightTwo};
     margin-bottom: ${size.medium};
 `;
+
+const ThumbnailCard = styled(Card)`
+    position: relative;
+`;
+
+const ThumbnailButton = styled(Button)`
+    left: 40%;
+    position: absolute;
+    top: 35%;
+`;
+
+const Thumbnail = ({ thumbnailUrl = buildImage, videoId, ...props }) => (
+    <ThumbnailCard maxWidth={MEDIA_WIDTH} image={buildImage}>
+        <Modal
+            dialogContainerStyle={{
+                height: '90%',
+                padding: `0 ${size.large}`,
+                width: '90%',
+            }}
+            transparent
+            triggerComponent={<ThumbnailButton play />}
+        >
+            <VideoEmbed
+                nodeData={{
+                    argument: [{ value: videoId }],
+                    name: 'twitch',
+                }}
+            />
+        </Modal>
+        <H5>{props.title}</H5>
+    </ThumbnailCard>
+);
+
 export default () => {
     // TODO enable for launch
-    // const { error, live, pending, videos } = useTwitchApi();
+    const { error, stream, pending, videos } = useTwitchApi();
+    const twitchVideo = useMemo(() => {
+        if (stream) return stream;
+        if (videos && videos.length) return videos[0];
+        return null;
+    }, [stream, videos]);
+    const thumbnailUrl = useMemo(() => {
+        if (twitchVideo) {
+            const nail = twitchVideo.thumbnail_url;
+            let newUrl = nail.replace('%{height}', MEDIA_WIDTH);
+            newUrl = newUrl.replace(
+                '%{width}',
+                `${MEDIA_WIDTH}x${MEDIA_WIDTH}`
+            );
+            return newUrl;
+        } else {
+            return null;
+        }
+    }, [twitchVideo]);
     return (
         <Layout>
             <BackgroundImage>
                 {/* 
                 // TODO enable for launch
-                {live && (
+                {stream && (
                     <Notification
-                        link={live.url}
-                        title={live.title}
+                        link={stream.url}
+                        title={stream.title}
                     />
                 )} 
                 */}
@@ -143,10 +205,20 @@ export default () => {
                 <FeatureSection altBackground>
                     <MediaBlock
                         mediaComponent={
+<<<<<<< HEAD
                             <Card
                                 maxWidth={MEDIA_WIDTH}
                                 image={greenPatternImage}
                             ></Card>
+=======
+                            twitchVideo && (
+                                <Thumbnail
+                                    videoId={twitchVideo.id}
+                                    thumbnailUrl={thumbnailUrl}
+                                    title={twitchVideo.title}
+                                />
+                            )
+>>>>>>> Implement latest twitch video player into home page
                         }
                     >
                         <SectionContent>
@@ -161,6 +233,7 @@ export default () => {
                                 Every Friday at noon EST come watch our
                                 developers make the MongoDB platform come alive.
                             </DescriptiveText>
+<<<<<<< HEAD
                             <Button
                                 secondary
                                 href="https://www.twitch.tv/mongodb"
@@ -169,6 +242,13 @@ export default () => {
                             >
                                 Watch
                             </Button>
+=======
+                            {twitchVideo && (
+                                <Button secondary href={twitchVideo.url}>
+                                    Watch
+                                </Button>
+                            )}
+>>>>>>> Implement latest twitch video player into home page
                         </SectionContent>
                     </MediaBlock>
                 </FeatureSection>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -104,10 +104,17 @@ const ThumbnailButton = styled(Button)`
 `;
 
 const Thumbnail = ({ video }) => {
-    let thumbnailUrl = buildImage;
+    let thumbnailUrl = buildImage; //fallback image if there is none
+    let dimensionsMatcher = '{width}x{height}';
     if (video.thumbnail_url) {
-        thumbnailUrl = video.thumbnail_url.replace('%{height}', MEDIA_WIDTH);
-        thumbnailUrl = thumbnailUrl.replace('%{width}', MEDIA_WIDTH);
+        const containsSpace = video.thumbnail_url.match('%{width}x%{height}');
+        dimensionsMatcher = containsSpace
+            ? '%{width}x%{height}'
+            : dimensionsMatcher;
+        thumbnailUrl = video.thumbnail_url.replace(
+            dimensionsMatcher,
+            `${MEDIA_WIDTH}x${MEDIA_WIDTH}`
+        );
     }
 
     return (

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -18,6 +18,7 @@ import stichImage from '../images/2x/Stitch-triggers@2x.png';
 import greenPatternImage from '../images/1x/pattern-green.png';
 import meetupsImage from '../images/1x/Meetups.png';
 import buildImage from '../images/1x/Build.png';
+import buildImage3x from '../images/3x/Build@3x.png';
 import GradientUnderline from '../components/dev-hub/gradient-underline';
 import homepageBackground from '../images/1x/homepage-background.png';
 import ProjectSignUpForm from '../components/dev-hub/project-sign-up-form';
@@ -104,7 +105,7 @@ const ThumbnailButton = styled(Button)`
 `;
 
 const Thumbnail = ({ video }) => {
-    let thumbnailUrl = buildImage; //fallback image if there is none
+    let thumbnailUrl = buildImage3x; //fallback image if there is none
     let dimensionsMatcher = '{width}x{height}';
     if (video.thumbnail_url) {
         const containsSpace = video.thumbnail_url.match('%{width}x%{height}');

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -15,10 +15,9 @@ import Button from '../components/dev-hub/button';
 import cSharpImage from '../images/1x/c-sharp.png';
 import nodejsImage from '../images/1x/Node.JS-1.png';
 import stichImage from '../images/2x/Stitch-triggers@2x.png';
-import greenPatternImage from '../images/1x/pattern-green.png';
+import greenPatternImage from '../images/3x/pattern-green@3x.png';
 import meetupsImage from '../images/1x/Meetups.png';
 import buildImage from '../images/1x/Build.png';
-import buildImage3x from '../images/3x/Build@3x.png';
 import GradientUnderline from '../components/dev-hub/gradient-underline';
 import homepageBackground from '../images/1x/homepage-background.png';
 import ProjectSignUpForm from '../components/dev-hub/project-sign-up-form';
@@ -105,7 +104,7 @@ const ThumbnailButton = styled(Button)`
 `;
 
 const Thumbnail = ({ video }) => {
-    let thumbnailUrl = buildImage3x; //fallback image if there is none
+    let thumbnailUrl = greenPatternImage; //fallback image if there is none
     let dimensionsMatcher = '{width}x{height}';
     if (video.thumbnail_url) {
         const containsSpace = video.thumbnail_url.match('%{width}x%{height}');

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -133,6 +133,7 @@ const Thumbnail = ({ video }) => {
                         argument: [{ value: video.id }],
                         name: 'twitch',
                     }}
+                    autoplay={true}
                 />
             </Modal>
             <H5>{video.title}</H5>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -15,7 +15,7 @@ import Button from '../components/dev-hub/button';
 import cSharpImage from '../images/1x/c-sharp.png';
 import nodejsImage from '../images/1x/Node.JS-1.png';
 import stichImage from '../images/2x/Stitch-triggers@2x.png';
-import greenPatternImage from '../images/3x/pattern-green@3x.png';
+import greenPatternImage from '../images/2x/pattern-green@2x.png';
 import meetupsImage from '../images/1x/Meetups.png';
 import buildImage from '../images/1x/Build.png';
 import GradientUnderline from '../components/dev-hub/gradient-underline';
@@ -151,15 +151,9 @@ export default () => {
     return (
         <Layout>
             <BackgroundImage>
-                {/* 
-                // TODO enable for launch
                 {stream && (
-                    <Notification
-                        link={stream.url}
-                        title={stream.title}
-                    />
-                )} 
-                */}
+                    <Notification link={stream.url} title={stream.title} />
+                )}
                 <Hero>
                     <Heading>
                         {`ideas.find({"attributes":`}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -214,7 +214,12 @@ export default () => {
                                 developers make the MongoDB platform come alive.
                             </DescriptiveText>
                             {twitchVideo && (
-                                <Button secondary href={twitchVideo.url}>
+                                <Button
+                                    target="_blank"
+                                    rel="noreferrer noopener"
+                                    secondary
+                                    href={twitchVideo.url}
+                                >
                                     Watch
                                 </Button>
                             )}

--- a/src/pages/storybook.js
+++ b/src/pages/storybook.js
@@ -515,14 +515,6 @@ export default () => (
                     </GradientUnderline>
                 </H2>
             </Row>
-            <SectionHeader>Icons</SectionHeader>
-            <Row>
-                <ShareIcon color={colorMap.teal} />
-                <ListIcon color={colorMap.orange} />
-                <FacebookIcon color={colorMap.salmon} />
-                <TwitterIcon color={colorMap.violet} />
-                <EnvelopeIcon color={colorMap.magenta} />
-            </Row>
             <SectionHeader>Cards</SectionHeader>
             <Row id="card-row">
                 <Card


### PR DESCRIPTION
This PR includes:
- Replaces Twitch video placeholder on home page with either the current live stream or latest video
- if clicked will open a modal so users can watch the video

@greggb Should I uncomment the live stream banner or do you still want this to be done closer to launch?

### Thumbnail Inconsistencies
If you notice I have some logic to update the dimensions on any thumbnail we receive. The Twitch docs say that the end of `thumbnail_urls` contains tokens `{width}x{height}` through which you can update the dimensions. **However,** I found the `thumbnail_url` had some extra space around the dimensions = `%{width}x%{height}`. 

The url isn't encoded so decoding it doesn't remove this space. I have some logic to handle this format but not sure if this is something that will consistently happen. Let me know your thoughts!

![Mar-03-2020 10-22-28](https://user-images.githubusercontent.com/8241921/75790279-f351d680-5d38-11ea-9edc-08b46d1c9062.gif)
