### PR TITLE
Fix Twitch Video Size on Mobile Home Page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -125,6 +125,9 @@ const TwitchVideoModal = ({ id, trigger, thumbnail }) => (
             padding: `0 ${size.large}`,
             width: '90%',
         }}
+        dialogMobileContainerStyle={{
+            width: '100%',
+        }}
         transparent
         triggerComponent={trigger}
     >


### PR DESCRIPTION
On mobile the Twitch video on the home page is very tiny. Specifying the width to be 100% fixes this issue and allows users to see the video on mobile.

Before:
<img width="58" alt="Screen Shot 2020-03-19 at 3 03 40 PM" src="https://user-images.githubusercontent.com/9064401/77104956-38d9f900-69f3-11ea-8b88-312536139a43.png">


After:
<img width="356" alt="Screen Shot 2020-03-19 at 3 03 25 PM" src="https://user-images.githubusercontent.com/9064401/77104966-3d061680-69f3-11ea-9a65-6ff63761c57d.png">
