### PR TITLE
Add alt tags to article and hero images

### DIFF
--- a/src/components/dev-hub/card.js
+++ b/src/components/dev-hub/card.js
@@ -124,7 +124,7 @@ const Card = ({
             <div>
                 {image && (
                     <ImageWrapper>
-                        <Image src={image} />
+                        <Image src={image} alt="" />
                     </ImageWrapper>
                 )}
                 {cardTitle && (

--- a/src/components/dev-hub/hero-banner.js
+++ b/src/components/dev-hub/hero-banner.js
@@ -86,7 +86,7 @@ const HeroBanner = ({
                     )}
                     {isMobile && showImageOnMobile && (
                         <MobileMediaContainer>
-                            <img src={background} alt={background} />
+                            <img src={background} alt="" />
                         </MobileMediaContainer>
                     )}
                     {children}


### PR DESCRIPTION
-the hero images are background-images so we can't really add alt tags to those
-this adds blank alt tags for the article cards and hero on mobile for now