### PR TITLE
Add Embedded Chart Support

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -1,52 +1,53 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { ADMONITIONS } from '../constants';
-import Step from './Step';
-import Paragraph from './Paragraph';
+import Admonition from './Admonition';
+import BlockQuote from './dev-hub/blockquote';
+import CardGroup from './CardGroup';
+import CodeBlock from './dev-hub/codeblock';
+import Chart from './dev-hub/chart';
+import Cond from './Cond';
+import Contents from './Contents';
+import Container from './Container';
+import CSSClass from './CSSClass';
+import DefinitionList from './DefinitionList';
+import DefinitionListItem from './DefinitionListItem';
+import Deprecated from './Deprecated';
+import Emphasis from './Emphasis';
+import Figure from './Figure';
+import Footnote from './Footnote';
+import FootnoteReference from './FootnoteReference';
+import Heading from './Heading';
+import HorizontalList from './HorizontalList';
+import Image from './Image';
+import Include from './Include';
+import Line from './Line';
+import LineBlock from './LineBlock';
 import List from './List';
 import ListItem from './ListItem';
 import ListTable from './ListTable';
-import Emphasis from './Emphasis';
-import Include from './Include';
-import Section from './Section';
-import CodeBlock from './dev-hub/codeblock';
-import LiteralInclude from './LiteralInclude';
-import Admonition from './Admonition';
-import Figure from './Figure';
 import Literal from './Literal';
-import Heading from './Heading';
-import BlockQuote from './dev-hub/blockquote';
-import Reference from './Reference';
-import Strong from './Strong';
-import TitleReference from './TitleReference';
-import Text from './Text';
-import DefinitionList from './DefinitionList';
-import DefinitionListItem from './DefinitionListItem';
-import Transition from './Transition';
-import CSSClass from './CSSClass';
-import SubstitutionReference from './SubstitutionReference';
-import Line from './Line';
-import LineBlock from './LineBlock';
-import HorizontalList from './HorizontalList';
-import Contents from './Contents';
-import Container from './Container';
-import Cond from './Cond';
-import Meta from './Meta';
-import VersionChanged from './VersionChanged';
-import VersionAdded from './VersionAdded';
-import Deprecated from './Deprecated';
-import CardGroup from './CardGroup';
-import Footnote from './Footnote';
-import FootnoteReference from './FootnoteReference';
 import LiteralBlock from './LiteralBlock';
-import Topic from './Topic';
+import LiteralInclude from './LiteralInclude';
+import Meta from './Meta';
+import MetaDescription from './meta-description';
+import Paragraph from './Paragraph';
+import Reference from './Reference';
+import RefRole from './RefRole';
+import Section from './Section';
+import Step from './Step';
+import Strong from './Strong';
 import Subscript from './Subscript';
 import Superscript from './Superscript';
-import Image from './Image';
-import RefRole from './RefRole';
-import TwitterMeta from './TwitterMeta';
-import MetaDescription from './meta-description';
+import SubstitutionReference from './SubstitutionReference';
 import Target from './Target';
+import Text from './Text';
+import TitleReference from './TitleReference';
+import Topic from './Topic';
+import Transition from './Transition';
+import TwitterMeta from './TwitterMeta';
+import VersionAdded from './VersionAdded';
+import VersionChanged from './VersionChanged';
 import VideoEmbed from './dev-hub/video-embed';
 
 import RoleAbbr from './Roles/Abbr';
