### PR TITLE
Gb/links and refs

### DIFF
--- a/src/components/RefRole.js
+++ b/src/components/RefRole.js
@@ -4,7 +4,7 @@ import ComponentFactory from './ComponentFactory';
 import Link from './Link';
 
 const RefRole = ({ nodeData: { children, fileid, target, url }, slug }) => {
-    const link = fileid === slug ? `#${target}` : `/${fileid}#${target}`;
+    const link = fileid === slug ? `#${target}` : `${fileid}#${target}`;
     return (
         <Link to={url || link} className="ref-role">
             {children.map((node, i) => (

--- a/src/components/RefRole.js
+++ b/src/components/RefRole.js
@@ -4,26 +4,12 @@ import ComponentFactory from './ComponentFactory';
 import Link from './Link';
 
 const RefRole = ({ nodeData: { children, fileid, target, url }, slug }) => {
-    // Render intersphinx target links
-    if (url) {
-        return (
-            <Link to={url} className="ref-role-inter">
-                {children.map((node, i) => (
-                    <ComponentFactory key={i} nodeData={node} />
-                ))}
-            </Link>
-        );
-    }
-
-    // Render internal target links
-    const link = fileid === slug ? `#${target}` : `${fileid}#${target}`;
+    const link = fileid === slug ? `#${target}` : `/${fileid}#${target}`;
     return (
-        <Link href={link} className="ref-role-anchor">
-            <span>
-                {children.map((node, i) => (
-                    <ComponentFactory key={i} nodeData={node} />
-                ))}
-            </span>
+        <Link to={url || link} className="ref-role">
+            {children.map((node, i) => (
+                <ComponentFactory key={i} nodeData={node} />
+            ))}
         </Link>
     );
 };

--- a/src/components/Roles/Doc.js
+++ b/src/components/Roles/Doc.js
@@ -1,16 +1,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ComponentFactory from '../ComponentFactory';
 import { formatText } from '../../utils/format-text';
 import { getNestedValue } from '../../utils/get-nested-value';
 import Link from '../Link';
 
-const RoleDoc = ({ nodeData: { target }, slugTitleMapping }) => {
+const RoleDoc = ({ nodeData: { children, target }, slugTitleMapping }) => {
+    if (children.length) {
+        return (
+            <Link to={target} className="ref-doc-children">
+                {children.map((node, i) => (
+                    <ComponentFactory key={i} nodeData={node} />
+                ))}
+            </Link>
+        );
+    }
     const key = target.startsWith('/') ? target.slice(1) : target;
     const text = getNestedValue([key], slugTitleMapping);
     const labelDisplay = text ? formatText(slugTitleMapping[key]) : target;
-
     return (
-        <Link to={target} className="reference internal">
+        <Link to={target} className="ref-doc-slug">
             {labelDisplay}
         </Link>
     );
@@ -18,9 +27,7 @@ const RoleDoc = ({ nodeData: { target }, slugTitleMapping }) => {
 
 RoleDoc.propTypes = {
     nodeData: PropTypes.shape({
-        label: PropTypes.shape({
-            value: PropTypes.string,
-        }),
+        children: PropTypes.arrayOf(PropTypes.node).isRequired,
         target: PropTypes.string.isRequired,
     }).isRequired,
     slugTitleMapping: PropTypes.shape({

--- a/src/components/dev-hub/link.js
+++ b/src/components/dev-hub/link.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { Link as RouterLink } from 'gatsby';
-import { animationSpeed, colorMap, fontSize, screenSize } from './theme';
+import { animationSpeed, colorMap, fontSize } from './theme';
 
 // Takes an event handler, and wraps it to call preventDefault.
 // If the handler is falsey, it is returned unchanged.


### PR DESCRIPTION
Fixes some issues with links and anchors

- All `RefRole` targets should use `to` in order for the `Link` component to format them correctly.
- doc roles (links to other articles) should check for and render any children before trying to use the slugMap for the link text

