### PR TITLE
WIP RSS Feed for Articles

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,3 +1,4 @@
+const dlv = require('dlv');
 const { generatePathPrefix } = require('./src/utils/generate-path-prefix');
 const { getMetadata } = require('./src/utils/get-metadata');
 
@@ -32,6 +33,83 @@ module.exports = {
             options: {
                 id: 'GTM-GDFN',
                 includeInDevelopment: false,
+            },
+        },
+        {
+            resolve: `gatsby-plugin-feed`,
+            options: {
+                query: `
+                {
+                    site {
+                    siteMetadata {
+                        title
+                        siteUrl
+                    }
+                    }
+                }
+                `,
+                feeds: [
+                    {
+                        serialize: ({ query: { site, allSitePage } }) => {
+                            return allSitePage.edges.map(edge => {
+                                const path = dlv(edge, 'node.path');
+                                const query_fields = dlv(
+                                    edge,
+                                    'node.context._xrefDocMapping.query_fields'
+                                );
+                                const description = dlv(
+                                    query_fields,
+                                    [
+                                        'meta_description',
+                                        0,
+                                        'children',
+                                        0,
+                                        'value',
+                                    ],
+                                    'No description available'
+                                );
+                                const title = dlv(
+                                    query_fields,
+                                    ['title', 0, 'value'],
+                                    'No title available'
+                                );
+                                return {
+                                    title: title,
+                                    description: description,
+                                    url: site.siteMetadata.siteUrl + path,
+                                };
+                            });
+                        },
+                        query: `
+                    {
+                        allSitePage(filter: {path: {regex: "/^/((article)|(how-to)|(quickstart))/"}}) {
+                            edges {
+                                node {
+                                id
+                                path
+                                context {
+                                    _xrefDocMapping {
+                                        query_fields {
+                                            meta_description {
+                                                children {
+                                                    value
+                                                }
+                                            }
+                                            title {
+                                                value
+                                            }
+                                        }
+                                    }
+                                }
+                                }
+                            }
+                        }
+                    }
+            `,
+                        output: '/rss.xml',
+                        title: 'MongoDB Developer Hub RSS Feed',
+                    },
+                ],
             },
         },
     ],

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,4 @@
-const dlv = require('dlv');
+const { getNestedValue } = require('./src/utils/get-nested-value');
 const { generatePathPrefix } = require('./src/utils/generate-path-prefix');
 const { getMetadata } = require('./src/utils/get-metadata');
 
@@ -52,27 +52,35 @@ module.exports = {
                     {
                         serialize: ({ query: { site, allSitePage } }) => {
                             return allSitePage.edges.map(edge => {
-                                const path = dlv(edge, 'node.path');
-                                const query_fields = dlv(
-                                    edge,
-                                    'node.context._xrefDocMapping.query_fields'
+                                const path = getNestedValue(
+                                    ['node', 'path'],
+                                    edge
                                 );
-                                const description = dlv(
-                                    query_fields,
+                                const query_fields = getNestedValue(
                                     [
-                                        'meta_description',
-                                        0,
-                                        'children',
-                                        0,
-                                        'value',
+                                        'node',
+                                        'context',
+                                        '_xrefDocMapping',
+                                        'query_fields',
                                     ],
-                                    'No description available'
+                                    edge
                                 );
-                                const title = dlv(
-                                    query_fields,
-                                    ['title', 0, 'value'],
-                                    'No title available'
-                                );
+                                const description =
+                                    getNestedValue(
+                                        [
+                                            'meta_description',
+                                            0,
+                                            'children',
+                                            0,
+                                            'value',
+                                        ],
+                                        query_fields
+                                    ) || '';
+                                const title =
+                                    getNestedValue(
+                                        ['title', 0, 'value'],
+                                        query_fields
+                                    ) || '';
                                 return {
                                     title: title,
                                     description: description,

--- a/gatsby-config.prod.js
+++ b/gatsby-config.prod.js
@@ -1,3 +1,4 @@
+const dlv = require('dlv');
 const { getMetadata } = require('./src/utils/get-metadata');
 const { plugins } = require('./gatsby-config');
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -270,6 +270,8 @@ exports.createPages = async ({ actions }) => {
             if (pageNodes.query_fields) {
                 const relatedPages = getRelatedPagesWithImages(pageNodes);
                 pageNodes['query_fields'].related = relatedPages;
+                pageNodes['query_fields'].meta_description =
+                    pageNodes['query_fields']['meta-description'];
             }
             const seriesArticles = getSeriesArticles(allSeries, slug);
             createPage({
@@ -281,6 +283,7 @@ exports.createPages = async ({ actions }) => {
                     slug,
                     snootyStitchId: SNOOTY_STITCH_ID,
                     __refDocMapping: pageNodes,
+                    _xrefDocMapping: pageNodes,
                 },
             });
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13904,6 +13904,33 @@
         }
       }
     },
+    "gatsby-plugin-feed": {
+      "version": "2.3.29",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-feed/-/gatsby-plugin-feed-2.3.29.tgz",
+      "integrity": "sha512-fbgmUdjcTj3pzDJa/y2MhSRAAYf6S5YVEN/CB+fqvaHyLq6gzRqLTEIYYnwtXhQk/14Zq6bntsRxH/2dA0J9bg==",
+      "requires": {
+        "@babel/runtime": "^7.8.7",
+        "@hapi/joi": "^15.1.1",
+        "fs-extra": "^8.1.0",
+        "lodash.merge": "^4.6.2",
+        "rss": "^1.2.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
+          "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+        }
+      }
+    },
     "gatsby-plugin-google-tagmanager": {
       "version": "2.1.25",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-google-tagmanager/-/gatsby-plugin-google-tagmanager-2.1.25.tgz",
@@ -18215,6 +18242,11 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.once": {
       "version": "4.1.1",
@@ -23215,6 +23247,30 @@
         "inherits": "^2.0.1"
       }
     },
+    "rss": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rss/-/rss-1.2.2.tgz",
+      "integrity": "sha1-UKFpiHYTgTOnT5oF0r3I240nqSE=",
+      "requires": {
+        "mime-types": "2.1.13",
+        "xml": "1.0.1"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.25.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+          "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I="
+        },
+        "mime-types": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+          "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
+          "requires": {
+            "mime-db": "~1.25.0"
+          }
+        }
+      }
+    },
     "rst-selector-parser": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
@@ -27262,6 +27318,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "dotenv": "^8.2.0",
     "gatsby": "^2.18.15",
     "gatsby-plugin-emotion": "^4.1.22",
+    "gatsby-plugin-feed": "^2.3.29",
     "gatsby-plugin-google-tagmanager": "^2.1.25",
     "gatsby-plugin-react-helmet": "^3.1.14",
     "gatsby-plugin-sitemap": "^2.2.27",


### PR DESCRIPTION
_There are some interesting gatsby tidbits that came up with this so marking as WIP to sort those out, but. feel free to leave other feedback as well_

This PR adds an rss feed to production builds of the devhub, via a new plugin for gatsby, where each article looks as such:
<img width="559" alt="Screen Shot 2020-03-16 at 5 01 43 PM" src="https://user-images.githubusercontent.com/9064401/76800256-a692e480-67a9-11ea-9ca8-6463af876a76.png">

Do we want to add more fields to the feed? I figured title, description, and link would suffice.