### PR TITLE
Remove hover from secondary buttons

### DIFF
--- a/src/components/dev-hub/button.js
+++ b/src/components/dev-hub/button.js
@@ -37,6 +37,7 @@ const secondaryHoverStyles = css`
     &:active,
     &:hover,
     &:focus {
+        color: ${colorMap.devWhite};
         border: 2px solid ${colorMap.lightGreen};
     }
 `;
@@ -61,7 +62,6 @@ const secondaryStyles = css`
     border: 2px solid ${colorMap.greyDarkOne};
     position: relative;
     text-decoration: none;
-    ${buttonHoverStyles}
     ${buttonPadding}
     ${secondaryHoverStyles}
 `;


### PR DESCRIPTION
This PR removes the slide-out hover state from secondary buttons, but keeps the existing border change on hover.

There is a primary button with the hover issue on the community page, but not sure how we would like to add a border to it. We may need a design for border, etc to remove the slide-out from primary buttons as well.