### PR TITLE
add border and background for charts

### DIFF
--- a/src/components/dev-hub/chart.js
+++ b/src/components/dev-hub/chart.js
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { css } from '@emotion/core';
 import { buildQueryString } from '../../utils/query-string';
 import styled from '@emotion/styled';
+import { colorMap } from './theme';
 
 const DEFAULT_CHART_AUTOREFRESH = 3600;
 const DEFAULT_CHART_HEIGHT = '570';
@@ -40,7 +41,9 @@ const buildChartUrl = options => {
 };
 
 const StyledChart = styled('iframe')`
-    border: none;
+    background: ${({ theme }) =>
+        theme === 'light' ? colorMap.devWhite : 'transparent'};
+    border: 1px solid ${colorMap.devWhite};
     ${({ customAlign }) => getAlignment(customAlign)};
     max-width: 100%;
 `;
@@ -50,6 +53,7 @@ const Chart = ({ nodeData: { options } }) => {
     return (
         <StyledChart
             customAlign={options.align}
+            theme={options.theme}
             height={options.height || DEFAULT_CHART_HEIGHT}
             title={options.title}
             src={chartSrc}

--- a/src/components/dev-hub/stories/chart.stories.mdx
+++ b/src/components/dev-hub/stories/chart.stories.mdx
@@ -9,16 +9,32 @@ We support embedded MongoDB Charts through the component factory for articles.
 
 <Preview>
     <Story name="Chart">
-        <Chart
-            nodeData={{
-                options: {
-                    id: '6f921f0c-a1ee-4106-839c-412fad3c64e7',
-                    width: 760,
-                    align: 'center',
-                    height: 570,
-                    url: 'https://charts.mongodb.com/charts-coronavirus-lwlvn',
-                },
-            }}
-        />
+        <div>
+            <Chart
+                nodeData={{
+                    options: {
+                        id: '6f921f0c-a1ee-4106-839c-412fad3c64e7',
+                        width: 760,
+                        align: 'center',
+                        height: 570,
+                        url:
+                            'https://charts.mongodb.com/charts-coronavirus-lwlvn',
+                        theme: 'light',
+                    },
+                }}
+            />
+            <Chart
+                nodeData={{
+                    options: {
+                        id: '9b2d8fb8-bd0d-4394-8153-1aebef8ec284',
+                        width: 760,
+                        align: 'center',
+                        height: 570,
+                        url:
+                            'https://charts.mongodb.com/charts-coronavirus-lwlvn',
+                    },
+                }}
+            />
+        </div>
     </Story>
 </Preview>


### PR DESCRIPTION
Both themese get a `devWhite` border, but the light theme also gets a white background in order to legibly render the text

Light theme before:
![image](https://user-images.githubusercontent.com/514026/77784373-cbe8e380-7030-11ea-9b48-e731912d7585.png)
Light theme after:
![Screen Shot 2020-03-27 at 1 31 50 PM](https://user-images.githubusercontent.com/514026/77784404-d6a37880-7030-11ea-843d-6af70028b668.png)
Dark theme:
![Screen Shot 2020-03-27 at 1 32 18 PM](https://user-images.githubusercontent.com/514026/77784425-df944a00-7030-11ea-90db-bbc5980e2f22.png)
