### PR TITLE
Add loading state to events hook

### DIFF
--- a/src/components/dev-hub/event-list.js
+++ b/src/components/dev-hub/event-list.js
@@ -13,6 +13,7 @@ const EventsPreview = styled('div')`
     display: flex;
     flex-direction: row;
     justify-content: space-between;
+    min-height: ${size.xxlarge};
     width: 100%;
     @media ${screenSize.upToMedium} {
         flex-direction: column;

--- a/src/components/dev-hub/event-list.js
+++ b/src/components/dev-hub/event-list.js
@@ -39,11 +39,12 @@ const CenterBlock = styled('div')`
 `;
 
 export const EventsListPreview = () => {
-    const [events, error] = useEventData(EVENTS_API);
+    const [events, error, isLoading] = useEventData(EVENTS_API);
     const previews = events ? events.slice(0, 3) : [];
 
     return (
         <EventsPreview>
+            {isLoading && <P>Loading...</P>}
             {!error &&
                 !!previews.length &&
                 previews.map(event => <Event key={event.url} event={event} />)}

--- a/src/hooks/use-event-data.js
+++ b/src/hooks/use-event-data.js
@@ -12,8 +12,10 @@ export const removePastEvents = events => {
 const useEventData = url => {
     const [events, setEvents] = useState(null);
     const [error, setError] = useState(null);
+    const [isLoading, setIsLoading] = useState(false);
     useEffect(() => {
         const getData = async () => {
+            setIsLoading(true);
             try {
                 const data = await fetch(url, {
                     credentials: 'same-origin',
@@ -24,10 +26,12 @@ const useEventData = url => {
                 if (data) {
                     const parsedData = await data.json();
                     const upcomingEvents = removePastEvents(parsedData);
+                    setIsLoading(false);
                     setError(null);
                     setEvents(upcomingEvents.reverse());
                 }
             } catch (e) {
+                setIsLoading(false);
                 setError(e);
                 setEvents(null);
             }
@@ -35,7 +39,7 @@ const useEventData = url => {
         getData();
     }, [url]);
 
-    return [events, error];
+    return [events, error, isLoading];
 };
 
 export default useEventData;

--- a/src/pages/community/events.js
+++ b/src/pages/community/events.js
@@ -25,7 +25,7 @@ const breadcrumbs = [
 ];
 
 export default () => {
-    const [events, error] = useEventData(EVENTS_API);
+    const [events, error, isLoading] = useEventData(EVENTS_API);
 
     const metadata = useSiteMetadata();
     return (
@@ -49,7 +49,7 @@ export default () => {
                     {/* TODO: Add FilterBar */}
                     <H3>All Events</H3>
                 </EventsFilter>
-                {!events && !error && <P>Loading...</P>}
+                {isLoading && <P>Loading...</P>}
                 {events && <EventsList items={events} />}
                 {error && <P>Check back later for upcoming events</P>}
             </section>


### PR DESCRIPTION
The community index page jumps a bit because it loads data from the events API. I noticed the community index page was missing a loading state, so I added it to the `useEventData` hook and copied the simple loading state from the events page into the `EventsListPreview` component