### PR TITLE
Add Twitch URL to Home Page Notification

### DIFF
--- a/src/utils/use-twitch-api.js
+++ b/src/utils/use-twitch-api.js
@@ -30,6 +30,9 @@ export default ({ getStream = true, videoLimit = 1 } = {}) => {
                 const streamResp = await get(STREAMS_URL, headers);
                 // since we're only interested in one channel just get the first
                 currentStream = streamResp.data[0];
+                if (currentStream) {
+                    currentStream.url = `https://twitch.tv/${currentStream.user_name}`;
+                }
                 setStream(currentStream);
             }
             //get videos


### PR DESCRIPTION
This PR resolves the undefined URL issue for the live notification on the home page. We did not get a url from twitch on the stream, so here we just add the channel url in.