### PR TITLE
Support Multiple Authors (and Authors as Array)

### DIFF
--- a/src/components/dev-hub/blog-post-title-area.js
+++ b/src/components/dev-hub/blog-post-title-area.js
@@ -32,7 +32,7 @@ const DateTextContainer = styled('div')`
 
 const BlogPostTitleArea = ({
     articleImage,
-    author,
+    authors,
     breadcrumb,
     originalDate,
     tags,
@@ -54,12 +54,7 @@ const BlogPostTitleArea = ({
                 </DateTextContainer>
                 <BlogTagList tags={tags} />
             </PostMetaLine>
-            {author && (
-                <BylineBlock
-                    authorName={author.name}
-                    authorImage={author.image}
-                />
-            )}
+            <BylineBlock authors={authors} />
         </HeroBanner>
     );
 };

--- a/src/components/dev-hub/byline-block.js
+++ b/src/components/dev-hub/byline-block.js
@@ -36,14 +36,33 @@ const StyledAuthorImage = styled(AuthorImage)`
     margin-right: ${size.small};
 `;
 
-const BylineBlock = ({ authorImage, authorName = '' }) => {
-    const authorLink = `/author/${getTagPageUriComponent(authorName)}`;
+const AuthorImages = ({ authors }) => (
+    <div>
+        {authors.map(({ name, image }) => (
+            <StyledAuthorImage image={image} key={name} />
+        ))}
+    </div>
+);
+
+const AuthorNames = ({ authors }) => (
+    <div>
+        {authors.map(({ name }) => {
+            const authorLink = `/author/${getTagPageUriComponent(name)}`;
+            return (
+                <AuthorText collapse key={name}>
+                    By <AuthorLink to={authorLink}>{name}</AuthorLink>
+                </AuthorText>
+            );
+        })}
+    </div>
+);
+
+const BylineBlock = ({ authors }) => {
+    if (!authors || !authors.length) return null;
     return (
         <ByLine>
-            <StyledAuthorImage image={authorImage} />
-            <AuthorText collapse>
-                By <AuthorLink to={authorLink}>{authorName}</AuthorLink>
-            </AuthorText>
+            <AuthorImages authors={authors} />
+            <AuthorNames authors={authors} />
         </ByLine>
     );
 };

--- a/src/components/dev-hub/byline-block.js
+++ b/src/components/dev-hub/byline-block.js
@@ -6,6 +6,10 @@ import { colorMap, fontSize, screenSize, size } from './theme';
 import { getTagPageUriComponent } from '../../utils/get-tag-page-uri-component';
 import AuthorImage from './author-image';
 
+const AuthorImageContainer = styled('div')`
+    display: flex;
+`;
+
 const AuthorLink = styled(Link)`
     font-size: ${fontSize.tiny};
     :visited {
@@ -17,8 +21,20 @@ const AuthorLink = styled(Link)`
 `;
 
 const AuthorText = styled(P)`
+    display: inline-block;
     @media ${screenSize.upToLarge} {
         font-size: ${fontSize.xsmall};
+    }
+    &:before {
+        content: 'By ';
+    }
+    &:after {
+        content: '\u00a0';
+    }
+    :not(:first-of-type) {
+        &:before {
+            content: 'and ';
+        }
     }
 `;
 
@@ -34,14 +50,17 @@ const ByLine = styled('div')`
 
 const StyledAuthorImage = styled(AuthorImage)`
     margin-right: ${size.small};
+    :not(:last-of-type) {
+        margin-right: -${size.small};
+    }
 `;
 
 const AuthorImages = ({ authors }) => (
-    <div>
+    <AuthorImageContainer>
         {authors.map(({ name, image }) => (
             <StyledAuthorImage image={image} key={name} />
         ))}
-    </div>
+    </AuthorImageContainer>
 );
 
 const AuthorNames = ({ authors }) => (
@@ -50,7 +69,7 @@ const AuthorNames = ({ authors }) => (
             const authorLink = `/author/${getTagPageUriComponent(name)}`;
             return (
                 <AuthorText collapse key={name}>
-                    By <AuthorLink to={authorLink}>{name}</AuthorLink>
+                    <AuthorLink to={authorLink}>{name}</AuthorLink>
                 </AuthorText>
             );
         })}

--- a/src/components/dev-hub/byline-block.js
+++ b/src/components/dev-hub/byline-block.js
@@ -25,17 +25,6 @@ const AuthorText = styled(P)`
     @media ${screenSize.upToLarge} {
         font-size: ${fontSize.xsmall};
     }
-    &:before {
-        content: 'By ';
-    }
-    &:after {
-        content: '\u00a0';
-    }
-    :not(:first-of-type) {
-        &:before {
-            content: 'and ';
-        }
-    }
 `;
 
 const ByLine = styled('div')`
@@ -65,10 +54,12 @@ const AuthorImages = ({ authors }) => (
 
 const AuthorNames = ({ authors }) => (
     <div>
-        {authors.map(({ name }) => {
+        {authors.map(({ name }, index) => {
             const authorLink = `/author/${getTagPageUriComponent(name)}`;
+            const prefix = index === 0 ? 'By ' : '\u00a0and ';
             return (
                 <AuthorText collapse key={name}>
+                    {prefix}
                     <AuthorLink to={authorLink}>{name}</AuthorLink>
                 </AuthorText>
             );

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -183,7 +183,7 @@ const Article = props => {
             </Helmet>
             <BlogPostTitleArea
                 articleImage={withPrefix(meta['atf-image'])}
-                author={meta.author}
+                authors={meta.author}
                 breadcrumb={articleBreadcrumbs}
                 originalDate={formattedPublishedDate}
                 tags={tagList}


### PR DESCRIPTION
_This PR must merge in sync with a docs platform autobuilder change_

This PR does two things:

- Allows support of the `author` value in `meta` to be an array of author objects, instead of a single author object.
- Adds styling to support articles with multiple authors at once:

One author:
<img width="172" alt="Screen Shot 2020-03-17 at 4 49 26 PM" src="https://user-images.githubusercontent.com/9064401/76900464-ca206280-686f-11ea-90f2-466cce731678.png">

Two: 
<img width="305" alt="Screen Shot 2020-03-17 at 4 49 16 PM" src="https://user-images.githubusercontent.com/9064401/76900463-c987cc00-686f-11ea-88e2-b0d98d536874.png">

Three:
<img width="443" alt="Screen Shot 2020-03-17 at 4 48 11 PM" src="https://user-images.githubusercontent.com/9064401/76900462-c987cc00-686f-11ea-93ac-19835691ac6f.png">

