### PR TITLE
add trailing slash to articleUrl

### DIFF
--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -157,7 +157,7 @@ const Article = props => {
     }
     const tagList = getTagLinksFromMeta(meta);
     const articleTitle = dlv(meta.title, [0, 'value'], thisPage);
-    const articleUrl = `${siteUrl}/${thisPage}`;
+    const articleUrl = `${siteUrl}/${thisPage}/`;
     const headingNodes = findSectionHeadings(
         getNestedValue(['ast', 'children'], __refDocMapping),
         'type',


### PR DESCRIPTION
Our CDN provider redirects pages to the trailing slash version, so we should use that in our links.