### PR TITLE
Add cypress testing for the home page

### DIFF
--- a/cypress/integration/home.js
+++ b/cypress/integration/home.js
@@ -1,6 +1,65 @@
+const CARDS = '[data-test="card"]';
+const FEATURED_ARTICLES = 'header';
+const TWITCH = '[data-test="twitch"]';
+
 describe('Home Page', () => {
     it('should properly render the home page', () => {
         cy.visit('/');
-        cy.contains('Learn MongoDB');
+        // Check the learn button correctly links out
+        cy.get(FEATURED_ARTICLES).within(() => {
+            cy.contains('Learn MongoDB')
+                .should('have.prop', 'href')
+                .should('include', '/learn');
+        });
+    });
+    it('should properly render some featured articles', () => {
+        cy.get(FEATURED_ARTICLES).within(() => {
+            // We expect [1,4] featured articles on the home page
+            cy.get(CARDS).should('have.length.of.at.least', 1);
+            cy.get(CARDS).should('have.length.of.at.most', 4);
+            // These cards should be links to articles
+            cy.get(CARDS)
+                .first()
+                .should('have.prop', 'href')
+                .should('not.be.empty');
+            cy.get(CARDS)
+                .first()
+                .within(() => {
+                    cy.get('img')
+                        .should('have.prop', 'src')
+                        .should('not.be.empty');
+                    cy.get('h5').should('not.be.empty');
+                });
+        });
+    });
+    it('should properly render embedded Twitch content', () => {
+        // Hang onto parent reference for checking modal later
+        cy.useBodyReference();
+        cy.get(TWITCH).within(() => {
+            cy.get(CARDS).within(() => {
+                // Check the thumbnail exists
+                cy.get('img')
+                    .should('have.prop', 'src')
+                    .should('not.be.empty');
+                // Check the play button
+                cy.get('button').should('exist');
+                cy.get('button')
+                    .first()
+                    .click()
+                    .then(() => {
+                        cy.get('@body').within(() => {
+                            cy.get('[data-test="modal"]').should('exist');
+                            cy.closeModal();
+                        });
+                    });
+            });
+        });
+    });
+    it('should link to events', () => {
+        cy.get('[data-test="events"]').within(() => {
+            cy.get('a')
+                .should('have.prop', 'href')
+                .should('contain', '/community/events');
+        });
     });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -10,16 +10,11 @@
 //
 //
 // -- This is a parent command --
-// Cypress.Commands.add("login", (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This will overwrite an existing command --
-// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+Cypress.Commands.add('closeModal', () => {
+    cy.get('[data-test="modal-close"]').click();
+});
+
+// Keep a reference to the body dom element to reference later even in "within" blocks
+Cypress.Commands.add('useBodyReference', () => {
+    cy.get('body').as('body');
+});

--- a/src/components/dev-hub/card.js
+++ b/src/components/dev-hub/card.js
@@ -117,6 +117,7 @@ const Card = ({
     const isClickable = onClick || isLink;
     return (
         <ContentWrapper
+            data-test="card"
             onClick={onClick}
             {...linkAttrs}
             maxWidth={maxWidth}

--- a/src/components/dev-hub/modal.js
+++ b/src/components/dev-hub/modal.js
@@ -48,6 +48,7 @@ const ModalClose = ({ closeModalOnEnter, deactivateModal }) => (
             tabIndex="0"
             onClick={deactivateModal}
             onKeyUp={closeModalOnEnter}
+            data-test="modal-close"
         >
             &times;
         </CloseButtonWrapper>
@@ -120,6 +121,7 @@ export const Modal = ({
     const ResponsiveModal = () =>
         isActive && (
             <AriaModal
+                data-test="modal"
                 mounted={isMounted}
                 focusDialog
                 titleText={title || 'Popup Modal'}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -204,7 +204,7 @@ export default ({ pageContext: { featuredArticles } }) => {
                         </Button>
                     </div>
                 </Hero>
-                <FeatureSection altBackground>
+                <FeatureSection altBackground data-test="twitch">
                     <MediaBlock
                         mediaComponent={
                             twitchVideo && <Thumbnail video={twitchVideo} />
@@ -235,7 +235,7 @@ export default ({ pageContext: { featuredArticles } }) => {
                         </SectionContent>
                     </MediaBlock>
                 </FeatureSection>
-                <FeatureSection>
+                <FeatureSection data-test="events">
                     <MediaBlock
                         mediaComponent={
                             <Card


### PR DESCRIPTION
This PR adds Cypress Integration testing to the home page. Right now, we can locally run these commands in Chrome, Edge, and Firefox after starting a development server.

I added checks for the following home page pieces:
- Featured Articles render (between 1 and 4) with images and refs to articles
- Learn MongoDB button links to learn page
- Twitch content renders with a thumbnail and pops open the content modal
- Events link has the expected href

We don't need specific data for these tests, since I just check the structure of components and props exist