### PR TITLE
Filter Without Stitch, Dynamically Change Counts

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -334,6 +334,7 @@ const getLearnPageFilters = async () => {
         products: {},
     };
 
+    // Get possible language and product values from Stitch
     const languageValues = await stitchClient.callFunction('getValuesByKey', [
         metadata,
         'languages',
@@ -342,6 +343,8 @@ const getLearnPageFilters = async () => {
         metadata,
         'products',
     ]);
+
+    // For each language, build an object with its total count, and count for each product
     for (let i = 0; i < languageValues.length; i++) {
         const l = languageValues[i];
         filters.languages[l._id] = {
@@ -356,6 +359,8 @@ const getLearnPageFilters = async () => {
             filters.languages[l._id].products[pl._id] = pl.count;
         });
     }
+
+    // For each product, build an object with its total count, and count for each language
     for (let i = 0; i < productValues.length; i++) {
         const p = productValues[i];
         filters.products[p._id] = {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -328,11 +328,57 @@ const getFeaturedLearnArticles = articles => {
     return result;
 };
 
+const getLearnPageFilters = async () => {
+    const filters = {
+        languages: {},
+        products: {},
+    };
+
+    const languageValues = await stitchClient.callFunction('getValuesByKey', [
+        metadata,
+        'languages',
+    ]);
+    const productValues = await stitchClient.callFunction('getValuesByKey', [
+        metadata,
+        'products',
+    ]);
+    for (let i = 0; i < languageValues.length; i++) {
+        const l = languageValues[i];
+        filters.languages[l._id] = {
+            count: l.count,
+            products: {},
+        };
+        const productValuesForLanguage = await stitchClient.callFunction(
+            'getValuesByKey',
+            [metadata, 'products', { languages: l._id }]
+        );
+        productValuesForLanguage.forEach(pl => {
+            filters.languages[l._id].products[pl._id] = pl.count;
+        });
+    }
+    for (let i = 0; i < productValues.length; i++) {
+        const p = productValues[i];
+        filters.products[p._id] = {
+            count: p.count,
+            languages: {},
+        };
+        const languageValuesForProduct = await stitchClient.callFunction(
+            'getValuesByKey',
+            [metadata, 'languages', { products: p._id }]
+        );
+        languageValuesForProduct.forEach(lp => {
+            filters.products[p._id].languages[lp._id] = lp.count;
+        });
+    }
+    return filters;
+};
+
 exports.onCreatePage = async ({ page, actions }) => {
     if (page.path === '/learn/') {
         const { createPage, deletePage } = actions;
         const allArticles = await getLearnPageArticles();
         const featuredArticles = getFeaturedLearnArticles(allArticles);
+        const filters = await getLearnPageFilters(allArticles);
         deletePage(page);
         createPage({
             ...page,
@@ -340,6 +386,7 @@ exports.onCreatePage = async ({ page, actions }) => {
                 ...page.context,
                 allArticles,
                 featuredArticles,
+                filters,
             },
         });
     }

--- a/src/components/dev-hub/filter-bar.js
+++ b/src/components/dev-hub/filter-bar.js
@@ -69,6 +69,7 @@ export default React.memo(
             const hasLanguageFilter =
                 filterValue.languages && filterValue.languages !== 'all';
             if (hasProductFilter) {
+                // Filter only languages which have an article in common with the selected product
                 const langs = filters.products[filterValue.products].languages;
                 setLanguages(
                     // Don't include counts if both filters are applied
@@ -78,6 +79,7 @@ export default React.memo(
                 setLanguages(initialLanguages);
             }
             if (hasLanguageFilter) {
+                // Filter only products which have an article in common with the selected language
                 const products =
                     filters.languages[filterValue.languages].products;
                 setProducts(

--- a/src/components/dev-hub/filter-bar.js
+++ b/src/components/dev-hub/filter-bar.js
@@ -103,7 +103,6 @@ export default React.memo(
             initialProducts,
         ]);
         const handleChange = (value, type) => {
-            console.log(value, type);
             // only update if the filter value has changed
             if (filterValue[type]) {
                 filterValue[type] !== value &&

--- a/src/components/dev-hub/select.js
+++ b/src/components/dev-hub/select.js
@@ -78,6 +78,7 @@ const FormSelect = ({
     errors = [],
     narrow = false,
     onChange = null,
+    styleSelectedText = null,
     validationStatus = null,
     value = '',
     ...extraProps
@@ -89,6 +90,15 @@ const FormSelect = ({
         setShowOptions(!showOptions);
     }, [showOptions]);
     const selectOptions = typeof choices !== 'undefined' ? choices : children;
+    const updateSelectedText = useCallback(
+        text => {
+            const updatedText = styleSelectedText
+                ? styleSelectedText(text)
+                : text;
+            setSelectText(updatedText);
+        },
+        [styleSelectedText]
+    );
     /**
      * This useEffect should only be called once the component first renders with choices,
      * this should populate the select item with the default choice if there is one
@@ -98,7 +108,7 @@ const FormSelect = ({
             const choice = selectOptions.filter(choice => choice[0] === value);
             if (choice && choice.length) {
                 setSelectValue(value);
-                setSelectText(choice[0][1]);
+                updateSelectedText(choice[0][1]);
             }
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -120,13 +130,13 @@ const FormSelect = ({
     const optionOnClick = useCallback(
         (value, text) => {
             setSelectValue(value);
-            setSelectText(text);
+            updateSelectedText(text);
             if (onChange) {
                 onChange(value, text);
             }
             setShowOptions(false);
         },
-        [onChange]
+        [onChange, updateSelectedText]
     );
 
     const optionOnEnter = useCallback(

--- a/src/components/dev-hub/select.js
+++ b/src/components/dev-hub/select.js
@@ -45,7 +45,7 @@ const Options = styled('ul')`
         narrow
             ? `${OPTIONS_POSITION_OFFSET_NARROW}px`
             : `${OPTIONS_POSITION_OFFSET}px`};
-    width: 100%;
+    width: calc(100% + ${2 * BORDER_SIZE}px);
     z-index: ${layer.middle};
 `;
 

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -177,7 +177,7 @@ const FeaturedArticles = ({ articles }) => {
 
 export default ({
     location,
-    pageContext: { allArticles, featuredArticles },
+    pageContext: { allArticles, featuredArticles, filters },
 }) => {
     const metadata = useSiteMetadata();
     const initialArticles = useMemo(() => parseArticles(allArticles), [
@@ -214,6 +214,7 @@ export default ({
             </Header>
             <Article>
                 <FilterBar
+                    filters={filters}
                     filterValue={filterValue}
                     setFilterValue={updateFilter}
                 />


### PR DESCRIPTION
This PR adds build-time logic to compute filtering values for the learn page filters. Specifically, now:

- Choosing a filter dynamically updates the other filter to show options where at least one article exists.
- Choosing filters dynamically changes the number shown available in the other filter.
- **Choosing both filters removes count numbers from the filters** (keeping numbers here did not make sense).

Please give this a try locally and see if anything is wonky!

The logic is a bit odd but I think this best supports how we want to use the filters. I chose to represent the filters like so:

<img width="541" alt="Screen Shot 2020-03-04 at 5 19 40 PM" src="https://user-images.githubusercontent.com/9064401/75928580-b7079e80-5e3c-11ea-9a28-ca90737f7a8b.png">

Where each value loooks something like (here for `languages`):
<img width="677" alt="Screen Shot 2020-03-04 at 5 21 30 PM" src="https://user-images.githubusercontent.com/9064401/75928581-b7a03500-5e3c-11ea-8839-10e70709e2cb.png">
