### PR TITLE
Design Improvements (Part 1)

### DIFF
--- a/src/components/dev-hub/filter-bar.js
+++ b/src/components/dev-hub/filter-bar.js
@@ -46,6 +46,12 @@ const SelectWrapper = styled('div')`
     }
 `;
 
+const HeadingText = styled(H3)`
+    @media ${screenSize.upToMedium} {
+        margin-bottom: ${size.default};
+    }
+`;
+
 export default React.memo(
     ({
         heading = 'All Articles',
@@ -119,7 +125,7 @@ export default React.memo(
         };
         return (
             <FilterBar {...props}>
-                <H3>{heading}</H3>
+                <HeadingText collapse>{heading}</HeadingText>
                 <ResponsiveFlexContainer>
                     <FilterLabel>Filter By</FilterLabel>
                     <SelectWrapper>

--- a/src/components/dev-hub/filter-bar.js
+++ b/src/components/dev-hub/filter-bar.js
@@ -47,7 +47,13 @@ const SelectWrapper = styled('div')`
 `;
 
 export default React.memo(
-    ({ heading = 'All Articles', filters, filterValue, setFilterValue }) => {
+    ({
+        heading = 'All Articles',
+        filters,
+        filterValue,
+        setFilterValue,
+        ...props
+    }) => {
         const initialLanguages = useMemo(
             () => zipFilterObjects(filters.languages),
             [filters.languages]
@@ -112,7 +118,7 @@ export default React.memo(
             }
         };
         return (
-            <FilterBar>
+            <FilterBar {...props}>
                 <H3>{heading}</H3>
                 <ResponsiveFlexContainer>
                     <FilterLabel>Filter By</FilterLabel>

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -47,6 +47,9 @@ const Header = styled('header')`
     background: ${colorMap.devBlack};
     margin-bottom: ${size.xlarge};
     padding: ${size.xlarge} ${size.medium};
+    @media ${screenSize.upToMedium} {
+        margin-bottom: ${size.large};
+    }
 `;
 
 const Article = styled('article')`

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -53,6 +53,10 @@ const Article = styled('article')`
     padding: ${size.medium};
 `;
 
+const StyledFilterBar = styled(FilterBar)`
+    padding-bottom: ${size.default};
+`;
+
 const parseArticles = arr =>
     arr.map(({ _id, query_fields }) => {
         return { _id, ...query_fields };
@@ -221,7 +225,7 @@ export default ({
                 <FeaturedArticles articles={featuredArticles} />
             </Header>
             <Article>
-                <FilterBar
+                <StyledFilterBar
                     filters={filters}
                     filterValue={filterValue}
                     setFilterValue={updateFilter}

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -31,6 +31,10 @@ const PrimarySection = styled('div')`
     padding-right: ${size.medium};
 `;
 
+const PrimaryImage = styled('img')`
+    border-radius: ${size.small};
+`;
+
 const SecondArticle = styled(Card)`
     grid-area: secondary;
 `;
@@ -152,7 +156,9 @@ const FeaturedArticles = ({ articles }) => {
         <MainFeatureGrid>
             <PrimarySection>
                 <MediaBlock
-                    mediaComponent={<img src={withPrefix(image)} alt="" />}
+                    mediaComponent={
+                        <PrimaryImage src={withPrefix(image)} alt="" />
+                    }
                     mediaWidth={360}
                 >
                     <Card


### PR DESCRIPTION
This PR addresses the following design concerns for the devhub:

- increase space between filter bar and article grid ( 20px;)
- make sure 'all articles' and 'filter by' are vertically center aligned
- round the corner on the learn page hero graphic to match card images