### PR TITLE
Add flexible featured article support

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -31,6 +31,12 @@ let PAGE_ID_PREFIX;
 const PAGES = [];
 const IMAGE_FILES = {};
 
+const FEATURED_LEARN_SLUGS = [
+    '/how-to/introducing-graphql-support-in-mongodb-atlas-with-stitch',
+    '/how-to/building-modern-applications-with-nextjs',
+    '/how-to/mongodb-and-data-streaming-implementing-a-mongodb-kafka-consumer',
+];
+
 const STITCH_TYPE_TO_URL_PREFIX = {
     author: 'author',
     languages: 'language',
@@ -305,16 +311,26 @@ const getLearnPageArticles = async () => {
     return documents;
 };
 
+const getFeaturedLearnArticles = articles => {
+    const result = [];
+    FEATURED_LEARN_SLUGS.forEach(f => {
+        result.push(articles.find(x => x.query_fields.slug === f));
+    });
+    return result;
+};
+
 exports.onCreatePage = async ({ page, actions }) => {
     if (page.path === '/learn/') {
         const { createPage, deletePage } = actions;
         const allArticles = await getLearnPageArticles();
+        const featuredArticles = getFeaturedLearnArticles(allArticles);
         deletePage(page);
         createPage({
             ...page,
             context: {
                 ...page.context,
                 allArticles,
+                featuredArticles,
             },
         });
     }


### PR DESCRIPTION
This PR adds some flexibility to the featured articles on the learn page.

- We define three "featured articles" in `gatsby-node` in order of precedence on the learn page
- We parse the articles in `learn.js`