### PR TITLE
check for fileid and use href

### DIFF
--- a/src/components/RefRole.js
+++ b/src/components/RefRole.js
@@ -16,9 +16,10 @@ const RefRole = ({ nodeData: { children, fileid, target, url }, slug }) => {
     }
 
     // Render internal target links
-    const link = fileid === slug ? `#${target}` : `${fileid}#${target}`;
+    const link =
+        fileid && fileid === slug ? `#${target}` : `${fileid}#${target}`;
     return (
-        <Link to={link} className="ref-role-anchor">
+        <Link href={link} className="ref-role-anchor">
             <span>
                 {children.map((node, i) => (
                     <ComponentFactory key={i} nodeData={node} />


### PR DESCRIPTION
Should fix anchor links within articles. We don't receive `fileid`s so we were point to the root of the site.