### PR TITLE
Support toml Featured Articles, Refactor gatsby-node

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -150,7 +150,7 @@ exports.sourceNodes = async () => {
 
 exports.createPages = async ({ actions }) => {
     const { createPage } = actions;
-    const pageMetadata = await stitchClient.callFunction('fetchDocument', [
+    const metadata = await stitchClient.callFunction('fetchDocument', [
         DB,
         METADATA_COLLECTION,
         constructDbFilter(),
@@ -174,7 +174,7 @@ exports.createPages = async ({ actions }) => {
                 path: slug,
                 component: path.resolve(`./src/templates/${template}.js`),
                 context: {
-                    metadata: pageMetadata,
+                    metadata,
                     seriesArticles,
                     slug,
                     snootyStitchId: SNOOTY_STITCH_ID,
@@ -189,7 +189,7 @@ exports.createPages = async ({ actions }) => {
         createTagPageType(
             type,
             createPage,
-            pageMetadata,
+            metadata,
             RESOLVED_REF_DOC_MAPPING,
             stitchClient
         )

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -338,14 +338,14 @@ const getLearnPageArticles = async () => {
     return filteredDocuments;
 };
 
-const getFeaturedLearnArticles = articles => {
+const getFeaturedArticles = (allArticles, featuredArticles) => {
     const result = [];
-    FEATURED_LEARN_SLUGS.forEach((f, i) => {
-        const newArticle = articles.find(x => x.query_fields.slug === f);
+    featuredArticles.forEach((f, i) => {
+        const newArticle = allArticles.find(x => x.query_fields.slug === f);
         if (newArticle) {
             result.push(newArticle);
         } else {
-            result.push(articles[i]);
+            result.push(allArticles[i]);
         }
     });
     return result;
@@ -405,7 +405,14 @@ exports.onCreatePage = async ({ page, actions }) => {
     if (page.path === '/learn/') {
         const { createPage, deletePage } = actions;
         const allArticles = await getLearnPageArticles();
-        const featuredArticles = getFeaturedLearnArticles(allArticles);
+        // TODO: Verify field names with docsp
+        const featuredLearnArticlesArray =
+            getNestedValue(['featuredArticles', 'learnPage']) ||
+            FEATURED_LEARN_SLUGS;
+        const featuredArticles = getFeaturedArticles(
+            allArticles,
+            featuredLearnArticlesArray
+        );
         const filters = await getLearnPageFilters(allArticles);
         deletePage(page);
         createPage({

--- a/package-lock.json
+++ b/package-lock.json
@@ -18429,8 +18429,7 @@
     "map-or-similar": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
-      "integrity": "sha1-beJlMXSt+12e3DPGnT6Sobdvrwg=",
-      "dev": true
+      "integrity": "sha1-beJlMXSt+12e3DPGnT6Sobdvrwg="
     },
     "map-visit": {
       "version": "1.0.0",
@@ -18590,7 +18589,6 @@
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
       "integrity": "sha1-fIekZGREwy11Q4VwkF8tvRsagFo=",
-      "dev": true,
       "requires": {
         "map-or-similar": "^1.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "gatsby-plugin-google-tagmanager": "^2.1.25",
     "gatsby-plugin-react-helmet": "^3.1.14",
     "gatsby-plugin-sitemap": "^2.2.27",
+    "memoizerific": "^1.11.3",
     "mongodb-stitch-browser-sdk": "^4.7.1",
     "mongodb-stitch-server-sdk": "^4.7.1",
     "prop-types": "^15.7.2",

--- a/src/build-constants.js
+++ b/src/build-constants.js
@@ -1,0 +1,5 @@
+// Atlas DB config
+module.exports.DOCUMENTS_COLLECTION = 'documents';
+module.exports.ASSETS_COLLECTION = 'assets';
+module.exports.METADATA_COLLECTION = 'metadata';
+module.exports.SNOOTY_STITCH_ID = 'snooty-koueq';

--- a/src/utils/setup/create-tag-page-type.js
+++ b/src/utils/setup/create-tag-page-type.js
@@ -2,6 +2,9 @@ const dlv = require('dlv');
 const path = require('path');
 const { getTagPageUriComponent } = require('../get-tag-page-uri-component');
 const { SNOOTY_STITCH_ID } = require('../../build-constants');
+const { getMetadata } = require('../get-metadata');
+
+const metadata = getMetadata();
 
 const STITCH_TYPE_TO_URL_PREFIX = {
     author: 'author',
@@ -30,8 +33,7 @@ const createTagPageType = async (
     createPage,
     pageMetadata,
     RESOLVED_REF_DOC_MAPPING,
-    stitchClient,
-    metadata
+    stitchClient
 ) => {
     const isAuthor = stitchType === 'author';
     const pageType = STITCH_TYPE_TO_URL_PREFIX[stitchType];

--- a/src/utils/setup/create-tag-page-type.js
+++ b/src/utils/setup/create-tag-page-type.js
@@ -1,0 +1,108 @@
+const dlv = require('dlv');
+const path = require('path');
+const { getTagPageUriComponent } = require('../get-tag-page-uri-component');
+const { SNOOTY_STITCH_ID } = require('../../build-constants');
+
+const STITCH_TYPE_TO_URL_PREFIX = {
+    author: 'author',
+    languages: 'language',
+    products: 'product',
+    tags: 'tag',
+    type: 'type',
+};
+
+const getAuthorIncludesPath = authorName => {
+    switch (authorName) {
+        // Handle case where REF_DOC_MAP name isnt just lastname-firstname
+        case 'Ken W. Alger':
+            return 'includes/authors/alger-ken';
+        default:
+            return `includes/authors/${authorName
+                .toLowerCase()
+                .split(' ')
+                .reverse()
+                .join('-')}`;
+    }
+};
+
+const createTagPageType = async (
+    stitchType,
+    createPage,
+    pageMetadata,
+    RESOLVED_REF_DOC_MAPPING,
+    stitchClient,
+    metadata
+) => {
+    const isAuthor = stitchType === 'author';
+    const pageType = STITCH_TYPE_TO_URL_PREFIX[stitchType];
+
+    // Query for all possible values for this type of tag
+    const possibleTagValues = await stitchClient.callFunction(
+        'getValuesByKey',
+        [metadata, stitchType]
+    );
+
+    const requests = [];
+
+    // For each possible tag value, query the pages that exist for it
+    await possibleTagValues.forEach(async tag => {
+        const requestKey = {};
+        requestKey[stitchType] = tag._id;
+        requests.push(
+            stitchClient.callFunction('fetchDevhubMetadata', [
+                metadata,
+                requestKey,
+            ])
+        );
+    });
+
+    const pageData = await Promise.all(requests);
+
+    // Once requests finish, map the item with name (and optional image) to the response's return value
+    const itemsWithPageData = possibleTagValues.map((r, i) => ({
+        item: r,
+        pages: pageData[i],
+    }));
+
+    const pageList = itemsWithPageData.map(page => {
+        const name = isAuthor ? page.item._id.name : page.item._id;
+        // Some bad data for authors doesn't follow this structure, so ignore it
+        if (!name) return null;
+        else {
+            const urlSuffix = getTagPageUriComponent(name);
+            const newPage = {
+                type: pageType,
+                name: name,
+                slug: `/${pageType}/${urlSuffix}`,
+                pages: page.pages,
+            };
+            if (isAuthor) {
+                const authorBioPath = getAuthorIncludesPath(name);
+                const bio = dlv(
+                    RESOLVED_REF_DOC_MAPPING[authorBioPath],
+                    ['ast', 'children', 0, 'children', 0],
+                    null
+                );
+                newPage['author_image'] = page.item._id.image;
+                newPage['bio'] = bio;
+            }
+            return newPage;
+        }
+    });
+
+    pageList.forEach(page => {
+        if (page) {
+            createPage({
+                path: page.slug,
+                component: path.resolve(`./src/templates/tag.js`),
+                context: {
+                    metadata: pageMetadata,
+                    snootyStitchId: SNOOTY_STITCH_ID,
+                    ...page,
+                },
+            });
+        }
+    });
+};
+
+module.exports = { createTagPageType };

--- a/src/utils/setup/on-create-page.js
+++ b/src/utils/setup/on-create-page.js
@@ -1,0 +1,157 @@
+const memoizerific = require('memoizerific');
+const { getNestedValue } = require('../get-nested-value');
+const { getMetadata } = require('../get-metadata');
+
+const metadata = getMetadata();
+let stitchClient;
+
+const DEFAULT_FEATURED_HOME_SLUGS = [
+    '/how-to/nextjs-building-modern-applications',
+    '/how-to/python-starlette-stitch',
+    '/how-to/graphql-support-atlas-stitch',
+    '/quickstart/free-atlas-cluster',
+];
+
+const DEFAULT_FEATURED_LEARN_SLUGS = [
+    '/quickstart/java-setup-crud-operations',
+    '/how-to/golang-alexa-skills',
+    '/how-to/polymorphic-pattern',
+];
+
+const requestStitch = async (functionName, ...args) =>
+    stitchClient.callFunction(functionName, [metadata, ...args]);
+const memoizedStitchRequest = memoizerific(10)(requestStitch);
+
+const getAllArticles = memoizerific(1)(async () => {
+    const documents = await memoizedStitchRequest('fetchDevhubMetadata', {});
+    // Ignore bad data, including links to the home page as an "article"
+    const filteredDocuments = documents.filter(d => {
+        const route = getNestedValue(['query_fields', 'slug'], d);
+        const title = getNestedValue(['query_fields', 'title'], d);
+        const image = getNestedValue(['query_fields', 'atf-image'], d);
+        return route !== '/' && !!title && !!image;
+    });
+    return filteredDocuments;
+});
+
+const getFeaturedArticles = (allArticles, featuredArticleSlugs) => {
+    const result = [];
+    featuredArticleSlugs.forEach((featuredSlug, i) => {
+        const newArticle = allArticles.find(
+            x => x.query_fields.slug === featuredSlug
+        );
+        if (newArticle) {
+            result.push(newArticle);
+        } else {
+            // This article was not found. pick an existing article and add it instead.
+            result.push(allArticles[i]);
+        }
+    });
+    return result;
+};
+
+const getLearnPageFilters = async () => {
+    const filters = {
+        languages: {},
+        products: {},
+    };
+
+    // Get possible language and product values from Stitch
+    const languageValues = await stitchClient.callFunction('getValuesByKey', [
+        metadata,
+        'languages',
+    ]);
+    const productValues = await stitchClient.callFunction('getValuesByKey', [
+        metadata,
+        'products',
+    ]);
+
+    // For each language, build an object with its total count, and count for each product
+    for (let i = 0; i < languageValues.length; i++) {
+        const l = languageValues[i];
+        filters.languages[l._id] = {
+            count: l.count,
+            products: {},
+        };
+        const productValuesForLanguage = await stitchClient.callFunction(
+            'getValuesByKey',
+            [metadata, 'products', { languages: l._id }]
+        );
+        productValuesForLanguage.forEach(pl => {
+            filters.languages[l._id].products[pl._id] = pl.count;
+        });
+    }
+
+    // For each product, build an object with its total count, and count for each language
+    for (let i = 0; i < productValues.length; i++) {
+        const p = productValues[i];
+        filters.products[p._id] = {
+            count: p.count,
+            languages: {},
+        };
+        const languageValuesForProduct = await stitchClient.callFunction(
+            'getValuesByKey',
+            [metadata, 'languages', { products: p._id }]
+        );
+        languageValuesForProduct.forEach(lp => {
+            filters.products[p._id].languages[lp._id] = lp.count;
+        });
+    }
+    return filters;
+};
+
+const getFeaturedArticlesForPage = async (page, defaultFeaturedArticles) => {
+    const allArticles = await getAllArticles();
+    // TODO: Verify field names with docsp
+    const featuredArticleSlugs =
+        getNestedValue(['featuredArticles', `${page}Page`], metadata) ||
+        defaultFeaturedArticles;
+    const featuredArticles = getFeaturedArticles(
+        allArticles,
+        featuredArticleSlugs
+    );
+    return featuredArticles;
+};
+
+const onCreatePage = async (page, actions, inheritedStitchClient) => {
+    const { createPage, deletePage } = actions;
+    stitchClient = inheritedStitchClient;
+    switch (page.path) {
+        case '/learn/':
+            const allArticles = await getAllArticles();
+            const filters = await getLearnPageFilters(allArticles);
+            const featuredLearnArticles = await getFeaturedArticlesForPage(
+                'learn',
+                DEFAULT_FEATURED_LEARN_SLUGS
+            );
+            deletePage(page);
+            createPage({
+                ...page,
+                context: {
+                    ...page.context,
+                    allArticles,
+                    featuredArticles: featuredLearnArticles,
+                    filters,
+                },
+            });
+            break;
+        case '/':
+            const featuredHomeArticles = await getFeaturedArticlesForPage(
+                'home',
+                DEFAULT_FEATURED_HOME_SLUGS
+            );
+            deletePage(page);
+            createPage({
+                ...page,
+                context: {
+                    ...page.context,
+                    featuredArticles: featuredHomeArticles,
+                },
+            });
+            break;
+        default:
+            break;
+    }
+};
+
+module.exports = { onCreatePage };

--- a/src/utils/setup/on-create-page.js
+++ b/src/utils/setup/on-create-page.js
@@ -18,6 +18,12 @@ const DEFAULT_FEATURED_LEARN_SLUGS = [
     '/how-to/polymorphic-pattern',
 ];
 
+// TODO: Verify field names with docsp
+const pageRouteToName = {
+    '/': 'home',
+    '/learn/': 'learn',
+};
+
 const requestStitch = async (functionName, ...args) =>
     stitchClient.callFunction(functionName, [metadata, ...args]);
 const memoizedStitchRequest = memoizerific(10)(requestStitch);
@@ -100,12 +106,16 @@ const getLearnPageFilters = async () => {
     return filters;
 };
 
-const getFeaturedArticlesForPage = async (page, defaultFeaturedArticles) => {
+const getFeaturedArticlesForPage = async (
+    pageRoute,
+    defaultFeaturedArticles
+) => {
     const allArticles = await getAllArticles();
-    // TODO: Verify field names with docsp
     const featuredArticleSlugs =
-        getNestedValue(['featuredArticles', `${page}Page`], metadata) ||
-        defaultFeaturedArticles;
+        getNestedValue(
+            ['featuredArticles', pageRouteToName[pageRoute]],
+            metadata
+        ) || defaultFeaturedArticles;
     const featuredArticles = getFeaturedArticles(
         allArticles,
         featuredArticleSlugs
@@ -121,7 +131,7 @@ const onCreatePage = async (page, actions, inheritedStitchClient) => {
             const allArticles = await getAllArticles();
             const filters = await getLearnPageFilters(allArticles);
             const featuredLearnArticles = await getFeaturedArticlesForPage(
-                'learn',
+                page.path,
                 DEFAULT_FEATURED_LEARN_SLUGS
             );
             deletePage(page);
@@ -137,7 +147,7 @@ const onCreatePage = async (page, actions, inheritedStitchClient) => {
             break;
         case '/':
             const featuredHomeArticles = await getFeaturedArticlesForPage(
-                'home',
+                page.path,
                 DEFAULT_FEATURED_HOME_SLUGS
             );
             deletePage(page);


### PR DESCRIPTION
This PR adds the ability to accept new arrays in the content repo's top-level [snooty.toml](https://github.com/mongodb/devhub-content/blob/master/snooty.toml) file as such:

```
[featured_articles]
"homePage" = ['path/to/article', ...]
"learnPage" = ['path/to/article', ...]
```

which allows the content team to dynamically change featured articles on the home and learn pages.

This PR. is just the changes to `gatsby-node` to pull this. data in and pass to the home/learn pages. A following PR ( #245 ) will make the change on the home page to show dynamic featured articles.