### PR TITLE
Fix MASTER to PROD for versions script

### DIFF
--- a/versions.sh
+++ b/versions.sh
@@ -27,4 +27,4 @@ log_flags=(
 
 echo
 echo changes in staging but not production:
-git log "${log_flags[@]}" $MASTER..$STAGING
+git log "${log_flags[@]}" $PROD..$STAGING


### PR DESCRIPTION
The versions script was using `MASTER` instead of `PROD` for the branch alias, so it was not picking up the right branch to check