### PR TITLE
Update date formatting for Articles

### DIFF
--- a/src/components/dev-hub/blog-post-title-area.js
+++ b/src/components/dev-hub/blog-post-title-area.js
@@ -19,12 +19,10 @@ const PostMetaLine = styled('div')`
     }
 `;
 
-const bulletStyling = css`
-    @media ${screenSize.xSmallAndUp} {
-        &:after {
-            content: '\u2022';
-            margin-left: ${size.tiny};
-        }
+const breakStyling = css`
+    &:after {
+        content: '|';
+        margin-left: ${size.tiny};
     }
 `;
 
@@ -33,15 +31,14 @@ const DateText = styled(P)`
     @media ${screenSize.upToLarge} {
         font-size: ${fontSize.xsmall};
     }
-    ${({ withBullet }) => withBullet && bulletStyling};
+    :first-of-type :not(:last-of-type) {
+        ${breakStyling};
+    }
 `;
 
 const DateTextContainer = styled('div')`
     margin-right: ${size.medium};
     display: flex;
-    @media ${screenSize.upToXSmall} {
-        flex-direction: column;
-    }
 `;
 
 const BlogPostTitleArea = ({
@@ -60,12 +57,10 @@ const BlogPostTitleArea = ({
             <PostMetaLine>
                 <DateTextContainer>
                     {updatedDate && (
-                        <DateText withBullet collapse>
-                            Updated {updatedDate}
-                        </DateText>
+                        <DateText collapse>Updated: {updatedDate}</DateText>
                     )}
                     {originalDate && (
-                        <DateText collapse>{originalDate}</DateText>
+                        <DateText collapse>Published: {originalDate}</DateText>
                     )}
                 </DateTextContainer>
                 <BlogTagList tags={tags} />

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -13,7 +13,7 @@ import { size } from '../components/dev-hub/theme';
 import Series from '../components/dev-hub/series';
 import { getTagLinksFromMeta } from '../utils/get-tag-links-from-meta';
 import { getTagPageUriComponent } from '../utils/get-tag-page-uri-component';
-import { normalizePath } from '../utils/normalize-path';
+import { toDateString } from '../utils/format-dates';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 
 /**
@@ -26,6 +26,12 @@ const contentNodesMap = {
     'meta-description': true,
     summary: true,
     twitter: true,
+};
+
+const dateFormatOptions = {
+    month: 'short',
+    day: '2-digit',
+    year: 'numeric',
 };
 
 /**
@@ -124,6 +130,15 @@ const Article = props => {
     const tagList = getTagLinksFromMeta(meta);
     const articleTitle = dlv(meta.title, [0, 'value'], thisPage);
     const articleUrl = `${siteUrl}/${thisPage}`;
+    const formattedPublishedDate = toDateString(
+        meta.pubdate,
+        dateFormatOptions
+    );
+    const formattedUpdatedDate = toDateString(
+        meta.updatedDate,
+        dateFormatOptions
+    );
+
     return (
         <Layout>
             <Helmet>
@@ -136,10 +151,10 @@ const Article = props => {
                 articleImage={withPrefix(meta['atf-image'])}
                 author={meta.author}
                 breadcrumb={articleBreadcrumbs}
-                originalDate={meta.pubdate}
+                originalDate={formattedPublishedDate}
                 tags={tagList}
                 title={articleTitle}
-                updatedDate={meta.updatedDate}
+                updatedDate={formattedUpdatedDate}
             />
 
             <ArticleContent>


### PR DESCRIPTION
This PR updates the date formatting for articles to look like the following:

Has been updated:
![Screen Shot 2020-03-05 at 2 22 02 PM](https://user-images.githubusercontent.com/9064401/76017682-fdb4d180-5eec-11ea-8af8-26e06937d099.png)

Has not been updated:
![Screen Shot 2020-03-05 at 2 22 11 PM](https://user-images.githubusercontent.com/9064401/76017684-fdb4d180-5eec-11ea-9a4b-9bf8ca943c0f.png)
