### PR TITLE
Nav hover/active states, smaller font and height

### DIFF
--- a/src/components/dev-hub/global-nav.js
+++ b/src/components/dev-hub/global-nav.js
@@ -41,8 +41,8 @@ const NavLink = styled(Link)`
     text-decoration: none;
     &:hover,
     &[aria-current='page'] {
-        /* 66 is 40% opacity in hex */
-        background-color: ${`${colorMap.greyDarkTwo}66`};
+        /* greyDarkTwo at 40% opacity on greyDarkThree */
+        background-color: #2c3d47;
     }
     @media ${screenSize.upToMedium} {
         font-size: ${fontSize.tiny};

--- a/src/components/dev-hub/global-nav.js
+++ b/src/components/dev-hub/global-nav.js
@@ -6,6 +6,9 @@ import DevLeafMobile from './icons/mdb-dev-leaf-mobile';
 import DevLeafDesktop from './icons/mdb-dev-leaf-desktop';
 import useMedia from '../../hooks/use-media';
 
+// nav height is 58px: 24px line height + 2 * 17px vertical padding
+const LINK_VERTICAL_PADDING = '17px';
+
 const GlobalNav = styled('nav')`
     background-color: ${colorMap.greyDarkThree};
     display: flex;
@@ -14,7 +17,7 @@ const GlobalNav = styled('nav')`
     &:after {
         background: radial-gradient(circle, #3ebb8c 0%, #76d3b1 100%);
         content: ' ';
-        height: 4px;
+        height: 2px;
         width: 100%;
     }
 `;
@@ -30,14 +33,16 @@ const NavContent = styled('div')`
 `;
 
 const NavLink = styled(Link)`
+    font-size: ${fontSize.small};
     font-weight: 300;
     letter-spacing: 1px;
-    line-height: ${lineHeight.xxlarge};
-    padding: ${size.small} ${size.xlarge};
+    line-height: ${lineHeight.small};
+    padding: ${LINK_VERTICAL_PADDING} ${size.xlarge};
     text-decoration: none;
     &:hover,
     &[aria-current='page'] {
-        background-color: ${colorMap.greyDarkTwo};
+        /* 66 is 40% opacity in hex */
+        background-color: ${`${colorMap.greyDarkTwo}66`};
     }
     @media ${screenSize.upToMedium} {
         font-size: ${fontSize.tiny};
@@ -48,7 +53,12 @@ const NavLink = styled(Link)`
 const HomeLink = styled(NavLink)`
     align-items: center;
     display: flex;
-    padding: 22px ${size.xlarge} 22px ${size.medium};
+    padding: ${LINK_VERTICAL_PADDING} ${size.xlarge} ${LINK_VERTICAL_PADDING}
+        ${size.medium};
+    &:hover,
+    &[aria-current='page'] {
+        background-color: unset;
+    }
     @media ${screenSize.upToMedium} {
         padding: ${size.default};
         svg {


### PR DESCRIPTION
Dan has asked for the following changes to the nav:
- Remove hover/active states from the logo for home (existing convention should be enough for users to know it is clickable)
- Shrinks the size of the nav to 58px and 2px for the bar underneath
- Switches the hover/active backgrounds to use 40% opacity

Staging:
![Screen Shot 2020-04-06 at 3 02 43 PM](https://user-images.githubusercontent.com/9064401/78595546-2b58a780-7818-11ea-9716-7c74efde12c4.png)

This PR:
![Screen Shot 2020-04-06 at 3 02 20 PM](https://user-images.githubusercontent.com/9064401/78595568-34e20f80-7818-11ea-8cd7-419de7a4aa14.png)

Closer look at hover/active:
![Screen Shot 2020-04-06 at 3 04 05 PM](https://user-images.githubusercontent.com/9064401/78595587-3ca1b400-7818-11ea-8da1-537be0e9c1e1.png)