@@ -72,6 +73,7 @@ export default class ComponentFactory extends Component {
             admonition: Admonition,
             blockquote: BlockQuote,
             'card-group': CardGroup,
+            chart: Chart,
             class: CSSClass,
             code: CodeBlock,
             cond: Cond,

--- a/src/components/dev-hub/chart.js
+++ b/src/components/dev-hub/chart.js
@@ -18,8 +18,8 @@ const buildChartUrl = options => {
 };
 
 const StyledChart = styled('iframe')`
-    ${({ chartWidth }) => `width: min(100%, ${chartWidth}px)`};
     ${({ customAlign }) => !customAlign && `float: ${customAlign};`};
+    max-width: 100%;
 `;
 
 const Chart = ({ nodeData: { options } }) => {
@@ -30,12 +30,11 @@ const Chart = ({ nodeData: { options } }) => {
     const chartSrc = useMemo(() => buildChartUrl(options), [options]);
     return (
         <StyledChart
-            // Use styled width responsive iframe
-            chartWidth={chartWidth}
             customAlign={customAlign}
             height={chartHeight}
             title={chartTitle}
             src={chartSrc}
+            width={chartWidth}
         />
     );
 };

--- a/src/components/dev-hub/chart.js
+++ b/src/components/dev-hub/chart.js
@@ -7,14 +7,14 @@ const DEFAULT_CHART_HEIGHT = '570';
 const DEFAULT_CHART_WIDTH = '760';
 const DEFAULT_CHART_THEME = 'dark';
 
-const buildChartUrl = (baseUrl, options) => {
+const buildChartUrl = options => {
     const params = {
         autorefresh: options.autorefresh,
         id: options.id,
         theme: options.theme || DEFAULT_CHART_THEME,
     };
     const queryString = buildQueryString(params);
-    return `${baseUrl}/embed/charts${queryString}`;
+    return `${options.url}/embed/charts${queryString}`;
 };
 
 const StyledChart = styled('iframe')`
@@ -23,15 +23,11 @@ const StyledChart = styled('iframe')`
 `;
 
 const Chart = ({ nodeData: { options } }) => {
-    const chartHostUrl = options.url;
     const chartHeight = options.height || DEFAULT_CHART_HEIGHT;
     const chartWidth = options.width || DEFAULT_CHART_WIDTH;
     const chartTitle = options.title;
     const customAlign = options.align;
-    const chartSrc = useMemo(() => buildChartUrl(chartHostUrl, options), [
-        chartHostUrl,
-        options,
-    ]);
+    const chartSrc = useMemo(() => buildChartUrl(options), [options]);
     return (
         <StyledChart
             // Use styled width responsive iframe

--- a/src/components/dev-hub/chart.js
+++ b/src/components/dev-hub/chart.js
@@ -14,7 +14,7 @@ const buildChartUrl = (baseUrl, options) => {
         theme: options.theme || DEFAULT_CHART_THEME,
     };
     const queryString = buildQueryString(params);
-    return `${baseUrl}/embed/charts?${queryString}`;
+    return `${baseUrl}/embed/charts${queryString}`;
 };
 
 const StyledChart = styled('iframe')`
@@ -26,7 +26,7 @@ const Chart = ({ nodeData: { options } }) => {
     const chartHostUrl = options.url;
     const chartHeight = options.height || DEFAULT_CHART_HEIGHT;
     const chartWidth = options.width || DEFAULT_CHART_WIDTH;
-    const chartTitle = options.title || 'MongoDB Chart';
+    const chartTitle = options.title;
     const customAlign = options.align;
     const chartSrc = useMemo(() => buildChartUrl(chartHostUrl, options), [
         chartHostUrl,
@@ -34,12 +34,12 @@ const Chart = ({ nodeData: { options } }) => {
     ]);
     return (
         <StyledChart
-            height={chartHeight}
-            src={chartSrc}
-            title={chartTitle}
             // Use styled width responsive iframe
             chartWidth={chartWidth}
             customAlign={customAlign}
+            height={chartHeight}
+            title={chartTitle}
+            src={chartSrc}
         />
     );
 };

--- a/src/components/dev-hub/chart.js
+++ b/src/components/dev-hub/chart.js
@@ -18,8 +18,8 @@ const buildChartUrl = (baseUrl, options) => {
 };
 
 const StyledChart = styled('iframe')`
-    ${({ customAlign }) => !customAlign && `float: ${customAlign};`};
     ${({ chartWidth }) => `width: min(100%, ${chartWidth}px)`};
+    ${({ customAlign }) => !customAlign && `float: ${customAlign};`};
 `;
 
 const Chart = ({ nodeData: { options } }) => {
@@ -37,6 +37,7 @@ const Chart = ({ nodeData: { options } }) => {
             height={chartHeight}
             src={chartSrc}
             title={chartTitle}
+            // Use styled width responsive iframe
             chartWidth={chartWidth}
             customAlign={customAlign}
         />
@@ -46,20 +47,16 @@ const Chart = ({ nodeData: { options } }) => {
 Chart.propTypes = {
     className: PropTypes.string,
     nodeData: PropTypes.shape({
-        argument: PropTypes.arrayOf(
-            PropTypes.shape({
-                value: PropTypes.string.isRequired,
-            })
-        ),
         options: PropTypes.shape({
+            align: PropTypes.string,
             autorefresh: PropTypes.string,
             height: PropTypes.string,
             id: PropTypes.string,
             theme: PropTypes.string,
+            url: PropTypes.string,
             width: PropTypes.string,
         }),
     }),
-    src: PropTypes.string,
 };
 
 export default Chart;

--- a/src/components/dev-hub/chart.js
+++ b/src/components/dev-hub/chart.js
@@ -1,0 +1,65 @@
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { buildQueryString } from '../../utils/query-string';
+import styled from '@emotion/styled';
+
+const DEFAULT_CHART_HEIGHT = '570';
+const DEFAULT_CHART_WIDTH = '760';
+const DEFAULT_CHART_THEME = 'dark';
+
+const buildChartUrl = (baseUrl, options) => {
+    const params = {
+        autorefresh: options.autorefresh,
+        id: options.id,
+        theme: options.theme || DEFAULT_CHART_THEME,
+    };
+    const queryString = buildQueryString(params);
+    return `${baseUrl}/embed/charts?${queryString}`;
+};
+
+const StyledChart = styled('iframe')`
+    ${({ customAlign }) => !customAlign && `float: ${customAlign};`};
+    ${({ chartWidth }) => `width: min(100%, ${chartWidth}px)`};
+`;
+
+const Chart = ({ nodeData: { options } }) => {
+    const chartHostUrl = options.url;
+    const chartHeight = options.height || DEFAULT_CHART_HEIGHT;
+    const chartWidth = options.width || DEFAULT_CHART_WIDTH;
+    const chartTitle = options.title || 'MongoDB Chart';
+    const customAlign = options.align;
+    const chartSrc = useMemo(() => buildChartUrl(chartHostUrl, options), [
+        chartHostUrl,
+        options,
+    ]);
+    return (
+        <StyledChart
+            height={chartHeight}
+            src={chartSrc}
+            title={chartTitle}
+            chartWidth={chartWidth}
+            customAlign={customAlign}
+        />
+    );
+};
+
+Chart.propTypes = {
+    className: PropTypes.string,
+    nodeData: PropTypes.shape({
+        argument: PropTypes.arrayOf(
+            PropTypes.shape({
+                value: PropTypes.string.isRequired,
+            })
+        ),
+        options: PropTypes.shape({
+            autorefresh: PropTypes.string,
+            height: PropTypes.string,
+            id: PropTypes.string,
+            theme: PropTypes.string,
+            width: PropTypes.string,
+        }),
+    }),
+    src: PropTypes.string,
+};
+
+export default Chart;

--- a/src/components/dev-hub/chart.js
+++ b/src/components/dev-hub/chart.js
@@ -1,15 +1,15 @@
 import React, { useMemo } from 'react';
-import PropTypes from 'prop-types';
 import { buildQueryString } from '../../utils/query-string';
 import styled from '@emotion/styled';
 
+const DEFAULT_CHART_AUTOREFRESH = 3600;
 const DEFAULT_CHART_HEIGHT = '570';
 const DEFAULT_CHART_WIDTH = '760';
 const DEFAULT_CHART_THEME = 'dark';
 
 const buildChartUrl = options => {
     const params = {
-        autorefresh: options.autorefresh,
+        autorefresh: options.autorefresh || DEFAULT_CHART_AUTOREFRESH,
         id: options.id,
         theme: options.theme || DEFAULT_CHART_THEME,
     };
@@ -23,35 +23,16 @@ const StyledChart = styled('iframe')`
 `;
 
 const Chart = ({ nodeData: { options } }) => {
-    const chartHeight = options.height || DEFAULT_CHART_HEIGHT;
-    const chartWidth = options.width || DEFAULT_CHART_WIDTH;
-    const chartTitle = options.title;
-    const customAlign = options.align;
     const chartSrc = useMemo(() => buildChartUrl(options), [options]);
     return (
         <StyledChart
-            customAlign={customAlign}
-            height={chartHeight}
-            title={chartTitle}
+            customAlign={options.align}
+            height={options.height || DEFAULT_CHART_HEIGHT}
+            title={options.title}
             src={chartSrc}
-            width={chartWidth}
+            width={options.width || DEFAULT_CHART_WIDTH}
         />
     );
-};
-
-Chart.propTypes = {
-    className: PropTypes.string,
-    nodeData: PropTypes.shape({
-        options: PropTypes.shape({
-            align: PropTypes.string,
-            autorefresh: PropTypes.string,
-            height: PropTypes.string,
-            id: PropTypes.string,
-            theme: PropTypes.string,
-            url: PropTypes.string,
-            width: PropTypes.string,
-        }),
-    }),
 };
 
 export default Chart;

--- a/src/components/dev-hub/stories/chart.stories.mdx
+++ b/src/components/dev-hub/stories/chart.stories.mdx
@@ -13,7 +13,6 @@ We support embedded MongoDB Charts through the component factory for articles.
             nodeData={{
                 options: {
                     id: '6f921f0c-a1ee-4106-839c-412fad3c64e7',
-                    autorefresh: 100,
                     width: 760,
                     height: 570,
                     url: 'https://charts.mongodb.com/charts-coronavirus-lwlvn',

--- a/src/components/dev-hub/stories/chart.stories.mdx
+++ b/src/components/dev-hub/stories/chart.stories.mdx
@@ -1,0 +1,24 @@
+import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import Chart from '../chart';
+
+<Meta title="Chart" />
+
+# Embedded MongoDB Chart
+
+We support embedded MongoDB Charts through the component factory for articles.
+
+<Preview>
+    <Story name="Chart">
+        <Chart
+            nodeData={{
+                options: {
+                    id: '6f921f0c-a1ee-4106-839c-412fad3c64e7',
+                    autorefresh: 100,
+                    width: 760,
+                    height: 570,
+                    url: 'https://charts.mongodb.com/charts-coronavirus-lwlvn',
+                },
+            }}
+        />
+    </Story>
+</Preview>


### PR DESCRIPTION
This PR adds support for embedded charts in articles. Sophie is adding the support to articles today, but the props to be passed to this component resemble the following:

```
nodeData={{
  options: {
    id: '6f921f0c-a1ee-4106-839c-412fad3c64e7',
    autorefresh: 3600,
    align: 'left',
    width: 760,
    height: 570,
    url: 'https://charts.mongodb.com/charts-coronavirus-lwlvn',
  },
}}
```

<img width="1332" alt="Screen Shot 2020-03-23 at 11 40 08 AM" src="https://user-images.githubusercontent.com/9064401/77337638-8ad69380-6cff-11ea-88cc-b29ef17217c2.png">
<img width="784" alt="Screen Shot 2020-03-23 at 11 40 15 AM" src="https://user-images.githubusercontent.com/9064401/77337640-8ad69380-6cff-11ea-9f0d-0d9d9b3d2c8f.png">
