### PR TITLE
Parse events API data as JSON

### DIFF
--- a/src/hooks/use-event-data.js
+++ b/src/hooks/use-event-data.js
@@ -62,8 +62,9 @@ const useEventData = url => {
                     },
                 });
                 if (data) {
+                    const parsedData = await data.json();
                     setError(null);
-                    setEvents(data);
+                    setEvents(parsedData);
                 }
             } catch (e) {
                 setError(e);


### PR DESCRIPTION
The community page was not rendering with an `events.slice` error. This seemed to be due to some changes on the events API which now give us a successful response.

![Screen Shot 2020-03-06 at 9 52 49 AM](https://user-images.githubusercontent.com/9064401/76094461-acf6b480-5f90-11ea-9f7a-fe6010af4d43.png)


This PR adds .json to that response to parse the returned events API data.