### PR TITLE
let titles wrap

### DIFF
--- a/src/components/dev-hub/series.js
+++ b/src/components/dev-hub/series.js
@@ -44,11 +44,9 @@ const activeLinkStyles = css`
 `;
 
 const Breadcrumb = styled('li')`
+    display: flex;
     padding-bottom: ${size.small};
     position: relative;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
     z-index: ${layer.back};
 `;
 
@@ -146,7 +144,7 @@ const SeriesList = styled('ul')`
             ),
             ${BORDER_GRADIENT};
         background-size: ${size.medium} 2px, cover;
-        bottom: ${BULLET_SIZE / 2 + 2}px;
+        bottom: ${BULLET_SIZE / 2 + 3}px;
         content: '';
         left: 7px;
         position: absolute;


### PR DESCRIPTION
Had feedback that the ellipsis can be confusing for certain series, so updated the article titles to wrap
### Before (with confusing titles)

<img width="829" alt="Screen Shot 2020-03-23 at 1 30 10 PM" src="https://user-images.githubusercontent.com/514026/77345219-b14dfc00-6d0a-11ea-8a3f-c72b5715ff52.png">

### After

<img width="822" alt="Screen Shot 2020-03-23 at 1 29 58 PM" src="https://user-images.githubusercontent.com/514026/77345217-b0b56580-6d0a-11ea-9b41-2803c2de80a5.png">
