### PR TITLE
Add width constraint for home page featured cards

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -61,7 +61,7 @@ const CardGallery = styled('section')`
     }
 `;
 const StyledTopCard = styled(Card)`
-    /* max-width: 300px; */
+    width: 100%;
     @media ${screenSize.upToLarge} {
         flex-basis: 50%;
     }


### PR DESCRIPTION
This PR fixes varying widths for featured articles on the home page specifically.

There was an issue with widths varying on Firefox.