### PR TITLE
move title

### DIFF
--- a/src/components/dev-hub/card.js
+++ b/src/components/dev-hub/card.js
@@ -111,7 +111,6 @@ const Card = ({
               href,
               target,
           };
-    const cardTitle = title || children;
     const isClickable = onClick || isLink;
     return (
         <ContentWrapper
@@ -127,12 +126,12 @@ const Card = ({
                         <Image src={image} alt="" />
                     </ImageWrapper>
                 )}
-                {cardTitle && (
+                {title && (
                     <CardTitle
                         css={truncate(maxTitleLines)}
                         collapse={!description}
                     >
-                        {cardTitle}
+                        {title}
                     </CardTitle>
                 )}
                 {description && (
@@ -141,7 +140,7 @@ const Card = ({
                     </DescriptionText>
                 )}
             </div>
-
+            {children}
             {tags && <TagList tags={tags} />}
         </ContentWrapper>
     );

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -118,7 +118,11 @@ const Thumbnail = ({ video }) => {
     }
 
     return (
-        <ThumbnailCard maxWidth={MEDIA_WIDTH} image={thumbnailUrl}>
+        <ThumbnailCard
+            maxWidth={MEDIA_WIDTH}
+            image={thumbnailUrl}
+            title={video.title}
+        >
             <Modal
                 dialogContainerStyle={{
                     height: '90%',
@@ -136,7 +140,6 @@ const Thumbnail = ({ video }) => {
                     autoplay={true}
                 />
             </Modal>
-            <H5>{video.title}</H5>
         </ThumbnailCard>
     );
 };
@@ -164,32 +167,32 @@ export default () => {
                     <Sub>What will you create today?</Sub>
                     <CardGallery>
                         <StyledTopCard
+                            maxTitleLines={3}
                             image={nodejsIllustration}
                             to="/how-to/nextjs-building-modern-applications"
-                        >
-                            Building Modern Applications with Next.js and
-                            MongoDB
-                        </StyledTopCard>
+                            title="Building Modern Applications with Next.js and
+                            MongoDB"
+                        />
                         <StyledTopCard
+                            maxTitleLines={3}
                             image={pythonImage}
                             to="/how-to/python-starlette-stitch"
-                        >
-                            Build a Property Booking Website with Starlette,
-                            MongoDB, and Twilio
-                        </StyledTopCard>
+                            title="Build a Property Booking Website with Starlette,
+                            MongoDB, and Twilio"
+                        />
                         <StyledTopCard
+                            maxTitleLines={3}
                             image={graphqlImage}
                             to="/how-to/graphql-support-atlas-stitch"
-                        >
-                            Introducing GraphQL Support in MongoDB Atlas with
-                            Stitch
-                        </StyledTopCard>
+                            title="Introducing GraphQL Support in MongoDB Atlas with
+                            Stitch"
+                        />
                         <StyledTopCard
+                            maxTitleLines={3}
                             image={buildImage}
                             to="/quickstart/free-atlas-cluster"
-                        >
-                            Quick Start: Getting Your Free MongoDB Atlas Cluster
-                        </StyledTopCard>
+                            title="Quick Start: Getting Your Free MongoDB Atlas Cluster"
+                        />
                     </CardGallery>
                     <div>
                         <Button to="/learn" primary>

--- a/src/pages/storybook.js
+++ b/src/pages/storybook.js
@@ -523,10 +523,9 @@ export default () => (
                     image={mockCardImage}
                     tags={mapTagTypeToUrl(['tag one', 'tag two'], 'tags')}
                     maxTitleLines={3}
-                >
-                    I'm a Card For A Post on the New Devhub Platform! With no
-                    links or clickable actions!
-                </Card>
+                    title="I'm a Card For A Post on the New Devhub Platform! With no
+                    links or clickable actions!"
+                ></Card>
                 <Card
                     href="#card-row"
                     image={mockCardImage}
@@ -534,16 +533,14 @@ export default () => (
                         ['tag one', 'tag two', 'tag three'],
                         'tags'
                     )}
-                >
-                    I'm a Card
-                </Card>
+                    title="I'm a Card"
+                ></Card>
                 <Card
                     image={mockCardImage}
                     onClick={() => console.log('Clicked!')}
                     highlight
-                >
-                    I'm a highlighted Card
-                </Card>
+                    card="I'm a highlighted Card"
+                ></Card>
             </Row>
             <Row>
                 <Card


### PR DESCRIPTION
Could use a hand checking for any places that still use children instead of title where appropriate. Think I caught all the cases.

We should use title for text only titles and only pass children for things like the twitch feature.

This also bumps the featured home page articles to 3 lines which is different than the design, but prevent the cutoff on most of the articles.