### PR TITLE
Clean featured article style on mobile learn page

### DIFF
--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -26,9 +26,11 @@ const MainFeatureGrid = styled('div')`
 `;
 
 const PrimarySection = styled('div')`
-    border-right: 1px solid ${colorMap.greyDarkTwo};
     grid-area: primary;
-    padding-right: ${size.medium};
+    @media ${screenSize.mediumAndUp} {
+        border-right: 1px solid ${colorMap.greyDarkTwo};
+        padding-right: ${size.medium};
+    }
 `;
 
 const PrimaryImage = styled('img')`


### PR DESCRIPTION
This PR adds some mobile styling logic to remove the right border for the featured article on the learn page while on mobile. This allows the article to span the full with and be centered appropriately.

Before:
<img width="406" alt="Screen Shot 2020-03-19 at 3 38 31 PM" src="https://user-images.githubusercontent.com/9064401/77108191-2adaa700-69f8-11ea-92b7-a35e9db5690a.png">

After:
<img width="404" alt="Screen Shot 2020-03-19 at 3 38 17 PM" src="https://user-images.githubusercontent.com/9064401/77108188-2a421080-69f8-11ea-8b5b-1bf7579f25c1.png">

