### PR TITLE
Update Twitter Share Text, Refactor Share URLs

### DIFF
--- a/src/components/dev-hub/article-share-footer.js
+++ b/src/components/dev-hub/article-share-footer.js
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import copy from 'copy-to-clipboard';
 import styled from '@emotion/styled';
+import { getArticleShareLinks } from '../../utils/get-article-share-links';
 import BlogTagList from './blog-tag-list';
 import { colorMap, screenSize, size } from './theme';
 import Link from './link';
@@ -33,6 +34,10 @@ const ArticleShareFooter = ({ tags, title, url }) => {
     const onCopyLink = useCallback(() => {
         copy(url);
     }, [url]);
+    const { facebookUrl, linkedInUrl, twitterUrl } = getArticleShareLinks(
+        title,
+        url
+    );
     return (
         <ArticleShareArea>
             <BlogTagList tags={tags} />
@@ -48,25 +53,14 @@ const ArticleShareFooter = ({ tags, title, url }) => {
                     Article link copied to clipboard!
                 </Tooltip>
 
-                <Link
-                    target="_blank"
-                    href={`https://www.linkedin.com/shareArticle?url=${url}`}
-                >
+                <Link target="_blank" href={linkedInUrl}>
                     <LinkedIn />
                 </Link>
 
-                <Link
-                    target="_blank"
-                    href={`https://twitter.com/intent/tweet?url=${url}&text=${encodeURIComponent(
-                        `Here is a post from @mongodb on "${title}"`
-                    )}`}
-                >
+                <Link target="_blank" href={twitterUrl}>
                     <TwitterIcon />
                 </Link>
-                <Link
-                    target="_blank"
-                    href={`https://www.facebook.com/sharer/sharer.php?u=${url}`}
-                >
+                <Link target="_blank" href={facebookUrl}>
                     <FacebookIcon height="22" width="22" />
                 </Link>
             </BlogShareLinks>

--- a/src/components/dev-hub/article-share-footer.js
+++ b/src/components/dev-hub/article-share-footer.js
@@ -29,7 +29,7 @@ const BlogShareLinks = styled('div')`
     }
 `;
 
-const ArticleShareFooter = ({ tags, url }) => {
+const ArticleShareFooter = ({ tags, title, url }) => {
     const onCopyLink = useCallback(() => {
         copy(url);
     }, [url]);
@@ -57,7 +57,9 @@ const ArticleShareFooter = ({ tags, url }) => {
 
                 <Link
                     target="_blank"
-                    href={`https://twitter.com/intent/tweet?url=${url}`}
+                    href={`https://twitter.com/intent/tweet?url=${url}&text=${encodeURIComponent(
+                        `Here is a post from @mongodb on "${title}"`
+                    )}`}
                 >
                     <TwitterIcon />
                 </Link>

--- a/src/components/dev-hub/share-menu.js
+++ b/src/components/dev-hub/share-menu.js
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
+import { getArticleShareLinks } from '../../utils/get-article-share-links';
 import Tooltip from './tooltip';
 import ShareIcon from './icons/share-icon';
 import LinkIcon from './icons/link-icon';
@@ -78,6 +79,10 @@ const ShareMenu = ({ title, url, ...props }) => {
         },
         [url]
     );
+    const { facebookUrl, linkedInUrl, twitterUrl } = getArticleShareLinks(
+        title,
+        url
+    );
 
     return (
         <Tooltip
@@ -98,20 +103,9 @@ const ShareMenu = ({ title, url, ...props }) => {
                     type="shareLink"
                     onClick={onCopyLink}
                 />
-                <SocialIcon
-                    type="facebook"
-                    href={`https://www.facebook.com/sharer/sharer.php?u=${url}`}
-                />
-                <SocialIcon
-                    type="twitter"
-                    href={`https://twitter.com/intent/tweet?url=${url}&text=${encodeURIComponent(
-                        `Here is a post from @mongodb on "${title}"`
-                    )}`}
-                />
-                <SocialIcon
-                    type="linkedin"
-                    href={`https://www.linkedin.com/shareArticle?url=${url}`}
-                />
+                <SocialIcon type="facebook" href={facebookUrl} />
+                <SocialIcon type="twitter" href={twitterUrl} />
+                <SocialIcon type="linkedin" href={linkedInUrl} />
             </Contents>
         </Tooltip>
     );

--- a/src/components/dev-hub/share-menu.js
+++ b/src/components/dev-hub/share-menu.js
@@ -67,7 +67,7 @@ const SocialIcon = ({ type, href, ...props }) => {
  * @param {Object<string, any>} props
  * @property {string} props.url
  */
-const ShareMenu = ({ url, ...props }) => {
+const ShareMenu = ({ title, url, ...props }) => {
     const [showCopyMessage, setShowCopyMessage] = useState(false);
     const onCopyLink = useCallback(
         e => {
@@ -104,7 +104,9 @@ const ShareMenu = ({ url, ...props }) => {
                 />
                 <SocialIcon
                     type="twitter"
-                    href={`https://twitter.com/intent/tweet?url=${url}`}
+                    href={`https://twitter.com/intent/tweet?url=${url}&text=${encodeURIComponent(
+                        `Here is a post from @mongodb on "${title}"`
+                    )}`}
                 />
                 <SocialIcon
                     type="linkedin"

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -199,6 +199,7 @@ const Article = props => {
                         width={size.default}
                     />
                     <ShareMenu
+                        title={articleTitle}
                         url={articleUrl}
                         height={size.default}
                         width={size.default}
@@ -211,7 +212,11 @@ const Article = props => {
                         slug={thisPage}
                         {...rest}
                     />
-                    <ArticleShareFooter url={articleUrl} tags={tagList} />
+                    <ArticleShareFooter
+                        title={articleTitle}
+                        url={articleUrl}
+                        tags={tagList}
+                    />
                     <ArticleSeries
                         allSeriesForArticle={seriesArticles}
                         slugTitleMapping={slugTitleMapping}

--- a/src/utils/get-article-share-links.js
+++ b/src/utils/get-article-share-links.js
@@ -1,0 +1,8 @@
+export const getArticleShareLinks = (title, url) => {
+    const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=${url}`;
+    const twitterUrl = `https://twitter.com/intent/tweet?url=${url}&text=${encodeURIComponent(
+        `Here is a post from @mongodb on "${title}"`
+    )}`;
+    const linkedInUrl = `https://www.linkedin.com/shareArticle?url=${url}`;
+    return { facebookUrl, linkedInUrl, twitterUrl };
+};

--- a/src/utils/get-article-share-links.js
+++ b/src/utils/get-article-share-links.js
@@ -1,7 +1,7 @@
 export const getArticleShareLinks = (title, url) => {
     const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=${url}`;
     const twitterUrl = `https://twitter.com/intent/tweet?url=${url}&text=${encodeURIComponent(
-        `Here is a post from @mongodb on "${title}"`
+        title
     )}`;
     const linkedInUrl = `https://www.linkedin.com/shareArticle?url=${url}`;
     return { facebookUrl, linkedInUrl, twitterUrl };


### PR DESCRIPTION
This PR addresses [DEVHUB-66](https://jira.mongodb.org/browse/DEVHUB-66) by adding some detailed Tweet text to the auto-populated Tweet when sharing an article. The new copy looks like the following:

![Screen Shot 2020-03-12 at 12 04 23 PM](https://user-images.githubusercontent.com/9064401/76541348-ce0c4900-6459-11ea-9910-5f51ee5f6a30.png)

I also refactored the URLs between the article share footer and share tooltip so future copy changes can be easier. I also asked about updating copy for other Social Media choices as well, no responses yet there.