### PR TITLE
Extract Document Postprocessing

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -80,12 +80,13 @@ exports.sourceNodes = async () => {
     const assets = [];
     documents.forEach(doc => {
         // Mimics onCreateNode
-        // TODO: Implement using createNode, onCreateNode
+        const { page_id, ...nodeContent } = doc;
+        const slug = page_id.replace(`${PAGE_ID_PREFIX}/`, '');
         postprocessDocument(
-            doc,
+            nodeContent,
+            slug,
             assets,
             PAGES,
-            PAGE_ID_PREFIX,
             RESOLVED_REF_DOC_MAPPING
         );
     });

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -26,7 +26,7 @@ const {
 const metadata = getMetadata();
 
 const DB = metadata.database;
-let PAGE_ID_PREFIX;
+const PAGE_ID_PREFIX = `${metadata.project}/${metadata.user}/${metadata.parserBranch}`;
 
 // different types of references
 const PAGES = [];
@@ -65,8 +65,6 @@ exports.sourceNodes = async () => {
     // wait to connect to stitch
     stitchClient = await initStitch();
 
-    const { parserBranch, project, user } = metadata;
-    PAGE_ID_PREFIX = `${project}/${user}/${parserBranch}`;
     const query = constructDbFilter(PAGE_ID_PREFIX);
     const documents = await stitchClient.callFunction('fetchDocuments', [
         DB,
@@ -80,11 +78,9 @@ exports.sourceNodes = async () => {
     const assets = [];
     documents.forEach(doc => {
         // Mimics onCreateNode
-        const { page_id, ...nodeContent } = doc;
-        const slug = page_id.replace(`${PAGE_ID_PREFIX}/`, '');
         postprocessDocument(
-            nodeContent,
-            slug,
+            doc,
+            PAGE_ID_PREFIX,
             assets,
             PAGES,
             RESOLVED_REF_DOC_MAPPING

--- a/src/utils/setup/postprocess-document.js
+++ b/src/utils/setup/postprocess-document.js
@@ -4,12 +4,14 @@ const { getNestedValue } = require('../get-nested-value');
   Modifies in-memory content based on what type of document (image, article)
 */
 const postprocessDocument = (
-    nodeContent,
-    slug,
+    doc,
+    PAGE_ID_PREFIX,
     assetsArray,
     pagesArray,
     RESOLVED_REF_DOC_MAPPING
 ) => {
+    const { page_id, ...nodeContent } = doc;
+    const slug = page_id.replace(`${PAGE_ID_PREFIX}/`, '');
     // Add contents to in-memory slug to content mapping
     RESOLVED_REF_DOC_MAPPING[slug] = nodeContent;
     const pageNode = getNestedValue(['ast', 'children'], nodeContent);

--- a/src/utils/setup/postprocess-document.js
+++ b/src/utils/setup/postprocess-document.js
@@ -4,23 +4,21 @@ const { getNestedValue } = require('../get-nested-value');
   Modifies in-memory content based on what type of document (image, article)
 */
 const postprocessDocument = (
-    doc,
+    nodeContent,
+    slug,
     assetsArray,
     pagesArray,
-    PAGE_ID_PREFIX,
     RESOLVED_REF_DOC_MAPPING
 ) => {
-    const { page_id, ...rest } = doc;
-    const slug = page_id.replace(`${PAGE_ID_PREFIX}/`, '');
     // Add contents to in-memory slug to content mapping
-    RESOLVED_REF_DOC_MAPPING[slug] = rest;
-    const pageNode = getNestedValue(['ast', 'children'], rest);
-    const filename = getNestedValue(['filename'], rest) || '';
+    RESOLVED_REF_DOC_MAPPING[slug] = nodeContent;
+    const pageNode = getNestedValue(['ast', 'children'], nodeContent);
+    const filename = getNestedValue(['filename'], nodeContent) || '';
     const isArticlePage =
         !filename.includes('images/') && filename.endsWith('.txt');
     // Add any static assets to in-memory collection of assets to store
     if (pageNode) {
-        assetsArray.push(...rest.static_assets);
+        assetsArray.push(...nodeContent.static_assets);
     }
     // Add any article pages to in-memory collection of pages to create
     if (isArticlePage) {

--- a/src/utils/setup/postprocess-document.js
+++ b/src/utils/setup/postprocess-document.js
@@ -1,0 +1,31 @@
+const { getNestedValue } = require('../get-nested-value');
+
+/*
+  Modifies in-memory content based on what type of document (image, article)
+*/
+const postprocessDocument = (
+    doc,
+    assetsArray,
+    pagesArray,
+    PAGE_ID_PREFIX,
+    RESOLVED_REF_DOC_MAPPING
+) => {
+    const { page_id, ...rest } = doc;
+    const slug = page_id.replace(`${PAGE_ID_PREFIX}/`, '');
+    // Add contents to in-memory slug to content mapping
+    RESOLVED_REF_DOC_MAPPING[slug] = rest;
+    const pageNode = getNestedValue(['ast', 'children'], rest);
+    const filename = getNestedValue(['filename'], rest) || '';
+    const isArticlePage =
+        !filename.includes('images/') && filename.endsWith('.txt');
+    // Add any static assets to in-memory collection of assets to store
+    if (pageNode) {
+        assetsArray.push(...rest.static_assets);
+    }
+    // Add any article pages to in-memory collection of pages to create
+    if (isArticlePage) {
+        pagesArray.push(slug);
+    }
+};
+
+module.exports = { postprocessDocument };

--- a/tests/utils/postprocess-document.test.js
+++ b/tests/utils/postprocess-document.test.js
@@ -1,0 +1,50 @@
+import { postprocessDocument } from '../../src/utils/setup/postprocess-document';
+
+describe('Should properly postprocess a document node after it is fetched', () => {
+    const articleSlug = 'article/test-article';
+    const articleNodeContent = {
+        ast: {
+            children: [],
+        },
+        filename: `${articleSlug}.txt`,
+        static_assets: ['STATIC_ASSET'],
+    };
+    const imageSlug = 'image/test-image';
+    const imageNodeContent = {
+        ast: {
+            children: [],
+        },
+        filename: `${imageSlug}.png`,
+        static_assets: [],
+    };
+
+    it('should properly add an asset to the in-memory assets array', () => {
+        const assets = [];
+        postprocessDocument(articleNodeContent, articleSlug, assets, [], {});
+        expect(assets).toStrictEqual(['STATIC_ASSET']);
+        postprocessDocument(imageNodeContent, imageSlug, assets, [], {});
+        // No assets added, but should keep old assets
+        expect(assets).toStrictEqual(['STATIC_ASSET']);
+    });
+
+    it('should properly add a page to the in-memory page array', () => {
+        const pages = [];
+        postprocessDocument(articleNodeContent, articleSlug, [], pages, {});
+        expect(pages).toStrictEqual([articleSlug]);
+    });
+
+    it('should not add an image to the in-memory page array', () => {
+        const pages = [];
+        postprocessDocument(imageNodeContent, imageSlug, [], pages, {});
+        expect(pages).toStrictEqual([]);
+    });
+
+    it('should properly update the in-memory REF_DOC_MAPPING array', () => {
+        const mapping = {};
+        postprocessDocument(articleNodeContent, articleSlug, [], [], mapping);
+        postprocessDocument(imageNodeContent, imageSlug, [], [], mapping);
+        expect(mapping[articleSlug]).toStrictEqual(articleNodeContent);
+        // Should still contain non-page content nodes in __refDocMapping
+        expect(mapping[imageSlug]).toStrictEqual(imageNodeContent);
+    });
+});

--- a/tests/utils/postprocess-document.test.js
+++ b/tests/utils/postprocess-document.test.js
@@ -21,10 +21,10 @@ describe('Should properly postprocess a document node after it is fetched', () =
     it('should properly add an asset to the in-memory assets array', () => {
         const assets = [];
         postprocessDocument(articleNodeContent, articleSlug, assets, [], {});
-        expect(assets).toStrictEqual(['STATIC_ASSET']);
+        expect(assets).toStrictEqual(articleNodeContent.static_assets);
         postprocessDocument(imageNodeContent, imageSlug, assets, [], {});
         // No assets added, but should keep old assets
-        expect(assets).toStrictEqual(['STATIC_ASSET']);
+        expect(assets).toStrictEqual(articleNodeContent.static_assets);
     });
 
     it('should properly add a page to the in-memory page array', () => {

--- a/tests/utils/postprocess-document.test.js
+++ b/tests/utils/postprocess-document.test.js
@@ -1,50 +1,56 @@
 import { postprocessDocument } from '../../src/utils/setup/postprocess-document';
 
 describe('Should properly postprocess a document node after it is fetched', () => {
+    const pageIdPrefix = 'test-pages/test';
     const articleSlug = 'article/test-article';
-    const articleNodeContent = {
+    const articleNode = {
         ast: {
             children: [],
         },
         filename: `${articleSlug}.txt`,
+        page_id: `${pageIdPrefix}/${articleSlug}`,
         static_assets: ['STATIC_ASSET'],
     };
     const imageSlug = 'image/test-image';
-    const imageNodeContent = {
+    const imageNode = {
         ast: {
             children: [],
         },
         filename: `${imageSlug}.png`,
+        page_id: `${pageIdPrefix}/${imageSlug}`,
         static_assets: [],
     };
 
     it('should properly add an asset to the in-memory assets array', () => {
         const assets = [];
-        postprocessDocument(articleNodeContent, articleSlug, assets, [], {});
-        expect(assets).toStrictEqual(articleNodeContent.static_assets);
-        postprocessDocument(imageNodeContent, imageSlug, assets, [], {});
+        postprocessDocument(articleNode, pageIdPrefix, assets, [], {});
+        expect(assets).toStrictEqual(articleNode.static_assets);
+        postprocessDocument(imageNode, pageIdPrefix, assets, [], {});
         // No assets added, but should keep old assets
-        expect(assets).toStrictEqual(articleNodeContent.static_assets);
+        expect(assets).toStrictEqual(articleNode.static_assets);
     });
 
-    it('should properly add a page to the in-memory page array', () => {
+    it('should properly add a page to the in-memory page array without the page id prefix', () => {
         const pages = [];
-        postprocessDocument(articleNodeContent, articleSlug, [], pages, {});
+        postprocessDocument(articleNode, pageIdPrefix, [], pages, {});
         expect(pages).toStrictEqual([articleSlug]);
     });
 
     it('should not add an image to the in-memory page array', () => {
         const pages = [];
-        postprocessDocument(imageNodeContent, imageSlug, [], pages, {});
+        postprocessDocument(imageNode, pageIdPrefix, [], pages, {});
         expect(pages).toStrictEqual([]);
     });
 
-    it('should properly update the in-memory REF_DOC_MAPPING array', () => {
+    it('should properly update the in-memory REF_DOC_MAPPING array without the pageIdPrefix', () => {
         const mapping = {};
-        postprocessDocument(articleNodeContent, articleSlug, [], [], mapping);
-        postprocessDocument(imageNodeContent, imageSlug, [], [], mapping);
-        expect(mapping[articleSlug]).toStrictEqual(articleNodeContent);
+        const { page_id: articlePageId, ...articleContentNode } = articleNode;
+        const { page_id: imagePageId, ...imageContentNode } = imageNode;
+        postprocessDocument(articleNode, pageIdPrefix, [], [], mapping);
+        postprocessDocument(imageNode, pageIdPrefix, [], [], mapping);
+        // refDocMapping should not include page_id, but should contain everything else
+        expect(mapping[articleSlug]).toStrictEqual(articleContentNode);
         // Should still contain non-page content nodes in __refDocMapping
-        expect(mapping[imageSlug]).toStrictEqual(imageNodeContent);
+        expect(mapping[imageSlug]).toStrictEqual(imageContentNode);
     });
 });


### PR DESCRIPTION
This PR moves operations relating to postprocessing incoming documents from our data store (stitch) to a helper method with tests.

Doing so helps us more align with Gatsby API methodology by moving `onCreateNode` related processes to one place.

I also removed the unused `IMAGE_FILES` object.