### PR TITLE
Full-width Nav and Footer

### DIFF
--- a/src/components/dev-hub/global-footer.js
+++ b/src/components/dev-hub/global-footer.js
@@ -12,6 +12,9 @@ import Youtube from './icons/youtube';
 import Twitch from './icons/twitch';
 import { P } from './text';
 
+// Logo size 150px + 64px padding right
+const LOGO_DESKTOP_COLUMN_SIZE = 214;
+
 const siteLinks = [
     {
         name: 'Developer Hub',
@@ -75,16 +78,19 @@ const iconLinks = [
 ];
 const GlobalFooter = styled('footer')`
     background: ${colorMap.greyDarkThree};
+    width: 100%;
+`;
+const FooterContent = styled('div')`
     color: ${colorMap.greyLightTwo};
     display: grid;
     @media ${screenSize.mediumAndUp} {
-        grid-gap: 0 ${size.large};
+        grid-gap: 0 ${size.xlarge};
         grid-template-areas:
             'logo list'
             'logo icons'
             'logo copyright';
-        grid-template-columns: 25% 70%;
-        padding: ${size.large};
+        grid-template-columns: ${LOGO_DESKTOP_COLUMN_SIZE}px auto;
+        padding: ${size.large} ${size.default};
     }
     @media ${screenSize.upToMedium} {
         grid-template-areas:
@@ -94,6 +100,9 @@ const GlobalFooter = styled('footer')`
         grid-template-columns: 49% 49%;
         padding: 0 ${size.default};
     }
+    margin: 0 auto;
+    max-width: ${size.maxWidth};
+    width: 100%;
 `;
 const logoStyles = css`
     @media ${screenSize.upToMedium} {
@@ -108,7 +117,7 @@ const LogoContainer = styled('section')`
     justify-content: center;
     @media ${screenSize.mediumAndUp} {
         border-right: 1px solid ${colorMap.greyLightTwo};
-        padding: ${size.large};
+        padding-right: ${size.xlarge};
     }
     @media ${screenSize.upToMedium} {
         border-top: 1px solid ${colorMap.greyLightTwo};
@@ -189,18 +198,23 @@ const getLinksList = (link, isListType) => (
 export default () => {
     return (
         <GlobalFooter>
-            <LogoContainer>
-                <FooterLink css={iconstyles} href="https://www.mongodb.com/">
-                    <MongodbLogoIcon css={logoStyles} />
-                </FooterLink>
-            </LogoContainer>
-            <LinksList>
-                {siteLinks.map(list => getLinksList(list, true))}
-            </LinksList>
-            <IconList>
-                {iconLinks.map(list => getLinksList(list, false))}
-            </IconList>
-            <Copyright collapse>© MongoDB, Inc.</Copyright>
+            <FooterContent>
+                <LogoContainer>
+                    <FooterLink
+                        css={iconstyles}
+                        href="https://www.mongodb.com/"
+                    >
+                        <MongodbLogoIcon css={logoStyles} />
+                    </FooterLink>
+                </LogoContainer>
+                <LinksList>
+                    {siteLinks.map(list => getLinksList(list, true))}
+                </LinksList>
+                <IconList>
+                    {iconLinks.map(list => getLinksList(list, false))}
+                </IconList>
+                <Copyright collapse>© MongoDB, Inc.</Copyright>
+            </FooterContent>
         </GlobalFooter>
     );
 };

--- a/src/components/dev-hub/global-nav.js
+++ b/src/components/dev-hub/global-nav.js
@@ -7,12 +7,9 @@ import DevLeafDesktop from './icons/mdb-dev-leaf-desktop';
 import useMedia from '../../hooks/use-media';
 
 const GlobalNav = styled('nav')`
-    align-items: center;
     background-color: ${colorMap.greyDarkThree};
-    color: ${colorMap.greyLightOne};
     display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-start;
+    flex-direction: column;
     width: 100%;
     &:after {
         background: radial-gradient(circle, #3ebb8c 0%, #76d3b1 100%);
@@ -20,6 +17,16 @@ const GlobalNav = styled('nav')`
         height: 4px;
         width: 100%;
     }
+`;
+
+const NavContent = styled('div')`
+    align-items: center;
+    color: ${colorMap.greyLightOne};
+    display: flex;
+    flex-wrap: wrap;
+    margin: 0 auto;
+    max-width: ${size.maxWidth};
+    width: 100%;
 `;
 
 const NavLink = styled(Link)`
@@ -30,7 +37,7 @@ const NavLink = styled(Link)`
     text-decoration: none;
     &:hover,
     &[aria-current='page'] {
-        background-color: ${colorMap.devBlack};
+        background-color: ${colorMap.pageBackground};
     }
     @media ${screenSize.upToMedium} {
         font-size: ${fontSize.tiny};
@@ -56,12 +63,14 @@ export default () => {
     const isMobile = useMedia(screenSize.upToMedium);
     return (
         <GlobalNav>
-            <HomeLink to="/">
-                {!isMobile && <DevLeafDesktop width="185px" />}
-                {isMobile && <DevLeafMobile width={size.xxlarge} />}
-            </HomeLink>
-            <NavLink to="/learn">Learn</NavLink>
-            <NavLink to="/community">Community</NavLink>
+            <NavContent>
+                <HomeLink to="/">
+                    {!isMobile && <DevLeafDesktop width="185px" />}
+                    {isMobile && <DevLeafMobile width={size.xxlarge} />}
+                </HomeLink>
+                <NavLink to="/learn">Learn</NavLink>
+                <NavLink to="/community">Community</NavLink>
+            </NavContent>
         </GlobalNav>
     );
 };

--- a/src/components/dev-hub/global-nav.js
+++ b/src/components/dev-hub/global-nav.js
@@ -37,7 +37,7 @@ const NavLink = styled(Link)`
     text-decoration: none;
     &:hover,
     &[aria-current='page'] {
-        background-color: ${colorMap.pageBackground};
+        background-color: ${colorMap.greyDarkTwo};
     }
     @media ${screenSize.upToMedium} {
         font-size: ${fontSize.tiny};

--- a/src/components/dev-hub/layout.js
+++ b/src/components/dev-hub/layout.js
@@ -44,16 +44,18 @@ const globalStyles = css`
 
 const Main = styled('main')`
     /* ensure content takes up full space between header & footer*/
+    margin: 0 auto;
+    max-width: ${size.maxWidth};
     min-height: calc(100vh - 300px);
+    width: 100%;
 `;
 
 const GlobalWrapper = styled('div')`
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    margin: 0 auto;
-    max-width: ${size.maxWidth};
     min-height: 100vh;
+    width: 100%;
 `;
 export const StorybookLayout = ({ children }) => {
     return (


### PR DESCRIPTION
This PR updates the page layout to support a full-width nav and footer. The main logical change was moving `max-width` related info out of the global wrapper and into the nav, main, and footer, and constraining child elements to it.

The nav/footer changes are pretty similar in this way.

Other pages should look normal, I checked on Chrome/Firefox but some extra poking around the different pages just to confirm this would be great!

I also bumped the hover state color for the nav by request.

Dan is currently taking a look, but any changes forthcoming would likely be minor.

![Screen Shot 2020-03-31 at 1 46 16 PM](https://user-images.githubusercontent.com/9064401/78058842-e4ba0780-7356-11ea-9e2b-4d226dfa8c0b.png)
