### PR TITLE
Move related pages helper out of gatsby node

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -34,7 +34,7 @@ const PAGE_ID_PREFIX = `${metadata.project}/${metadata.user}/${metadata.parserBr
 const PAGES = [];
 
 // in-memory object with key/value = filename/document
-let RESOLVED_REF_DOC_MAPPING = {};
+const slugContentMapping = {};
 
 // stich client connection
 let stitchClient;
@@ -67,7 +67,7 @@ exports.sourceNodes = async () => {
             PAGE_ID_PREFIX,
             assets,
             PAGES,
-            RESOLVED_REF_DOC_MAPPING
+            slugContentMapping
         );
     });
 
@@ -90,7 +90,7 @@ exports.createPages = async ({ actions }) => {
     delete allSeries.home;
     delete allSeries.learn;
     PAGES.forEach(page => {
-        const pageNodes = RESOLVED_REF_DOC_MAPPING[page];
+        const pageNodes = slugContentMapping[page];
 
         if (pageNodes && Object.keys(pageNodes).length > 0) {
             const template = getTemplate(
@@ -100,7 +100,7 @@ exports.createPages = async ({ actions }) => {
             if (pageNodes.query_fields) {
                 const relatedPages = getRelatedPagesWithImages(
                     pageNodes,
-                    RESOLVED_REF_DOC_MAPPING
+                    slugContentMapping
                 );
                 pageNodes['query_fields'].related = relatedPages;
             }
@@ -125,7 +125,7 @@ exports.createPages = async ({ actions }) => {
             type,
             createPage,
             metadata,
-            RESOLVED_REF_DOC_MAPPING,
+            slugContentMapping,
             stitchClient
         )
     );

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,10 +1,12 @@
 const path = require('path');
-const dlv = require('dlv');
 const { constructDbFilter } = require('./src/utils/setup/construct-db-filter');
 const { initStitch } = require('./src/utils/setup/init-stich');
 const {
     postprocessDocument,
 } = require('./src/utils/setup/postprocess-document');
+const {
+    getRelatedPagesWithImages,
+} = require('./src/utils/setup/get-related-pages-with-images');
 const { saveAssetFiles } = require('./src/utils/setup/save-asset-files');
 const {
     validateEnvVariables,
@@ -40,19 +42,6 @@ let stitchClient;
 // Featured articles for home/learn pages
 let homeFeaturedArticles;
 let learnFeaturedArticles;
-
-const getRelatedPagesWithImages = pageNodes => {
-    const related = dlv(pageNodes, 'query_fields.related', []);
-    const relatedPageInfo = related.map(r => ({
-        image: dlv(
-            RESOLVED_REF_DOC_MAPPING,
-            [r.target, 'query_fields', 'atf-image'],
-            null
-        ),
-        ...r,
-    }));
-    return relatedPageInfo;
-};
 
 exports.onPreBootstrap = validateEnvVariables;
 
@@ -109,7 +98,10 @@ exports.createPages = async ({ actions }) => {
             );
             const slug = getPageSlug(page);
             if (pageNodes.query_fields) {
-                const relatedPages = getRelatedPagesWithImages(pageNodes);
+                const relatedPages = getRelatedPagesWithImages(
+                    pageNodes,
+                    RESOLVED_REF_DOC_MAPPING
+                );
                 pageNodes['query_fields'].related = relatedPages;
             }
             const seriesArticles = getSeriesArticles(allSeries, slug);

--- a/src/utils/setup/get-related-pages-with-images.js
+++ b/src/utils/setup/get-related-pages-with-images.js
@@ -1,0 +1,16 @@
+const dlv = require('dlv');
+
+const getRelatedPagesWithImages = (pageNodes, RESOLVED_REF_DOC_MAPPING) => {
+    const related = dlv(pageNodes, 'query_fields.related', []);
+    const relatedPageInfo = related.map(r => ({
+        image: dlv(
+            RESOLVED_REF_DOC_MAPPING,
+            [r.target, 'query_fields', 'atf-image'],
+            null
+        ),
+        ...r,
+    }));
+    return relatedPageInfo;
+};
+
+module.exports = { getRelatedPagesWithImages };

--- a/tests/utils/get-related-pages-with-images.test.js
+++ b/tests/utils/get-related-pages-with-images.test.js
@@ -1,0 +1,36 @@
+import { getRelatedPagesWithImages } from '../../src/utils/setup/get-related-pages-with-images';
+
+it('should get pages and images for posts related to an article', () => {
+    const articleData = {
+        '/foo': {
+            query_fields: {
+                'atf-image': 'IMAGE_FILE',
+            },
+        },
+        '/bar': {
+            query_fields: {},
+        },
+    };
+    const blankArticle = {
+        query_fields: {},
+    };
+    const articleWithRelatedImage = {
+        query_fields: {
+            related: [{ target: '/foo' }],
+        },
+    };
+    const articleWithoutRelatedImage = {
+        query_fields: {
+            related: [{ target: '/bar' }],
+        },
+    };
+
+    expect(getRelatedPagesWithImages(blankArticle, articleData)).toEqual([]);
+    expect(
+        getRelatedPagesWithImages(articleWithRelatedImage, articleData)[0].image
+    ).toBe('IMAGE_FILE');
+    expect(
+        getRelatedPagesWithImages(articleWithoutRelatedImage, articleData)[0]
+            .image
+    ).toBeNull();
+});

--- a/tests/utils/get-related-pages-with-images.test.js
+++ b/tests/utils/get-related-pages-with-images.test.js
@@ -28,7 +28,7 @@ it('should get pages and images for posts related to an article', () => {
     expect(getRelatedPagesWithImages(blankArticle, articleData)).toEqual([]);
     expect(
         getRelatedPagesWithImages(articleWithRelatedImage, articleData)[0].image
-    ).toBe('IMAGE_FILE');
+    ).toBe(articleData['/foo'].query_fields['atf-image']);
     expect(
         getRelatedPagesWithImages(articleWithoutRelatedImage, articleData)[0]
             .image


### PR DESCRIPTION
Continuing with cleaning up `gatsby-node`, this PR moves a helper for related images out of `gatsby-node` and adds a test for it.

At this point `gatsby-node` just contains implementations of the Gatsby Node API methods, which is much cleaner!