### PR TITLE
Cache static assets to accelerate repeated builds

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -10,6 +10,7 @@ const {
     validateEnvVariables,
 } = require('./src/utils/setup/validate-env-variables');
 const { onCreatePage } = require('./src/utils/setup/on-create-page');
+const { createAssetNodes } = require('./src/utils/setup/create-asset-nodes');
 const { createTagPageType } = require('./src/utils/setup/create-tag-page-type');
 const { getMetadata } = require('./src/utils/get-metadata');
 const {
@@ -57,23 +58,7 @@ exports.sourceNodes = async ({
     }
 
     documents.forEach(doc => {
-        const pageNode = getNestedValue(['ast', 'children'], doc);
-        if (pageNode) {
-            // Cache static assets to save file i/o on repeated builds
-            doc.static_assets.forEach(asset => {
-                const assetNode = {
-                    id: asset,
-                    parent: null,
-                    children: [],
-                    internal: {
-                        type: 'Asset',
-                        content: asset,
-                        contentDigest: createContentDigest(asset),
-                    },
-                };
-                createNode(assetNode);
-            });
-        }
+        createAssetNodes(doc, createNode, createContentDigest);
         // Mimics onCreateNode
         postprocessDocument(doc, PAGE_ID_PREFIX, pages, slugContentMapping);
     });

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,8 +4,7 @@ const { initStitch } = require('./src/utils/setup/init-stich');
 const {
     postprocessDocument,
 } = require('./src/utils/setup/postprocess-document');
-const { getNestedValue } = require('./src/get-nested-value');
-const { saveAssetFile } = require('./src/utils/setup/save-asset-file');
+const { saveAssetFiles } = require('./src/utils/setup/save-asset-files');
 const {
     validateEnvVariables,
 } = require('./src/utils/setup/validate-env-variables');
@@ -26,6 +25,7 @@ const DB = metadata.database;
 const PAGE_ID_PREFIX = `${metadata.project}/${metadata.user}/${metadata.parserBranch}`;
 
 // different types of references
+const assets = [];
 const pages = [];
 
 // in-memory object with key/value = filename/document
@@ -66,11 +66,12 @@ exports.sourceNodes = async ({
 
 exports.onCreateNode = async ({ node }) => {
     if (node.internal.type === 'Asset') {
-        await saveAssetFile(node.id, stitchClient);
+        assets.push(node.id);
     }
 };
 
 exports.createPages = async ({ actions }) => {
+    await saveAssetFiles(assets, stitchClient);
     const { createPage } = actions;
     const metadata = await stitchClient.callFunction('fetchDocument', [
         DB,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,7 +4,8 @@ const { initStitch } = require('./src/utils/setup/init-stich');
 const {
     postprocessDocument,
 } = require('./src/utils/setup/postprocess-document');
-const { saveAssetFiles } = require('./src/utils/setup/save-asset-files');
+const { getNestedValue } = require('./src/get-nested-value');
+const { saveAssetFile } = require('./src/utils/setup/save-asset-file');
 const {
     validateEnvVariables,
 } = require('./src/utils/setup/validate-env-variables');
@@ -38,7 +39,10 @@ let learnFeaturedArticles;
 
 exports.onPreBootstrap = validateEnvVariables;
 
-exports.sourceNodes = async () => {
+exports.sourceNodes = async ({
+    actions: { createNode },
+    createContentDigest,
+}) => {
     // wait to connect to stitch
     stitchClient = await initStitch();
 
@@ -52,19 +56,33 @@ exports.sourceNodes = async () => {
         console.error('No documents matched your query.');
     }
 
-    const assets = [];
     documents.forEach(doc => {
+        const pageNode = getNestedValue(['ast', 'children'], doc);
+        if (pageNode) {
+            // Cache static assets to save file i/o on repeated builds
+            doc.static_assets.forEach(asset => {
+                const assetNode = {
+                    id: asset,
+                    parent: null,
+                    children: [],
+                    internal: {
+                        type: 'Asset',
+                        content: asset,
+                        contentDigest: createContentDigest(asset),
+                    },
+                };
+                createNode(assetNode);
+            });
+        }
         // Mimics onCreateNode
-        postprocessDocument(
-            doc,
-            PAGE_ID_PREFIX,
-            assets,
-            pages,
-            slugContentMapping
-        );
+        postprocessDocument(doc, PAGE_ID_PREFIX, pages, slugContentMapping);
     });
+};
 
-    await saveAssetFiles(assets, stitchClient);
+exports.onCreateNode = async ({ node }) => {
+    if (node.internal.type === 'Asset') {
+        await saveAssetFile(node.id, stitchClient);
+    }
 };
 
 exports.createPages = async ({ actions }) => {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -71,12 +71,14 @@ exports.onCreateNode = async ({ node }) => {
 };
 
 exports.createPages = async ({ actions }) => {
-    await saveAssetFiles(assets, stitchClient);
     const { createPage } = actions;
-    const metadata = await stitchClient.callFunction('fetchDocument', [
-        DB,
-        METADATA_COLLECTION,
-        constructDbFilter(PAGE_ID_PREFIX),
+    const [, metadata] = await Promise.all([
+        saveAssetFiles(assets, stitchClient),
+        stitchClient.callFunction('fetchDocument', [
+            DB,
+            METADATA_COLLECTION,
+            constructDbFilter(PAGE_ID_PREFIX),
+        ]),
     ]);
 
     const allSeries = metadata.pageGroups;

--- a/src/utils/setup/create-asset-nodes.js
+++ b/src/utils/setup/create-asset-nodes.js
@@ -1,0 +1,23 @@
+const { getNestedValue } = require('../get-nested-value');
+
+const createAssetNodes = (doc, createNode, createContentDigest) => {
+    const pageNode = getNestedValue(['ast', 'children'], doc);
+    if (pageNode) {
+        // Cache static assets to save file i/o on repeated builds
+        doc.static_assets.forEach(asset => {
+            const assetNode = {
+                id: asset,
+                parent: null,
+                children: [],
+                internal: {
+                    type: 'Asset',
+                    content: asset,
+                    contentDigest: createContentDigest(asset),
+                },
+            };
+            createNode(assetNode);
+        });
+    }
+};
+
+module.exports = { createAssetNodes };

--- a/src/utils/setup/postprocess-document.js
+++ b/src/utils/setup/postprocess-document.js
@@ -6,7 +6,6 @@ const { getNestedValue } = require('../get-nested-value');
 const postprocessDocument = (
     doc,
     PAGE_ID_PREFIX,
-    assetsArray,
     pagesArray,
     RESOLVED_REF_DOC_MAPPING
 ) => {
@@ -14,14 +13,9 @@ const postprocessDocument = (
     const slug = page_id.replace(`${PAGE_ID_PREFIX}/`, '');
     // Add contents to in-memory slug to content mapping
     RESOLVED_REF_DOC_MAPPING[slug] = nodeContent;
-    const pageNode = getNestedValue(['ast', 'children'], nodeContent);
     const filename = getNestedValue(['filename'], nodeContent) || '';
     const isArticlePage =
         !filename.includes('images/') && filename.endsWith('.txt');
-    // Add any static assets to in-memory collection of assets to store
-    if (pageNode) {
-        assetsArray.push(...nodeContent.static_assets);
-    }
     // Add any article pages to in-memory collection of pages to create
     if (isArticlePage) {
         pagesArray.push(slug);

--- a/src/utils/setup/save-asset-file.js
+++ b/src/utils/setup/save-asset-file.js
@@ -6,7 +6,7 @@ const { getMetadata } = require('../get-metadata');
 const metadata = getMetadata();
 const DB = metadata.database;
 
-const saveAssetFile = async asset => {
+const saveFile = async asset => {
     await fs.mkdir(path.join('static', path.dirname(asset.filename)), {
         recursive: true,
     });
@@ -18,17 +18,17 @@ const saveAssetFile = async asset => {
 };
 
 // Write all assets to static directory
-const saveAssetFiles = async (assets, stitchClient) => {
+const saveAssetFile = async (asset, stitchClient) => {
     const promises = [];
-    const assetQuery = { _id: { $in: assets } };
+    const assetQuery = { _id: { $eq: asset } };
     const assetDataDocuments = await stitchClient.callFunction(
         'fetchDocuments',
         [DB, ASSETS_COLLECTION, assetQuery]
     );
     assetDataDocuments.forEach(asset => {
-        promises.push(saveAssetFile(asset));
+        promises.push(saveFile(asset));
     });
     return Promise.all(promises);
 };
 
-module.exports = { saveAssetFiles };
+module.exports = { saveAssetFile };

--- a/src/utils/setup/save-asset-files.js
+++ b/src/utils/setup/save-asset-files.js
@@ -18,17 +18,19 @@ const saveFile = async asset => {
 };
 
 // Write all assets to static directory
-const saveAssetFile = async (asset, stitchClient) => {
-    const promises = [];
-    const assetQuery = { _id: { $eq: asset } };
-    const assetDataDocuments = await stitchClient.callFunction(
-        'fetchDocuments',
-        [DB, ASSETS_COLLECTION, assetQuery]
-    );
-    assetDataDocuments.forEach(asset => {
-        promises.push(saveFile(asset));
-    });
-    return Promise.all(promises);
+const saveAssetFiles = async (assets, stitchClient) => {
+    if (assets.length) {
+        const promises = [];
+        const assetQuery = { _id: { $in: assets } };
+        const assetDataDocuments = await stitchClient.callFunction(
+            'fetchDocuments',
+            [DB, ASSETS_COLLECTION, assetQuery]
+        );
+        assetDataDocuments.forEach(asset => {
+            promises.push(saveFile(asset));
+        });
+        await Promise.all(promises);
+    }
 };
 
-module.exports = { saveAssetFile };
+module.exports = { saveAssetFiles };

--- a/tests/utils/create-asset-nodes.test.js
+++ b/tests/utils/create-asset-nodes.test.js
@@ -1,0 +1,24 @@
+import { createAssetNodes } from '../../src/utils/setup/create-asset-nodes';
+
+it('should properly construct nodes for static assets', () => {
+    const testArticle = {
+        ast: {
+            children: [],
+        },
+        static_assets: ['asset_1', 'asset_2'],
+    };
+
+    const createNode = jest.fn();
+    const createContentDigest = jest.fn(asset => asset[0]);
+
+    createAssetNodes(testArticle, createNode, createContentDigest);
+    expect(createNode.mock.calls.length).toBe(testArticle.static_assets.length);
+
+    // check asset_1 call node
+    const firstNode = createNode.mock.calls[0][0];
+    expect(firstNode.id).toBe(testArticle.static_assets[0]);
+    expect(firstNode.internal.type).toBe('Asset');
+    expect(firstNode.internal.contentDigest).toBe(
+        createContentDigest(testArticle.static_assets[0])
+    );
+});

--- a/tests/utils/postprocess-document.test.js
+++ b/tests/utils/postprocess-document.test.js
@@ -9,7 +9,6 @@ describe('Should properly postprocess a document node after it is fetched', () =
         },
         filename: `${articleSlug}.txt`,
         page_id: `${pageIdPrefix}/${articleSlug}`,
-        static_assets: ['STATIC_ASSET'],
     };
     const imageSlug = 'image/test-image';
     const imageNode = {
@@ -18,27 +17,17 @@ describe('Should properly postprocess a document node after it is fetched', () =
         },
         filename: `${imageSlug}.png`,
         page_id: `${pageIdPrefix}/${imageSlug}`,
-        static_assets: [],
     };
-
-    it('should properly add an asset to the in-memory assets array', () => {
-        const assets = [];
-        postprocessDocument(articleNode, pageIdPrefix, assets, [], {});
-        expect(assets).toStrictEqual(articleNode.static_assets);
-        postprocessDocument(imageNode, pageIdPrefix, assets, [], {});
-        // No assets added, but should keep old assets
-        expect(assets).toStrictEqual(articleNode.static_assets);
-    });
 
     it('should properly add a page to the in-memory page array without the page id prefix', () => {
         const pages = [];
-        postprocessDocument(articleNode, pageIdPrefix, [], pages, {});
+        postprocessDocument(articleNode, pageIdPrefix, pages, {});
         expect(pages).toStrictEqual([articleSlug]);
     });
 
     it('should not add an image to the in-memory page array', () => {
         const pages = [];
-        postprocessDocument(imageNode, pageIdPrefix, [], pages, {});
+        postprocessDocument(imageNode, pageIdPrefix, pages, {});
         expect(pages).toStrictEqual([]);
     });
 
@@ -46,8 +35,8 @@ describe('Should properly postprocess a document node after it is fetched', () =
         const mapping = {};
         const { page_id: articlePageId, ...articleContentNode } = articleNode;
         const { page_id: imagePageId, ...imageContentNode } = imageNode;
-        postprocessDocument(articleNode, pageIdPrefix, [], [], mapping);
-        postprocessDocument(imageNode, pageIdPrefix, [], [], mapping);
+        postprocessDocument(articleNode, pageIdPrefix, [], mapping);
+        postprocessDocument(imageNode, pageIdPrefix, [], mapping);
         // refDocMapping should not include page_id, but should contain everything else
         expect(mapping[articleSlug]).toStrictEqual(articleContentNode);
         // Should still contain non-page content nodes in __refDocMapping


### PR DESCRIPTION
Now that we have broken up pieces of gatsby-node, we can begin to optimize pieces of the build process by leveraging Gatsby's caching.

This PR optimizes writes to disk on repeated builds for static assets (images, etc.) and cuts build time by about 33% (about 4 seconds) on a repeated build (a build where the cache has already been populated).

What happens on a first build is the `createNode` method writes a new node to the cache which stores the asset ID in cached files. On a repeated build, we just use the cache instead of making a new node, therefore we do not call the `onCreateNode` handler and avoid writing out to disk.

I cleared my local `static` folder and re-ran the build. I didn't notice any missing assets.