### PR TITLE
Remove erroneous article data from learn page

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -307,7 +307,12 @@ const getLearnPageArticles = async () => {
         metadata,
         {},
     ]);
-    return documents;
+    // Ignore bad data, including links to the home page as an "article"
+    const filteredDocuments = documents.filter(d => {
+        const route = dlv(d, ['query_fields', 'slug'], null);
+        return route !== '/';
+    });
+    return filteredDocuments;
 };
 
 const getFeaturedLearnArticles = articles => {


### PR DESCRIPTION
This PR fixes the blank article on the learn page. What happened is we were getting data from stitch that looked like:

```
{ _id: 'some id',
  query_fields: {
    slug: '/'
    // no other fields
  }
}
```

While this data should be removed from stitch, we can also filter it out at build time. No learn page article should link to the home page.