### PR TITLE
Remove old console logs on builds

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -162,7 +162,6 @@ const createTagPageType = async (createPage, pageMetadata, stitchType) => {
 
     pageList.forEach(page => {
         if (page) {
-            console.log(page.slug);
             createPage({
                 path: page.slug,
                 component: path.resolve(`./src/templates/tag.js`),

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -61,7 +61,6 @@ const getContent = nodes => {
 };
 
 const ArticleSeries = ({ allSeriesForArticle, slugTitleMapping, title }) => {
-    console.log(allSeriesForArticle);
     // Handle if this article is not in a series or no series are defined
     if (!allSeriesForArticle) return null;
     // Handle if this series is not defined in the top-level content TOML file


### PR DESCRIPTION
This PR removes some noisy logs from builds to help reduce clutter.