### PR TITLE
Refactor and Test onCreatePage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -25,5 +25,15 @@ module.exports = {
                 '^.+\\.jsx?$': `<rootDir>/jest-preprocess.js`,
             },
         },
+        {
+            displayName: 'utils',
+            globals: {
+                __PATH_PREFIX__: '',
+            },
+            testMatch: ['<rootDir>/tests/utils/*.test.js'],
+            transform: {
+                '^.+\\.jsx?$': `<rootDir>/jest-preprocess.js`,
+            },
+        },
     ],
 };

--- a/src/utils/setup/create-tag-page-type.js
+++ b/src/utils/setup/create-tag-page-type.js
@@ -66,15 +66,14 @@ const createTagPageType = async (
         pages: pageData[i],
     }));
 
-    const pageList = itemsWithPageData.map(page => {
+    itemsWithPageData.forEach(page => {
         const name = isAuthor ? page.item._id.name : page.item._id;
         // Some bad data for authors doesn't follow this structure, so ignore it
-        if (!name) return null;
-        else {
+        if (name) {
             const urlSuffix = getTagPageUriComponent(name);
             const newPage = {
+                name,
                 type: pageType,
-                name: name,
                 slug: `/${pageType}/${urlSuffix}`,
                 pages: page.pages,
             };
@@ -88,19 +87,13 @@ const createTagPageType = async (
                 newPage['author_image'] = page.item._id.image;
                 newPage['bio'] = bio;
             }
-            return newPage;
-        }
-    });
-
-    pageList.forEach(page => {
-        if (page) {
             createPage({
-                path: page.slug,
+                path: newPage.slug,
                 component: path.resolve(`./src/templates/tag.js`),
                 context: {
                     metadata: pageMetadata,
                     snootyStitchId: SNOOTY_STITCH_ID,
-                    ...page,
+                    ...newPage,
                 },
             });
         }

--- a/src/utils/setup/on-create-page.js
+++ b/src/utils/setup/on-create-page.js
@@ -57,11 +57,10 @@ const getLearnPageFilters = async () => {
     const allArticles = await getAllArticles();
 
     allArticles.forEach(a => {
-        const langs = a.query_fields.languages;
-        const prods = a.query_fields.products;
-        // Just lang
-        if (langs) {
-            langs.forEach(l => {
+        const languagesForArticle = a.query_fields.languages;
+        const productsForArticle = a.query_fields.products;
+        if (languagesForArticle) {
+            languagesForArticle.forEach(l => {
                 if (languages[l]) {
                     languages[l].count++;
                 } else {
@@ -70,20 +69,17 @@ const getLearnPageFilters = async () => {
                         products: {},
                     };
                 }
-                if (prods) {
-                    prods.forEach(p => {
-                        if (languages[l].products[p]) {
-                            languages[l].products[p]++;
-                        } else {
-                            languages[l].products[p] = 1;
-                        }
+                if (productsForArticle) {
+                    productsForArticle.forEach(p => {
+                        languages[l].products[p]
+                            ? languages[l].products[p]++
+                            : (languages[l].products[p] = 1);
                     });
                 }
             });
         }
-        if (prods) {
-            // Just products
-            prods.forEach(p => {
+        if (productsForArticle) {
+            productsForArticle.forEach(p => {
                 if (products[p]) {
                     products[p].count++;
                 } else {
@@ -92,19 +88,16 @@ const getLearnPageFilters = async () => {
                         languages: {},
                     };
                 }
-                if (langs) {
-                    langs.forEach(l => {
-                        if (products[p].languages[l]) {
-                            products[p].languages[l]++;
-                        } else {
-                            products[p].languages[l] = 1;
-                        }
+                if (languagesForArticle) {
+                    languagesForArticle.forEach(l => {
+                        products[p].languages[l]
+                            ? products[p].languages[l]++
+                            : (products[p].languages[l] = 1);
                     });
                 }
             });
         }
     });
-
     return { languages, products };
 };
 

--- a/src/utils/setup/on-create-page.js
+++ b/src/utils/setup/on-create-page.js
@@ -150,4 +150,4 @@ const onCreatePage = async (
     }
 };
 
-module.exports = { getFeaturedArticles, getLearnPageFilters, onCreatePage };
+module.exports = { findArticlesFromSlugs, getLearnPageFilters, onCreatePage };

--- a/src/utils/setup/on-create-page.js
+++ b/src/utils/setup/on-create-page.js
@@ -150,4 +150,4 @@ const onCreatePage = async (
     }
 };
 
-module.exports = { getLearnPageFilters, onCreatePage };
+module.exports = { getFeaturedArticles, getLearnPageFilters, onCreatePage };

--- a/src/utils/setup/on-create-page.js
+++ b/src/utils/setup/on-create-page.js
@@ -66,9 +66,11 @@ const getLearnPageFilters = allArticles => {
         // of how many itmes we see a product with this language
         if (languagesForArticle) {
             languagesForArticle.forEach(language => {
-                if (languages[language]) {
-                    languages[language].count++;
+                const currentLanguage = languages[language];
+                if (currentLanguage) {
+                    currentLanguage.count++;
                 } else {
+                    // Update language reference directly in outer block object
                     languages[language] = {
                         count: 1,
                         products: {},
@@ -76,10 +78,11 @@ const getLearnPageFilters = allArticles => {
                 }
                 if (productsForArticle) {
                     // If this article also has products, update those counts as well for this language
+                    const productsForLanguage = languages[language].products;
                     productsForArticle.forEach(product => {
-                        languages[language].products[product]
-                            ? languages[language].products[product]++
-                            : (languages[language].products[product] = 1);
+                        productsForLanguage[product]
+                            ? productsForLanguage[product]++
+                            : (productsForLanguage[product] = 1);
                     });
                 }
             });
@@ -89,9 +92,11 @@ const getLearnPageFilters = allArticles => {
         // of how many itmes we see a language with this product
         if (productsForArticle) {
             productsForArticle.forEach(product => {
-                if (products[product]) {
-                    products[product].count++;
+                const currentProduct = products[product];
+                if (currentProduct) {
+                    currentProduct.count++;
                 } else {
+                    // Update product reference directly in outer block object
                     products[product] = {
                         count: 1,
                         languages: {},
@@ -99,10 +104,11 @@ const getLearnPageFilters = allArticles => {
                 }
                 if (languagesForArticle) {
                     // If this article also has languages, update those counts as well for this products
+                    const languagesForProduct = products[product].languages;
                     languagesForArticle.forEach(language => {
-                        products[product].languages[language]
-                            ? products[product].languages[language]++
-                            : (products[product].languages[language] = 1);
+                        languagesForProduct[language]
+                            ? languagesForProduct[language]++
+                            : (languagesForProduct[language] = 1);
                     });
                 }
             });

--- a/src/utils/setup/on-create-page.js
+++ b/src/utils/setup/on-create-page.js
@@ -50,15 +50,14 @@ const findArticlesFromSlugs = (allArticles, articleSlugs) => {
     return result;
 };
 
-const getLearnPageFilters = async () => {
+const getLearnPageFilters = allArticles => {
     const languages = {};
     const products = {};
-
-    const allArticles = await getAllArticles();
 
     allArticles.forEach(a => {
         const languagesForArticle = a.query_fields.languages;
         const productsForArticle = a.query_fields.products;
+        // Go through languages for this article and update filter info
         if (languagesForArticle) {
             languagesForArticle.forEach(l => {
                 if (languages[l]) {
@@ -70,6 +69,7 @@ const getLearnPageFilters = async () => {
                     };
                 }
                 if (productsForArticle) {
+                    // If this article also has products, update those counts as well for this language
                     productsForArticle.forEach(p => {
                         languages[l].products[p]
                             ? languages[l].products[p]++
@@ -78,6 +78,7 @@ const getLearnPageFilters = async () => {
                 }
             });
         }
+        // Go through products for this article and update filter info
         if (productsForArticle) {
             productsForArticle.forEach(p => {
                 if (products[p]) {
@@ -89,6 +90,7 @@ const getLearnPageFilters = async () => {
                     };
                 }
                 if (languagesForArticle) {
+                    // If this article also has languages, update those counts as well for this products
                     languagesForArticle.forEach(l => {
                         products[p].languages[l]
                             ? products[p].languages[l]++
@@ -148,4 +150,4 @@ const onCreatePage = async (
     }
 };
 
-module.exports = { onCreatePage };
+module.exports = { getLearnPageFilters, onCreatePage };

--- a/src/utils/setup/on-create-page.js
+++ b/src/utils/setup/on-create-page.js
@@ -51,10 +51,8 @@ const findArticlesFromSlugs = (allArticles, articleSlugs) => {
 };
 
 const getLearnPageFilters = async () => {
-    const filters = {
-        languages: {},
-        products: {},
-    };
+    const languages = {};
+    const products = {};
 
     // Get possible language and product values from Stitch
     const languageValues = await stitchClient.callFunction('getValuesByKey', [
@@ -69,7 +67,7 @@ const getLearnPageFilters = async () => {
     // For each language, build an object with its total count, and count for each product
     for (let i = 0; i < languageValues.length; i++) {
         const l = languageValues[i];
-        filters.languages[l._id] = {
+        languages[l._id] = {
             count: l.count,
             products: {},
         };
@@ -78,14 +76,14 @@ const getLearnPageFilters = async () => {
             [metadata, 'products', { languages: l._id }]
         );
         productValuesForLanguage.forEach(pl => {
-            filters.languages[l._id].products[pl._id] = pl.count;
+            languages[l._id].products[pl._id] = pl.count;
         });
     }
 
     // For each product, build an object with its total count, and count for each language
     for (let i = 0; i < productValues.length; i++) {
         const p = productValues[i];
-        filters.products[p._id] = {
+        products[p._id] = {
             count: p.count,
             languages: {},
         };
@@ -94,10 +92,10 @@ const getLearnPageFilters = async () => {
             [metadata, 'languages', { products: p._id }]
         );
         languageValuesForProduct.forEach(lp => {
-            filters.products[p._id].languages[lp._id] = lp.count;
+            products[p._id].languages[lp._id] = lp.count;
         });
     }
-    return filters;
+    return { languages, products };
 };
 
 const onCreatePage = async (

--- a/src/utils/setup/on-create-page.js
+++ b/src/utils/setup/on-create-page.js
@@ -54,47 +54,51 @@ const getLearnPageFilters = allArticles => {
     const languages = {};
     const products = {};
 
-    allArticles.forEach(a => {
-        const languagesForArticle = a.query_fields.languages;
-        const productsForArticle = a.query_fields.products;
-        // Go through languages for this article and update filter info
+    allArticles.forEach(article => {
+        const languagesForArticle = article.query_fields.languages;
+        const productsForArticle = article.query_fields.products;
+        // Go through languages for this article and update filter info.
+        // Add a count of how many times this language appears and keep track
+        // of how many itmes we see a product with this language
         if (languagesForArticle) {
-            languagesForArticle.forEach(l => {
-                if (languages[l]) {
-                    languages[l].count++;
+            languagesForArticle.forEach(language => {
+                if (languages[language]) {
+                    languages[language].count++;
                 } else {
-                    languages[l] = {
+                    languages[language] = {
                         count: 1,
                         products: {},
                     };
                 }
                 if (productsForArticle) {
                     // If this article also has products, update those counts as well for this language
-                    productsForArticle.forEach(p => {
-                        languages[l].products[p]
-                            ? languages[l].products[p]++
-                            : (languages[l].products[p] = 1);
+                    productsForArticle.forEach(product => {
+                        languages[language].products[product]
+                            ? languages[language].products[product]++
+                            : (languages[language].products[product] = 1);
                     });
                 }
             });
         }
-        // Go through products for this article and update filter info
+        // Go through products for this article and update filter info.
+        // Add a count of how many times this product appears and keep track
+        // of how many itmes we see a language with this product
         if (productsForArticle) {
-            productsForArticle.forEach(p => {
-                if (products[p]) {
-                    products[p].count++;
+            productsForArticle.forEach(product => {
+                if (products[product]) {
+                    products[product].count++;
                 } else {
-                    products[p] = {
+                    products[product] = {
                         count: 1,
                         languages: {},
                     };
                 }
                 if (languagesForArticle) {
                     // If this article also has languages, update those counts as well for this products
-                    languagesForArticle.forEach(l => {
-                        products[p].languages[l]
-                            ? products[p].languages[l]++
-                            : (products[p].languages[l] = 1);
+                    languagesForArticle.forEach(language => {
+                        products[product].languages[language]
+                            ? products[product].languages[language]++
+                            : (products[product].languages[language] = 1);
                     });
                 }
             });

--- a/src/utils/setup/on-create-page.js
+++ b/src/utils/setup/on-create-page.js
@@ -5,6 +5,9 @@ const { getMetadata } = require('../get-metadata');
 const metadata = getMetadata();
 let stitchClient;
 
+const MAX_LEARN_PAGE_FEATURED_ARTICLES = 3;
+const MAX_HOME_PAGE_FEATURED_ARTICLES = 4;
+
 const DEFAULT_FEATURED_HOME_SLUGS = [
     '/how-to/nextjs-building-modern-applications',
     '/how-to/python-starlette-stitch',
@@ -34,9 +37,10 @@ const getAllArticles = memoizerific(1)(async () => {
     return filteredDocuments;
 });
 
-const findArticlesFromSlugs = (allArticles, articleSlugs) => {
+const findArticlesFromSlugs = (allArticles, articleSlugs, maxSize) => {
     const result = [];
-    articleSlugs.forEach((featuredSlug, i) => {
+    // If maxSize is undefined, this will return a shallow copy of articleSlugs
+    articleSlugs.slice(0, maxSize).forEach((featuredSlug, i) => {
         const newArticle = allArticles.find(
             x => x.query_fields.slug === featuredSlug
         );
@@ -122,7 +126,8 @@ const onCreatePage = async (
             const filters = await getLearnPageFilters(allArticles);
             const featuredLearnArticles = findArticlesFromSlugs(
                 allArticles,
-                learnFeaturedArticles || DEFAULT_FEATURED_LEARN_SLUGS
+                learnFeaturedArticles || DEFAULT_FEATURED_LEARN_SLUGS,
+                MAX_LEARN_PAGE_FEATURED_ARTICLES
             );
             deletePage(page);
             createPage({
@@ -138,7 +143,8 @@ const onCreatePage = async (
         case '/':
             const featuredHomeArticles = findArticlesFromSlugs(
                 await getAllArticles(),
-                homeFeaturedArticles || DEFAULT_FEATURED_HOME_SLUGS
+                homeFeaturedArticles || DEFAULT_FEATURED_HOME_SLUGS,
+                MAX_HOME_PAGE_FEATURED_ARTICLES
             );
             deletePage(page);
             createPage({

--- a/tests/utils/find-articles-from-slugs.test.js
+++ b/tests/utils/find-articles-from-slugs.test.js
@@ -1,4 +1,4 @@
-import { getFeaturedArticles } from '../../src/utils/setup/on-create-page';
+import { findArticlesFromSlugs } from '../../src/utils/setup/on-create-page';
 
 it('should correctly find featured articles given a set of requested articles', () => {
     let requestedFeaturedSlugs = [
@@ -19,7 +19,7 @@ it('should correctly find featured articles given a set of requested articles', 
         },
     }));
 
-    let result = getFeaturedArticles(allArticles, requestedFeaturedSlugs).map(
+    let result = findArticlesFromSlugs(allArticles, requestedFeaturedSlugs).map(
         a => a.query_fields.slug
     );
 
@@ -32,7 +32,7 @@ it('should correctly find featured articles given a set of requested articles', 
         '/how-to/polymorphic-pattern',
     ];
 
-    result = getFeaturedArticles(allArticles, requestedFeaturedSlugs).map(
+    result = findArticlesFromSlugs(allArticles, requestedFeaturedSlugs).map(
         a => a.query_fields.slug
     );
 

--- a/tests/utils/find-articles-from-slugs.test.js
+++ b/tests/utils/find-articles-from-slugs.test.js
@@ -19,12 +19,13 @@ it('should correctly find featured articles given a set of requested articles', 
         },
     }));
 
-    let result = findArticlesFromSlugs(allArticles, requestedFeaturedSlugs).map(
-        a => a.query_fields.slug
-    );
+    let foundSlugs = findArticlesFromSlugs(
+        allArticles,
+        requestedFeaturedSlugs
+    ).map(a => a.query_fields.slug);
 
     // All articles were found, so we should get them back in order
-    expect(result).toStrictEqual(requestedFeaturedSlugs);
+    expect(foundSlugs).toStrictEqual(requestedFeaturedSlugs);
 
     requestedFeaturedSlugs = [
         '/quickstart',
@@ -32,12 +33,12 @@ it('should correctly find featured articles given a set of requested articles', 
         '/how-to/polymorphic-pattern',
     ];
 
-    result = findArticlesFromSlugs(allArticles, requestedFeaturedSlugs).map(
+    foundSlugs = findArticlesFromSlugs(allArticles, requestedFeaturedSlugs).map(
         a => a.query_fields.slug
     );
 
     // The first two were not found, so return the 0th and 1st elements (instead of null)
-    expect(result).toStrictEqual([
+    expect(foundSlugs).toStrictEqual([
         '/foo',
         '/how-to/golang-alexa-skills',
         '/how-to/polymorphic-pattern',

--- a/tests/utils/find-articles-from-slugs.test.js
+++ b/tests/utils/find-articles-from-slugs.test.js
@@ -43,4 +43,14 @@ it('should correctly find featured articles given a set of requested articles', 
         '/how-to/golang-alexa-skills',
         '/how-to/polymorphic-pattern',
     ]);
+
+    const maxSize = 1;
+    foundSlugs = findArticlesFromSlugs(
+        allArticles,
+        requestedFeaturedSlugs,
+        maxSize
+    ).map(a => a.query_fields.slug);
+
+    // Since we only want a max of one, only consider the first slug to check
+    expect(foundSlugs).toStrictEqual(['/foo']);
 });

--- a/tests/utils/get-featured-articles.test.js
+++ b/tests/utils/get-featured-articles.test.js
@@ -1,0 +1,45 @@
+import { getFeaturedArticles } from '../../src/utils/setup/on-create-page';
+
+it('should correctly find featured articles given a set of requested articles', () => {
+    let requestedFeaturedSlugs = [
+        '/quickstart/java-setup-crud-operations',
+        '/how-to/golang-alexa-skills',
+        '/how-to/polymorphic-pattern',
+    ];
+
+    const allArticles = [
+        '/foo',
+        '/how-to/golang-alexa-skills',
+        '/how-to/polymorphic-pattern',
+        '/quickstart/java-setup-crud-operations',
+        '/quickstart/csharp',
+    ].map(slug => ({
+        query_fields: {
+            slug,
+        },
+    }));
+
+    let result = getFeaturedArticles(allArticles, requestedFeaturedSlugs).map(
+        a => a.query_fields.slug
+    );
+
+    // All articles were found, so we should get them back in order
+    expect(result).toStrictEqual(requestedFeaturedSlugs);
+
+    requestedFeaturedSlugs = [
+        '/quickstart',
+        '/how-to',
+        '/how-to/polymorphic-pattern',
+    ];
+
+    result = getFeaturedArticles(allArticles, requestedFeaturedSlugs).map(
+        a => a.query_fields.slug
+    );
+
+    // The first two were not found, so return the 0th and 1st elements (instead of null)
+    expect(result).toStrictEqual([
+        '/foo',
+        '/how-to/golang-alexa-skills',
+        '/how-to/polymorphic-pattern',
+    ]);
+});

--- a/tests/utils/get-learn-page-filters.test.js
+++ b/tests/utils/get-learn-page-filters.test.js
@@ -28,9 +28,7 @@ it('should correctly create filters for the learn page based on article tags', (
         },
     ];
 
-    const result = getLearnPageFilters(allArticles);
-    const languages = result.languages;
-    const products = result.products;
+    const { languages, products } = getLearnPageFilters(allArticles);
 
     const expectedLanguages = {
         node: {

--- a/tests/utils/get-learn-page-filters.test.js
+++ b/tests/utils/get-learn-page-filters.test.js
@@ -28,9 +28,9 @@ it('should correctly create filters for the learn page based on article tags', (
         },
     ];
 
-    let result = getLearnPageFilters(allArticles);
-    let languages = result.languages;
-    let products = result.products;
+    const result = getLearnPageFilters(allArticles);
+    const languages = result.languages;
+    const products = result.products;
 
     const expectedLanguages = {
         node: {

--- a/tests/utils/get-learn-page-filters.test.js
+++ b/tests/utils/get-learn-page-filters.test.js
@@ -28,8 +28,6 @@ it('should correctly create filters for the learn page based on article tags', (
         },
     ];
 
-    const { languages, products } = getLearnPageFilters(allArticles);
-
     const expectedLanguages = {
         node: {
             count: 1,
@@ -77,6 +75,8 @@ it('should correctly create filters for the learn page based on article tags', (
             },
         },
     };
+
+    const { languages, products } = getLearnPageFilters(allArticles);
 
     expect(languages).toStrictEqual(expectedLanguages);
     expect(products).toStrictEqual(expectedProducts);

--- a/tests/utils/get-learn-page-filters.test.js
+++ b/tests/utils/get-learn-page-filters.test.js
@@ -1,0 +1,85 @@
+import { getLearnPageFilters } from '../../src/utils/setup/on-create-page';
+
+it('should correctly create filters for the learn page based on article tags', () => {
+    const allArticles = [
+        {
+            query_fields: {
+                languages: ['node', 'react'],
+                products: ['atlas', 'stitch'],
+            },
+        },
+        {
+            query_fields: {
+                languages: ['python', 'react'],
+                products: ['server'],
+            },
+        },
+        {
+            query_fields: {
+                languages: ['python', 'react'],
+                products: ['server'],
+            },
+        },
+        {
+            query_fields: {
+                languages: [],
+                products: ['server', 'stitch'],
+            },
+        },
+    ];
+
+    let result = getLearnPageFilters(allArticles);
+    let languages = result.languages;
+    let products = result.products;
+
+    const expectedLanguages = {
+        node: {
+            count: 1,
+            products: {
+                atlas: 1,
+                stitch: 1,
+            },
+        },
+        python: {
+            count: 2,
+            products: {
+                server: 2,
+            },
+        },
+        react: {
+            count: 3,
+            products: {
+                atlas: 1,
+                server: 2,
+                stitch: 1,
+            },
+        },
+    };
+
+    const expectedProducts = {
+        atlas: {
+            count: 1,
+            languages: {
+                node: 1,
+                react: 1,
+            },
+        },
+        server: {
+            count: 3,
+            languages: {
+                python: 2,
+                react: 2,
+            },
+        },
+        stitch: {
+            count: 2,
+            languages: {
+                node: 1,
+                react: 1,
+            },
+        },
+    };
+
+    expect(languages).toStrictEqual(expectedLanguages);
+    expect(products).toStrictEqual(expectedProducts);
+});


### PR DESCRIPTION
This PR does a few things:

- Refactors logic to generate the filters for the learn page to not repeatedly call stitch. Instead we use the article objects we have to update language/product values.
- Cleans up var names from a prior PR
- Adds testing for both generating the filters and getting featured articles
- Adds a `utils` subdirectory in `/tests` with a simple config (since this is mainly for js helpers, not components).