### PR TITLE
Jb/update card alignment

### DIFF
--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -11,8 +11,9 @@ const CardContainer = styled('div')`
     display: grid;
     grid-template-columns: repeat(auto-fill, 350px);
     grid-auto-rows: 1fr;
-    grid-column-gap: 10px;
-    grid-row-gap: 10px;
+    grid-column-gap: ${size.small};
+    grid-row-gap: ${size.small};
+    justify-content: center;
     margin: 0 -${size.medium};
 
     @media ${screenSize.upToMedium} {

--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -8,19 +8,13 @@ import { getNestedText } from '../../utils/get-nested-text';
 import { getTagLinksFromMeta } from '../../utils/get-tag-links-from-meta';
 
 const CardContainer = styled('div')`
-    align-items: start;
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-start;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, 350px);
+    grid-auto-rows: 1fr;
+    grid-column-gap: 10px;
+    grid-row-gap: 10px;
     margin: 0 -${size.medium};
 
-    @media ${screenSize.xlargeAndUp} {
-        &:after {
-            /* Hack to prevent last row cards from expanding */
-            content: '';
-            flex-grow: 1000000000;
-        }
-    }
     @media ${screenSize.upToMedium} {
         display: block;
     }

--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -10,7 +10,6 @@ import { getTagLinksFromMeta } from '../../utils/get-tag-links-from-meta';
 const CardContainer = styled('div')`
     display: grid;
     grid-template-columns: repeat(auto-fill, 350px);
-    grid-auto-rows: 1fr;
     grid-column-gap: ${size.small};
     grid-row-gap: ${size.small};
     justify-content: center;

--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -10,7 +10,6 @@ import { getTagLinksFromMeta } from '../../utils/get-tag-links-from-meta';
 const CardContainer = styled('div')`
     display: grid;
     grid-template-columns: repeat(auto-fill, 350px);
-    grid-column-gap: ${size.small};
     grid-row-gap: ${size.small};
     justify-content: center;
     margin: 0 -${size.medium};

--- a/src/components/dev-hub/card.js
+++ b/src/components/dev-hub/card.js
@@ -23,6 +23,7 @@ const Image = styled('img')`
 
 const ImageWrapper = styled('div')`
     border-radius: ${size.small};
+    height: 300px;
     margin-bottom: ${size.medium};
     overflow: hidden;
     padding: 0;
@@ -51,6 +52,7 @@ const Wrapper = styled('div')`
     text-decoration: none;
     transition: background-color ${animationSpeed.medium};
     width: ${({ width = 'auto' }) => width};
+    ${({ collapseImage }) => !collapseImage && `min-height: 562px`};
     ${({ highlight }) => highlight && `background: rgba(255, 255, 255, 0.3);`};
     ${({ isClickable }) => isClickable && hoverStyles}
 `;
@@ -72,6 +74,7 @@ const CardTitle = styled(H5)`
  * @param {Object<string, any>} props
  * @property {node} props.children
  * @property {string} props.className
+ * @property {boolean?} props.collapseImage
  * @property {string} props.description
  * @property {bool?} props.gradient
  * @property {bool?} props.highlight
@@ -90,6 +93,7 @@ const CardTitle = styled(H5)`
 const Card = ({
     children,
     className,
+    collapseImage = false,
     description,
     href,
     image,
@@ -119,11 +123,12 @@ const Card = ({
             maxWidth={maxWidth}
             isClickable={isClickable}
             className={className}
+            collapseImage={collapseImage}
         >
             <div>
-                {image && (
+                {!collapseImage && (
                     <ImageWrapper>
-                        <Image src={image} alt="" />
+                        {image && <Image src={image} alt="" />}
                     </ImageWrapper>
                 )}
                 {title && (

--- a/src/components/dev-hub/card.js
+++ b/src/components/dev-hub/card.js
@@ -23,7 +23,6 @@ const Image = styled('img')`
 
 const ImageWrapper = styled('div')`
     border-radius: ${size.small};
-    height: 300px;
     margin-bottom: ${size.medium};
     overflow: hidden;
     padding: 0;

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -124,6 +124,7 @@ const SecondaryFeaturedArticle = ({ article, Wrapper }) => {
         );
         return (
             <Wrapper
+                collapseImage
                 to={slug}
                 title={title}
                 description={description}
@@ -155,6 +156,7 @@ const FeaturedArticles = ({ articles }) => {
                     mediaWidth={360}
                 >
                     <Card
+                        collapseImage
                         maxDescriptionLines={4}
                         to={slug}
                         title={title}


### PR DESCRIPTION
This PR sets a consistent height and alignment for a Card list. It also gives additional flexibility to a card to allow its image space to collapse (now by default we will insure a set height is taken up whether or not an article has an image).


<img width="1514" alt="Screen Shot 2020-03-05 at 3 29 34 PM" src="https://user-images.githubusercontent.com/8241921/76022980-3ad19180-5ef6-11ea-8a68-162db519cff4.png">
