### PR TITLE
Cap Badge List Size, Reorder Badge Priority

### DIFF
--- a/src/components/dev-hub/blog-tag-list.js
+++ b/src/components/dev-hub/blog-tag-list.js
@@ -4,6 +4,7 @@ import Link from './link';
 import { colorMap, fontSize, lineHeight, screenSize, size } from './theme';
 
 const MINIMUM_EXPANDABLE_SIZE = 3;
+const MAX_TAG_LIST_SIZE = 5;
 
 const TagLink = styled(Link)`
     background-color: ${colorMap.greyDarkThree};
@@ -41,17 +42,6 @@ const TagListItem = styled('li')`
     display: inline-block;
 `;
 
-const getTagData = (tags, tagLinkBase) =>
-    tags.map(tag => {
-        if (typeof tag === 'string') {
-            return {
-                text: tag,
-                to: `${tagLinkBase}/${tag}`,
-            };
-        }
-        return tag;
-    });
-
 const BlogTag = ({ children, ...props }) => (
     <TagListItem>
         <TagLink {...props}>{children}</TagLink>
@@ -69,11 +59,13 @@ const BlogTagList = ({ tags = [] }) => {
     return (
         <TagList>
             {isExpanded &&
-                tags.map(t => (
-                    <BlogTag key={t.label} to={t.to}>
-                        {t.label}
-                    </BlogTag>
-                ))}
+                tags
+                    .map(t => (
+                        <BlogTag key={t.label} to={t.to}>
+                            {t.label}
+                        </BlogTag>
+                    ))
+                    .slice(0, MAX_TAG_LIST_SIZE)}
             {!isExpanded && canExpand && (
                 <>
                     {/* Since this can expand, we know value[0] and value[1] exist */}

--- a/src/components/dev-hub/blog-tag-list.js
+++ b/src/components/dev-hub/blog-tag-list.js
@@ -59,13 +59,11 @@ const BlogTagList = ({ tags = [] }) => {
     return (
         <TagList>
             {isExpanded &&
-                tags
-                    .map(t => (
-                        <BlogTag key={t.label} to={t.to}>
-                            {t.label}
-                        </BlogTag>
-                    ))
-                    .slice(0, MAX_TAG_LIST_SIZE)}
+                tags.slice(0, MAX_TAG_LIST_SIZE).map(t => (
+                    <BlogTag key={t.label} to={t.to}>
+                        {t.label}
+                    </BlogTag>
+                ))}
             {!isExpanded && canExpand && (
                 <>
                     {/* Since this can expand, we know value[0] and value[1] exist */}

--- a/src/utils/get-tag-links-from-meta.js
+++ b/src/utils/get-tag-links-from-meta.js
@@ -5,9 +5,9 @@ export const getTagLinksFromMeta = meta => {
     const mappedLanguageTags = mapTagTypeToUrl(meta.languages, 'language');
     const mappedProductTags = mapTagTypeToUrl(meta.products, 'product');
     const allTags = [
-        ...mappedTags,
-        ...mappedLanguageTags,
         ...mappedProductTags,
+        ...mappedLanguageTags,
+        ...mappedTags,
     ];
     return allTags;
 };


### PR DESCRIPTION
This PR caps the number of displayed badges in an expanded `BadgeList` at 5, and also re-orders the priority of badges to first show products, then languages, then tags.