### PR TITLE
Align copy icon and text on copy button

### DIFF
--- a/src/components/dev-hub/copy-button.js
+++ b/src/components/dev-hub/copy-button.js
@@ -13,9 +13,15 @@ const StyledCopyButton = styled(Button)`
     border-radius: ${size.small};
     background-color: transparent;
     color: ${colorMap.black};
-    padding: 0 ${size.default};
-    width: ${COPY_BUTTON_WIDTH}px;
     height: ${size.large};
+    left: 0;
+    padding: 0 ${size.default};
+    position: absolute;
+    top: 0;
+    width: ${COPY_BUTTON_WIDTH}px;
+    @media ${screenSize.upToMedium} {
+        padding: 0 ${size.default};
+    }
     /* Remove pseudoelements since no visible animation is occurring */
     &:active,
     &:hover,
@@ -29,9 +35,12 @@ const StyledCopyButton = styled(Button)`
     }
 `;
 
-const CopyText = styled('span')`
+const CopyText = styled('div')`
+    align-items: center;
+    display: flex;
     font-family: 'Fira Mono', monospace;
     font-size: ${fontSize.micro};
+    justify-content: center;
     @media ${screenSize.upToMedium} {
         font-family: 'Fira Mono', monospace;
         font-size: ${fontSize.micro};
@@ -87,7 +96,7 @@ const CopyButton = ({
             if (!wasCopied) {
                 setFeedbackMessage(<CopyText>Error</CopyText>);
             } else {
-                setFeedbackMessage(feedbackString);
+                setFeedbackMessage(<CopyText>{feedbackString}</CopyText>);
             }
             const newTimeoutId = setTimeout(() => {
                 setFeedbackMessage(copyString);


### PR DESCRIPTION
This PR fixes some alignment and padding issues with the copy button on codeblocks to address design concerns:

![Screen Shot 2020-03-06 at 3 38 35 PM](https://user-images.githubusercontent.com/9064401/76121140-fa8b1580-5fc0-11ea-9efa-73c300384543.png)
