### PR TITLE
Add Related Article Flex-Wrap

### DIFF
--- a/src/components/dev-hub/related-articles.js
+++ b/src/components/dev-hub/related-articles.js
@@ -10,36 +10,33 @@ const MAX_CARD_WIDTH = 270;
 
 const RelatedContainer = styled('div')`
     background-color: ${colorMap.devBlack};
-    padding: 30px;
+    padding: 30px ${size.medium};
     @media ${screenSize.mediumAndUp} {
-        padding: 70px ${size.xxlarge};
+        padding: 70px calc(${size.xxlarge} - ${size.medium});
     }
 `;
 
 const RelatedCards = styled('div')`
     display: flex;
-    @media ${screenSize.upToMedium} {
+    flex-wrap: wrap;
+    @media ${screenSize.upToLarge} {
         flex-direction: column;
         > a,
         > div {
             margin: 0 auto;
         }
     }
-    @media ${screenSize.mediumAndUp} {
+    @media ${screenSize.largeAndUp} {
         > a,
         > div {
-            padding-left: 0;
-            padding-right: 0;
             margin-left: ${size.medium};
             margin-right: ${size.medium};
         }
-        > :first-child {
-            margin-left: 0;
-        }
-        > :last-child {
-            margin-right: 0;
-        }
     }
+`;
+
+const RelatedHeaderText = styled(H4)`
+    margin-left: ${size.medium};
 `;
 
 const getCardParamsFromRelatedType = (relatedArticle, slugTitleMapping) => {
@@ -82,7 +79,7 @@ const RelatedArticles = ({ related, slugTitleMapping }) => {
     if (!related || !related.length) return null;
     return (
         <RelatedContainer>
-            <H4>Related</H4>
+            <RelatedHeaderText>Related</RelatedHeaderText>
             <RelatedCards>
                 {related.map((r, i) => {
                     const {
@@ -93,15 +90,17 @@ const RelatedArticles = ({ related, slugTitleMapping }) => {
 
                     /* TODO: Case on doc to link internal vs external */
                     return (
-                        <Card
-                            // Title may be undefined, so tacking on index keeps unique
-                            key={`${title}-${i}`}
-                            image={image}
-                            href={target}
-                            maxDescriptionLines={2}
-                            title={title}
-                            maxWidth={MAX_CARD_WIDTH}
-                        />
+                        <>
+                            <Card
+                                // Title may be undefined, so tacking on index keeps unique
+                                key={`${title}-${i}`}
+                                image={image}
+                                href={target}
+                                maxTitleLines={2}
+                                title={title}
+                                maxWidth={MAX_CARD_WIDTH}
+                            />
+                        </>
                     );
                 })}
             </RelatedCards>


### PR DESCRIPTION
This PR adds some styling improvements for related articles (specifically padding and handling >4 related articles).

- Added `flex-wrap` to keep width consistent and move more cards to new rows
- Fixed padding/margin to properly have card hover state

Because of flex-wrapping and a fixed width, I decided to just switch to a `column` flex under the large size. Otherwise cards were awkwardly flushed left.

![Screen Shot 2020-03-03 at 1 24 31 PM](https://user-images.githubusercontent.com/9064401/75808410-10949e00-5d55-11ea-8a21-5445e2c025e2.png)
![Screen Shot 2020-03-03 at 1 24 43 PM](https://user-images.githubusercontent.com/9064401/75808412-112d3480-5d55-11ea-81ac-00d0371f8802.png)
![Screen Shot 2020-03-03 at 1 24 59 PM](https://user-images.githubusercontent.com/9064401/75808413-112d3480-5d55-11ea-9c74-5ee98c7fed57.png)
