### PR TITLE
Support Featured Articles in pageGroups

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -36,6 +36,10 @@ let RESOLVED_REF_DOC_MAPPING = {};
 // stich client connection
 let stitchClient;
 
+// Featured articles for home/learn pages
+let homeFeaturedArticles;
+let learnFeaturedArticles;
+
 const setupStitch = () => {
     return new Promise(resolve => {
         stitchClient = Stitch.hasAppClient(SNOOTY_STITCH_ID)
@@ -157,6 +161,12 @@ exports.createPages = async ({ actions }) => {
     ]);
 
     const allSeries = metadata.pageGroups;
+
+    // featured aricles are in pageGroups but not series, so we remove them
+    homeFeaturedArticles = allSeries.home;
+    learnFeaturedArticles = allSeries.learn;
+    delete allSeries.home;
+    delete allSeries.learn;
     PAGES.forEach(page => {
         const pageNodes = RESOLVED_REF_DOC_MAPPING[page];
 
@@ -226,4 +236,10 @@ exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
 };
 
 exports.onCreatePage = async ({ page, actions }) =>
-    onCreatePage(page, actions, stitchClient);
+    onCreatePage(
+        page,
+        actions,
+        stitchClient,
+        homeFeaturedArticles,
+        learnFeaturedArticles
+    );


### PR DESCRIPTION
This PR updates the logic for supporting featured articles to use the `pageGroups` field from Stitch's metadata. We still have a fallback case for if this has not been implemented yet by the authors or the parser.

Instead of diving into data from the `getMetadata` hook, we store the values from a single stitch call in gatsby-node and pass them through.

This will conflict with the refactor work, but I expect this PR to go in first, so I will handle conflicts on the refactor branch.