### PR TITLE
Fix article dates off by one day

### DIFF
--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -35,6 +35,7 @@ const dateFormatOptions = {
     month: 'short',
     day: '2-digit',
     year: 'numeric',
+    timeZone: 'UTC',
 };
 
 /**


### PR DESCRIPTION
This PR fixes article dates being shown one day earlier than they should be (for example, an article could be published on August 10th and show August 9th).

What was happening was we were using `toLocaleString` on a date object that was being interpreted as UTC, without specifying 'UTC' as the timezone option in `toLocaleString` (we were using the browser's timezone).

Before:
(The first date is the date the article was published, the second date was after running the date through the `createDateObject` helper, and the third was the return value of `toDateString` without the 'UTC' tz declared in options being passed).
![Screen Shot 2020-03-10 at 10 02 59 AM](https://user-images.githubusercontent.com/9064401/76320295-dd06c600-62b6-11ea-8422-0ed225ba961e.png)

After:
![Screen Shot 2020-03-10 at 10 02 41 AM](https://user-images.githubusercontent.com/9064401/76320386-01fb3900-62b7-11ea-85c3-7e6602f0cfb8.png)

I pulled the hour and minutes out, but wanted to show for effect.