### PR TITLE
Pass twitch video_id to options for video player

### DIFF
--- a/src/components/dev-hub/video-embed.js
+++ b/src/components/dev-hub/video-embed.js
@@ -59,6 +59,7 @@ const VideoEmbed = ({
                     twitch: {
                         options: {
                             autoplay,
+                            video: videoId,
                         },
                     },
                 }}


### PR DESCRIPTION
Looks like we had to explicitly pass the video_id as an option. Many of the cors errors went away but there are still a couple cors warnings. The video in the modal should work now though and clicking on the `twitch` icon also links to the correct video as well. 

Although the video works I'm not sure how concerned we should be about the remaining cors warnings. Let me know if you all can view the live video as well!