### PR TITLE
Add pre-commit hooks for linting/testing

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+    '*.{js}': [
+        'npm lint:fix',
+        'npm format:fix',
+        'git add',
+        'npm test --bail --findRelatedTests --coverage=false ',
+    ],
+    '*.json': ['npm format:fix', 'git add'],
+    '*.css': ['npm format:fix', 'git add'],
+};

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,10 +1,10 @@
 module.exports = {
     '*.{js}': [
-        'npm lint:fix',
-        'npm format:fix',
+        'npm run lint:fix',
+        'npm run format:fix',
         'git add',
         'npm test --bail --findRelatedTests --coverage=false ',
     ],
-    '*.json': ['npm format:fix', 'git add'],
-    '*.css': ['npm format:fix', 'git add'],
+    '*.json': ['npm run format:fix', 'git add'],
+    '*.css': ['npm run format:fix', 'git add'],
 };

--- a/package.json
+++ b/package.json
@@ -18,17 +18,6 @@
     "test:regression": "jest regression",
     "test:unit": "jest unit"
   },
-  "lint-staged": {
-    "*.js": [
-      "eslint --fix",
-      "prettier --write",
-      "git add"
-    ],
-    "*.{json,md,mdx}": [
-      "prettier --write",
-      "git add"
-    ]
-  },
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"

--- a/preview-start.js
+++ b/preview-start.js
@@ -1,6 +1,6 @@
+/* eslint-disable import/no-unresolved */
 import React from 'react';
 import ReactDOM from 'react-dom';
-// eslint-disable-next-line import/no-unresolved
 import { getPageData } from 'previewSetup'; // Alias found in gatsby-node and webpack.config.js
 // Layouts
 import Layout from './src/components/dev-hub/layout';

--- a/src/components/dev-hub/controlled-tooltip.js
+++ b/src/components/dev-hub/controlled-tooltip.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import React from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
@@ -243,6 +244,8 @@ const contentLocation = padding => ({
             left = targetRect.right + padding;
             // our adjustment
             topAdjustment = -20;
+            break;
+        default:
             break;
     }
     const finalTop = top + window.pageYOffset + topAdjustment;

--- a/src/components/dev-hub/controlled-tooltip.js
+++ b/src/components/dev-hub/controlled-tooltip.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import React from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
@@ -206,16 +205,8 @@ const Trigger = styled('span')`
 // In order to provide custom positioning of right/left tooltips
 // we must hook into the logic of the library and add the
 // adjustments needed
-const contentLocation = padding => ({
-    align,
-    position,
-    popoverRect,
-    targetRect,
-    nudgedLeft,
-    nudgedTop,
-}) => {
+const contentLocation = padding => ({ position, popoverRect, targetRect }) => {
     const targetMidX = targetRect.left + targetRect.width / 2;
-    const targetMidY = targetRect.top + targetRect.height / 2;
     let top;
     let left;
     let topAdjustment = 0; // this is our 'top' adjustment

--- a/src/components/dev-hub/event-list.js
+++ b/src/components/dev-hub/event-list.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import styled from '@emotion/styled';
 import Button from './button';
 import Event from './events';

--- a/src/components/dev-hub/global-nav.js
+++ b/src/components/dev-hub/global-nav.js
@@ -2,10 +2,8 @@ import React from 'react';
 import styled from '@emotion/styled';
 import Link from './link';
 import { colorMap, fontSize, lineHeight, screenSize, size } from './theme';
-import Leaf from './icons/mdb-leaf';
 import DevLeafMobile from './icons/mdb-dev-leaf-mobile';
 import DevLeafDesktop from './icons/mdb-dev-leaf-desktop';
-import { withPrefix } from 'gatsby';
 import useMedia from '../../hooks/use-media';
 
 const GlobalNav = styled('nav')`

--- a/src/components/dev-hub/gradient-image.js
+++ b/src/components/dev-hub/gradient-image.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
-import { gradientMap, size, colorMap } from './theme';
+import { gradientMap, size } from './theme';
 
 const fullSizeAbsolute = css`
     bottom: 0;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -5,7 +5,7 @@ import Card from '../components/dev-hub/card';
 import MediaBlock from '../components/dev-hub/media-block';
 import Layout from '../components/dev-hub/layout';
 import Notification from '../components/dev-hub/notification';
-import { H1, H2, P, SubHeader, H5 } from '../components/dev-hub/text';
+import { H1, H2, P, SubHeader } from '../components/dev-hub/text';
 import {
     colorMap,
     gradientMap,

--- a/tests/unit/use-event-data.test.js
+++ b/tests/unit/use-event-data.test.js
@@ -1,5 +1,5 @@
 import { removePastEvents } from '../../src/hooks/use-event-data';
-import { createDateObject } from '../../src/utils/format-dates';
+// import { createDateObject } from '../../src/utils/format-dates';
 
 const events = [
     {
@@ -18,6 +18,7 @@ const events = [
     },
 ];
 
+/*
 const today = createDateObject(new Date());
 const todayAsia = today.toLocaleString('en-US', {
     timeZone: 'Asia/Shanghai',
@@ -38,11 +39,11 @@ const timezonedEvents = [
         },
         status: 'published',
     },
-];
+]; */
 it('should remove events that have past', () => {
     const filtered = removePastEvents(events);
-    // eslint-disable-next-line no-unused-vars
-    const timezoneFiltered = removePastEvents(timezonedEvents);
+
+    // const timezoneFiltered = removePastEvents(timezonedEvents);
     expect(filtered).toEqual([events[0]]);
     // TODO: uncomment below when browser inconsistencies with `createDateObject()`
     // comparisons is resolved

--- a/tests/unit/use-event-data.test.js
+++ b/tests/unit/use-event-data.test.js
@@ -41,6 +41,7 @@ const timezonedEvents = [
 ];
 it('should remove events that have past', () => {
     const filtered = removePastEvents(events);
+    // eslint-disable-next-line no-unused-vars
     const timezoneFiltered = removePastEvents(timezonedEvents);
     expect(filtered).toEqual([events[0]]);
     // TODO: uncomment below when browser inconsistencies with `createDateObject()`


### PR DESCRIPTION
Now that `npm test` works again, this PR enables linting and testing on commits (similar to with university) using husky/lint-staged.

After enabling this, there were some lint errors to handle, so these were taken care of as well.