### PR TITLE
Prevent ul text from wrapping under bullet

### DIFF
--- a/src/components/List.js
+++ b/src/components/List.js
@@ -17,6 +17,9 @@ const UnorderedList = styled('ul')`
         position: relative;
         top: -3px;
     }
+    li {
+        display: flex;
+    }
 `;
 
 const List = props => {

--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -4,17 +4,20 @@ import ComponentFactory from './ComponentFactory';
 
 const ListItem = ({ nodeData, ...rest }) => (
     <li>
-        {nodeData.children.map((child, index) => (
-            <ComponentFactory
-                {...rest}
-                nodeData={child}
-                key={index}
-                // Include <p> tags in <li> if there is more than one paragraph
-                parentNode={
-                    nodeData.children.length === 1 ? 'listItem' : undefined
-                }
-            />
-        ))}
+        {/* div provides flex alignment with preceding bullet */}
+        <div>
+            {nodeData.children.map((child, index) => (
+                <ComponentFactory
+                    {...rest}
+                    nodeData={child}
+                    key={index}
+                    // Include <p> tags in <li> if there is more than one paragraph
+                    parentNode={
+                        nodeData.children.length === 1 ? 'listItem' : undefined
+                    }
+                />
+            ))}
+        </div>
     </li>
 );
 


### PR DESCRIPTION
This PR flushes `li` text next to the bullet for a `ul`.

![Screen Shot 2020-03-06 at 2 59 53 PM](https://user-images.githubusercontent.com/9064401/76118177-52bf1900-5fbb-11ea-9ed7-9c9a29afd595.png)
