### PR TITLE
Move env validation into onPreBootstrap part of the lifecycle

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -66,14 +66,9 @@ const getRelatedPagesWithImages = pageNodes => {
     return relatedPageInfo;
 };
 
+exports.onPreBootstrap = validateEnvVariables;
+
 exports.sourceNodes = async () => {
-    // setup env variables
-    const envResults = validateEnvVariables();
-
-    if (envResults.error) {
-        throw Error(envResults.message);
-    }
-
     // wait to connect to stitch
     await setupStitch();
 

--- a/src/utils/setup/validate-env-variables.js
+++ b/src/utils/setup/validate-env-variables.js
@@ -7,15 +7,10 @@ const validateEnvVariables = () => {
         !process.env.GATSBY_PARSER_USER ||
         !process.env.GATSBY_PARSER_BRANCH
     ) {
-        return {
-            error: true,
-            message: `${process.env.NODE_ENV} requires the variables GATSBY_SITE, GATSBY_PARSER_USER, and GATSBY_PARSER_BRANCH`,
-        };
+        throw new Error(
+            `${process.env.NODE_ENV} requires the variables GATSBY_SITE, GATSBY_PARSER_USER, and GATSBY_PARSER_BRANCH`
+        );
     }
-    // create split prefix for use in stitch function
-    return {
-        error: false,
-    };
 };
 
 module.exports.validateEnvVariables = validateEnvVariables;

--- a/tests/utils/validate-env-variables.test.js
+++ b/tests/utils/validate-env-variables.test.js
@@ -1,0 +1,28 @@
+import { validateEnvVariables } from '../../src/utils/setup/validate-env-variables';
+
+it('should properly require specific environment variables at build-time', () => {
+    const oldEnv = process.env;
+    process.env = {
+        ...oldEnv,
+    };
+
+    // jest requires the test function to be wrapped, otherwise the error is not caught
+    expect(() => {
+        validateEnvVariables();
+    }).toThrow();
+
+    process.env.GATSBY_SITE = 'devhub';
+    process.env.GATSBY_PARSER_USER = 'test-user';
+    // Should throw unless all three env vars are set
+    // GATSBY_SITE, GATSBY_PARSER_USER, GATSBY_PARSER_BRANCH
+    expect(() => {
+        validateEnvVariables();
+    }).toThrow();
+
+    process.env.GATSBY_PARSER_BRANCH = 'test-branch';
+    expect(() => {
+        validateEnvVariables();
+    }).not.toThrow();
+
+    process.env = oldEnv;
+});


### PR DESCRIPTION
I'm starting to refactor pieces of `gatsby-node` so we better match pieces of the Gatsby Node API based on what each Node API method is doing.

This piece moves some environment validation logic from the `sourceNodes` step of the lifecycle to the `onPreBootstrap` part of the lifecycle, because it is a better fit here. `sourceNodes` should simply be about pulling in data from any APIs, not validating env variables. `onPreBootstrap` runs earlier in the process and is for checking options and requirements.

As for the env validation itself, I decluttered an unnecessary return from it and instead just throw an error right in the function to abstract it from `gatsby-node`. I also added a quick test.