### PR TITLE
Use fs Promises for asset handling

### DIFF
--- a/src/utils/setup/save-asset-files.js
+++ b/src/utils/setup/save-asset-files.js
@@ -1,5 +1,4 @@
 const fs = require('fs').promises;
-const mkdirp = require('mkdirp');
 const path = require('path');
 const { ASSETS_COLLECTION } = require('../../build-constants');
 const { getMetadata } = require('../get-metadata');
@@ -8,21 +7,14 @@ const metadata = getMetadata();
 const DB = metadata.database;
 
 const saveAssetFile = async asset => {
-    return new Promise((resolve, reject) => {
-        // Create nested directories as specified by the asset filenames if they do not exist
-        mkdirp(path.join('static', path.dirname(asset.filename)), err => {
-            if (err) return reject(err);
-            fs.writeFile(
-                path.join('static', asset.filename),
-                asset.data.buffer,
-                'binary',
-                err => {
-                    if (err) reject(err);
-                }
-            );
-            resolve();
-        });
+    await fs.mkdir(path.join('static', path.dirname(asset.filename)), {
+        recursive: true,
     });
+    await fs.writeFile(
+        path.join('static', asset.filename),
+        asset.data.buffer,
+        'binary'
+    );
 };
 
 // Write all assets to static directory


### PR DESCRIPTION
The `saveAssetFiles` function had a concurrency issue. We were using the `fsPromises` API, which gives us the ability to query the filesystem using Promises, however we were not properly blocking for these queries to complete.

This PR uses `fsPromises` properly and blocks for both creating a static directory and writing a static file. It also lets us remove `mkdirp` (which was way outdated) because `fs.mkdir` with `{recursive: true}` is identical, so it is much easier to see what is going on here.

I also noticed `gatsby develop` did not get killed mid-build after making this change.