### PR TITLE
Extract "Create Page" logic and Test

### DIFF
--- a/src/utils/setup/create-article-page.js
+++ b/src/utils/setup/create-article-page.js
@@ -1,0 +1,47 @@
+const path = require('path');
+const {
+    getRelatedPagesWithImages,
+} = require('./get-related-pages-with-images');
+const { getNestedValue } = require('../get-nested-value');
+const { getPageSlug } = require('../get-page-slug');
+const { getSeriesArticles } = require('../get-series-articles');
+const { getTemplate } = require('../get-template');
+const { SNOOTY_STITCH_ID } = require('../../build-constants');
+
+const createArticlePage = (
+    page,
+    slugContentMapping,
+    allSeries,
+    metadata,
+    createPage
+) => {
+    const pageNodes = slugContentMapping[page];
+
+    if (pageNodes && Object.keys(pageNodes).length > 0) {
+        const template = getTemplate(
+            getNestedValue(['ast', 'options', 'template'], pageNodes)
+        );
+        const slug = getPageSlug(page);
+        if (pageNodes.query_fields) {
+            const relatedPages = getRelatedPagesWithImages(
+                pageNodes,
+                slugContentMapping
+            );
+            pageNodes['query_fields'].related = relatedPages;
+        }
+        const seriesArticles = getSeriesArticles(allSeries, slug);
+        createPage({
+            path: slug,
+            component: path.resolve(`./src/templates/${template}.js`),
+            context: {
+                metadata,
+                seriesArticles,
+                slug,
+                snootyStitchId: SNOOTY_STITCH_ID,
+                __refDocMapping: pageNodes,
+            },
+        });
+    }
+};
+
+module.exports = { createArticlePage };

--- a/tests/utils/create-article-page.test.js
+++ b/tests/utils/create-article-page.test.js
@@ -1,0 +1,92 @@
+import { createArticlePage } from '../../src/utils/setup/create-article-page';
+
+describe('creating an article page', () => {
+    const articleOneSlug = '/article1';
+    const slugContentMapping = {
+        [articleOneSlug]: { ast: {} },
+    };
+    let createPage;
+    beforeEach(() => {
+        // Reset mock fn each time to check calls in isolation
+        createPage = jest.fn();
+    });
+
+    it('should create a page at the correct slug', () => {
+        createArticlePage(
+            articleOneSlug,
+            slugContentMapping,
+            {},
+            {},
+            createPage
+        );
+        expect(createPage.mock.calls.length).toBe(1);
+        expect(createPage.mock.calls[0][0].path).toBe(articleOneSlug);
+    });
+
+    it('should properly tag series for a page', () => {
+        const series = {
+            seriesWithArticleOne: [articleOneSlug],
+            seriesWithoutArticleOne: [],
+        };
+        createArticlePage(
+            articleOneSlug,
+            slugContentMapping,
+            series,
+            {},
+            createPage
+        );
+        expect(createPage.mock.calls.length).toBe(1);
+        expect(
+            createPage.mock.calls[0][0].context.seriesArticles
+        ).toHaveProperty('seriesWithArticleOne');
+        expect(
+            createPage.mock.calls[0][0].context.seriesArticles
+        ).not.toHaveProperty('seriesWithoutArticleOne');
+        expect(
+            createPage.mock.calls[0][0].context.seriesArticles
+                .seriesWithArticleOne
+        ).toStrictEqual(series.seriesWithArticleOne);
+    });
+
+    it('should get the correct template for a page', () => {
+        slugContentMapping[articleOneSlug].ast = {
+            options: {
+                // "devhub-article" is a keyword to choose a specific article template
+                template: 'devhub-article',
+            },
+        };
+        createArticlePage(
+            articleOneSlug,
+            slugContentMapping,
+            {},
+            {},
+            createPage
+        );
+        expect(createPage.mock.calls[0][0].component).toContain('article.js');
+    });
+
+    it('should properly get related pages for a page', () => {
+        const articleTwoSlug = '/article2';
+        slugContentMapping[articleTwoSlug] = {
+            ast: {},
+        };
+        slugContentMapping[articleOneSlug].query_fields = {
+            related: [{ target: articleTwoSlug }],
+        };
+        createArticlePage(
+            articleOneSlug,
+            slugContentMapping,
+            {},
+            {},
+            createPage
+        );
+        expect(
+            createPage.mock.calls[0][0].context.__refDocMapping.query_fields
+                .related.length
+        ).toBe(1);
+        expect(
+            createPage.mock.calls[0][0].context.__refDocMapping.query_fields
+                .related[0].target
+        ).toBe(articleTwoSlug);
+    });
+});


### PR DESCRIPTION
This PR simply moves the logic for creating an article page into another file and adding a few tests for it (things like properly adding series, related articles, etc.).