### PR TITLE
Add more restrictive phantom data filtering

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -331,7 +331,9 @@ const getLearnPageArticles = async () => {
     // Ignore bad data, including links to the home page as an "article"
     const filteredDocuments = documents.filter(d => {
         const route = dlv(d, ['query_fields', 'slug'], null);
-        return route !== '/';
+        const title = dlv(d, ['query_fields', 'title'], null);
+        const image = dlv(d, ['query_fields', 'atf-image'], null);
+        return route !== '/' && !!title && !!image;
     });
     return filteredDocuments;
 };


### PR DESCRIPTION
This PR solves odd phantom data in the `learn` page.

What was happening is we were getting data from Stitch for articles that were oddly misshaped (see items 22 and 23):

![Screen Shot 2020-03-10 at 2 15 27 PM](https://user-images.githubusercontent.com/9064401/76347133-7ac0bc00-62dc-11ea-824c-b5a20cf05faf.png)

This PR adds filtering to look for additional fields before handing data off to the learn page. We were already doing this for `/` cards.
