### PR TITLE
Pull saveAssetFiles, constructDbFilter Out of gatsby-node

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,8 +1,8 @@
 const path = require('path');
 const dlv = require('dlv');
-const fs = require('fs').promises;
-const mkdirp = require('mkdirp');
 const { Stitch, AnonymousCredential } = require('mongodb-stitch-server-sdk');
+const { constructDbFilter } = require('./src/utils/setup/construct-db-filter');
+const { saveAssetFiles } = require('./src/utils/setup/save-asset-files');
 const {
     validateEnvVariables,
 } = require('./src/utils/setup/validate-env-variables');
@@ -15,7 +15,6 @@ const { getSeriesArticles } = require('./src/utils/get-series-articles');
 const { getTemplate } = require('./src/utils/get-template');
 const {
     DOCUMENTS_COLLECTION,
-    ASSETS_COLLECTION,
     METADATA_COLLECTION,
     SNOOTY_STITCH_ID,
 } = require('./src/build-constants');
@@ -54,43 +53,6 @@ const setupStitch = () => {
     });
 };
 
-const saveAssetFile = async asset => {
-    return new Promise((resolve, reject) => {
-        // Create nested directories as specified by the asset filenames if they do not exist
-        mkdirp(path.join('static', path.dirname(asset.filename)), err => {
-            if (err) return reject(err);
-            fs.writeFile(
-                path.join('static', asset.filename),
-                asset.data.buffer,
-                'binary',
-                err => {
-                    if (err) reject(err);
-                }
-            );
-            resolve();
-        });
-    });
-};
-
-// Write all assets to static directory
-const saveAssetFiles = async assets => {
-    const promises = [];
-    const assetQuery = { _id: { $in: assets } };
-    const assetDataDocuments = await stitchClient.callFunction(
-        'fetchDocuments',
-        [DB, ASSETS_COLLECTION, assetQuery]
-    );
-    assetDataDocuments.forEach(asset => {
-        promises.push(saveAssetFile(asset));
-    });
-    return Promise.all(promises);
-};
-
-const constructDbFilter = () => ({
-    page_id: { $regex: new RegExp(`^${PAGE_ID_PREFIX}/*`) },
-    commit_hash: process.env.COMMIT_HASH || { $exists: false },
-});
-
 const getRelatedPagesWithImages = pageNodes => {
     const related = dlv(pageNodes, 'query_fields.related', []);
     const relatedPageInfo = related.map(r => ({
@@ -117,7 +79,7 @@ exports.sourceNodes = async () => {
 
     const { parserBranch, project, user } = metadata;
     PAGE_ID_PREFIX = `${project}/${user}/${parserBranch}`;
-    const query = constructDbFilter();
+    const query = constructDbFilter(PAGE_ID_PREFIX);
     const documents = await stitchClient.callFunction('fetchDocuments', [
         DB,
         DOCUMENTS_COLLECTION,
@@ -149,7 +111,7 @@ exports.sourceNodes = async () => {
         }
     });
 
-    await saveAssetFiles(assets);
+    await saveAssetFiles(assets, stitchClient);
 };
 
 exports.createPages = async ({ actions }) => {
@@ -157,7 +119,7 @@ exports.createPages = async ({ actions }) => {
     const metadata = await stitchClient.callFunction('fetchDocument', [
         DB,
         METADATA_COLLECTION,
-        constructDbFilter(),
+        constructDbFilter(PAGE_ID_PREFIX),
     ]);
 
     const allSeries = metadata.pageGroups;

--- a/src/utils/setup/construct-db-filter.js
+++ b/src/utils/setup/construct-db-filter.js
@@ -1,0 +1,6 @@
+const constructDbFilter = pageIdPrefix => ({
+    page_id: { $regex: new RegExp(`^${pageIdPrefix}/*`) },
+    commit_hash: process.env.COMMIT_HASH || { $exists: false },
+});
+
+module.exports = { constructDbFilter };

--- a/src/utils/setup/save-asset-files.js
+++ b/src/utils/setup/save-asset-files.js
@@ -1,0 +1,42 @@
+const fs = require('fs').promises;
+const mkdirp = require('mkdirp');
+const path = require('path');
+const { ASSETS_COLLECTION } = require('../../build-constants');
+const { getMetadata } = require('../get-metadata');
+
+const metadata = getMetadata();
+const DB = metadata.database;
+
+const saveAssetFile = async asset => {
+    return new Promise((resolve, reject) => {
+        // Create nested directories as specified by the asset filenames if they do not exist
+        mkdirp(path.join('static', path.dirname(asset.filename)), err => {
+            if (err) return reject(err);
+            fs.writeFile(
+                path.join('static', asset.filename),
+                asset.data.buffer,
+                'binary',
+                err => {
+                    if (err) reject(err);
+                }
+            );
+            resolve();
+        });
+    });
+};
+
+// Write all assets to static directory
+const saveAssetFiles = async (assets, stitchClient) => {
+    const promises = [];
+    const assetQuery = { _id: { $in: assets } };
+    const assetDataDocuments = await stitchClient.callFunction(
+        'fetchDocuments',
+        [DB, ASSETS_COLLECTION, assetQuery]
+    );
+    assetDataDocuments.forEach(asset => {
+        promises.push(saveAssetFile(asset));
+    });
+    return Promise.all(promises);
+};
+
+module.exports = { saveAssetFiles };

--- a/tests/utils/construct-db-filter.test.js
+++ b/tests/utils/construct-db-filter.test.js
@@ -1,0 +1,23 @@
+import { constructDbFilter } from '../../src/utils/setup/construct-db-filter';
+
+it('should properly create a filter for the specified environment', () => {
+    const commitHash = 'COMMIT_HASH';
+    expect(process.env.COMMIT_HASH).toBeUndefined();
+    process.env.COMMIT_HASH = commitHash;
+    const pageIdPrefix = 'devhub/testUser/master';
+    let filter = constructDbFilter(pageIdPrefix);
+
+    // Should have a regex
+    expect(filter.page_id['$regex']).toStrictEqual(
+        new RegExp(`^${pageIdPrefix}/*`)
+    );
+
+    // Should have a commit hash
+    expect(filter.commit_hash).toBe(commitHash);
+
+    delete process.env.COMMIT_HASH;
+    expect(process.env.COMMIT_HASH).toBeUndefined();
+    // Should now show the commit hash does not exist in the filter
+    filter = constructDbFilter(pageIdPrefix);
+    expect(filter.commit_hash).toStrictEqual({ $exists: false });
+});


### PR DESCRIPTION
This PR pulls three more helper functions out of gatsby node, and adds testing for `constructDBFilter`. `saveAssetFiles` is a bit more difficult to test since it involves file I/O, so I left that out.