### PR TITLE
Exclude tag pages from sitemap

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -19,6 +19,8 @@ module.exports = {
             resolve: 'gatsby-plugin-google-tagmanager',
             options: {
                 id: 'GTM-GDFN',
+                // Exclude paths we are using the noindex tag on
+                exclude: ['/language/*', '/product/*', '/tag/*'],
 
                 // Include GTM in development.
                 // Defaults to false meaning GTM will only be loaded in production.

--- a/gatsby-config.prod.js
+++ b/gatsby-config.prod.js
@@ -16,6 +16,8 @@ module.exports = {
             resolve: 'gatsby-plugin-google-tagmanager',
             options: {
                 id: 'GTM-GDFN',
+                // Exclude paths we are using the noindex tag on
+                exclude: ['/language/*', '/product/*', '/tag/*'],
 
                 // Include GTM in development.
                 // Defaults to false meaning GTM will only be loaded in production.

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -83,9 +83,11 @@ const Tag = props => {
     const capitalizedBreadcrumb = name.charAt(0).toUpperCase() + name.slice(1);
     return (
         <Layout>
-            <Helmet>
-                <meta name="robots" content="noindex" />
-            </Helmet>
+            {!isAuthor && (
+                <Helmet>
+                    <meta name="robots" content="noindex" />
+                </Helmet>
+            )}
             <HeroBanner
                 breadcrumb={[
                     { label: 'Home', to: '/' },


### PR DESCRIPTION
This is for [DEVHUB-69](https://jira.mongodb.org/browse/DEVHUB-69). This PR excludes the tag pages from the sitemap generation.

I used to [`exclude` option](https://www.gatsbyjs.org/packages/gatsby-plugin-sitemap/#options) on the sitemap plugin. This needs a production environment to test and I don't have gatsby build figured out yet, but seems to be what will do the trick.