### PR TITLE
Misc Design Improvements

### DIFF
--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -22,7 +22,9 @@ const ArticleCard = styled(Card)`
     flex: 1 1 360px;
 `;
 
-const CenterBlock = styled('div')`
+const HasMoreButtonContainer = styled('div')`
+    margin-bottom: ${size.large};
+    margin-top: ${size.large};
     text-align: center;
 `;
 
@@ -44,7 +46,7 @@ export default React.memo(({ items = [], limit = 9 }) => {
                 ))}
             </CardContainer>
             {hasMore && (
-                <CenterBlock>
+                <HasMoreButtonContainer>
                     <Button
                         secondary
                         pagination
@@ -52,7 +54,7 @@ export default React.memo(({ items = [], limit = 9 }) => {
                     >
                         Load more
                     </Button>
-                </CenterBlock>
+                </HasMoreButtonContainer>
             )}
         </>
     );

--- a/src/components/dev-hub/codeblock.js
+++ b/src/components/dev-hub/codeblock.js
@@ -29,7 +29,7 @@ const CopyContainer = styled('div')`
 `;
 
 const StyledCode = styled(Code)`
-    border-radius: ${size.small};
+    border-radius: ${size.xsmall};
     line-height: ${lineHeight.xsmall};
     padding-right: ${size.xlarge};
     padding-top: ${size.large};

--- a/src/components/dev-hub/select.js
+++ b/src/components/dev-hub/select.js
@@ -181,7 +181,7 @@ const FormSelect = ({
                 {...extraProps}
             >
                 <P collapse>{selectText}</P>
-                <ArrowheadIcon down={showOptions} />
+                <ArrowheadIcon down={!showOptions} />
             </SelectedOption>
             {showOptions && (
                 <Options narrow={narrow}>

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -59,7 +59,7 @@ const Article = styled('article')`
 `;
 
 const StyledFilterBar = styled(FilterBar)`
-    padding-bottom: ${size.default};
+    padding-bottom: ${size.medium};
 `;
 
 const parseArticles = arr =>


### PR DESCRIPTION
This PR adds a few more design improvements:

1. Changes codeblock border radius to 8px from 10px
2. Bumps the bottom padding on the learn page filter bar to 20px
3. Flips the arrowhead on filters for open and close
4. Adds margin to the "has more" button in the card list component.