### PR TITLE
Update substitution reference component to match new AST

### DIFF
--- a/src/components/SubstitutionReference.js
+++ b/src/components/SubstitutionReference.js
@@ -1,40 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
-import { getNestedValue } from '../utils/get-nested-value';
 
-const SubstitutionReference = ({
-    nodeData,
-    nodeData: { children, name },
-    substitutions,
-    ...rest
-}) => {
-    if (getNestedValue([name], substitutions)) {
-        return substitutions[name].map((sub, index) => (
-            <ComponentFactory {...rest} nodeData={sub} key={index} />
-        ));
-    }
-
-    if (children) {
-        return children.map((child, index) => (
-            <ComponentFactory {...rest} nodeData={child} key={index} />
-        ));
-    }
-
-    // If the map of substitutions does not include the desired substitution definition, don't replace it with anything
-    return <React.Fragment>{name}</React.Fragment>;
-};
+const SubstitutionReference = ({ nodeData: { children, name }, ...rest }) => (
+    <React.Fragment>
+        {children
+            ? children.map((child, index) => (
+                  <ComponentFactory {...rest} nodeData={child} key={index} />
+              ))
+            : name}
+    </React.Fragment>
+);
 
 SubstitutionReference.propTypes = {
     nodeData: PropTypes.shape({
-        children: PropTypes.arrayOf(
-            PropTypes.shape({
-                value: PropTypes.string,
-            })
-        ),
+        children: PropTypes.arrayOf(PropTypes.object).isRequired,
         name: PropTypes.string.isRequired,
     }).isRequired,
-    substitutions: PropTypes.objectOf(PropTypes.array).isRequired,
 };
 
 export default SubstitutionReference;


### PR DESCRIPTION
Duplicates https://github.com/mongodb/snooty/pull/159.

We recently introduced changes to the AST around substitutions ([DOCSPLAT-114](https://jira.mongodb.org/browse/DOCSPLAT-114)). This PR updates the front-end to accept this new schema. Backwards compatible with previous parser versions!