### PR TITLE
Remove unused url arg from useEventData

### DIFF
--- a/src/components/dev-hub/event-list.js
+++ b/src/components/dev-hub/event-list.js
@@ -6,9 +6,6 @@ import { P } from './text';
 import useEventData from '../../hooks/use-event-data';
 import { size, screenSize } from './theme';
 
-export const EVENTS_API =
-    'https://www.mongodb.com/api/event/all/1?sort=-node_type_attributes.event_start';
-
 const EventsPreview = styled('div')`
     display: flex;
     flex-direction: row;
@@ -40,7 +37,7 @@ const CenterBlock = styled('div')`
 `;
 
 export const EventsListPreview = () => {
-    const [events, error, isLoading] = useEventData(EVENTS_API);
+    const [events, error, isLoading] = useEventData();
     const previews = events ? events.slice(0, 3) : [];
 
     return (

--- a/src/hooks/use-event-data.js
+++ b/src/hooks/use-event-data.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import fetchEventData from '../utils/fetch-event-data';
 import fetchLiveEventData from '../utils/fetch-live-event-data';
 
-const useEventData = url => {
+const useEventData = () => {
     const [events, setEvents] = useState(null);
     const [error, setError] = useState(null);
     const [isLoading, setIsLoading] = useState(false);
@@ -11,7 +11,7 @@ const useEventData = url => {
         const getData = async () => {
             setIsLoading(true);
             try {
-                const eventData = fetchEventData(url);
+                const eventData = fetchEventData();
                 const liveData = fetchLiveEventData();
                 const allData = await Promise.all([eventData, liveData]);
                 const events = allData
@@ -31,7 +31,7 @@ const useEventData = url => {
             }
         };
         getData();
-    }, [url]);
+    }, []);
 
     return [events, error, isLoading];
 };

--- a/src/pages/community/events.js
+++ b/src/pages/community/events.js
@@ -4,7 +4,7 @@ import { Helmet } from 'react-helmet';
 import HeroBanner from '../../components/dev-hub/hero-banner';
 import Layout from '../../components/dev-hub/layout';
 import useEventData from '../../hooks/use-event-data';
-import EventsList, { EVENTS_API } from '../../components/dev-hub/event-list';
+import EventsList from '../../components/dev-hub/event-list';
 import { H1, H3, P } from '../../components/dev-hub/text';
 import TempBackgroundImage from '../../images/1x/MDB-and-Node.js.png';
 import { colorMap } from '../../components/dev-hub/theme';
@@ -25,7 +25,7 @@ const breadcrumbs = [
 ];
 
 export default () => {
-    const [events, error, isLoading] = useEventData(EVENTS_API);
+    const [events, error, isLoading] = useEventData();
 
     const metadata = useSiteMetadata();
     return (


### PR DESCRIPTION
I noticed components using the `useEventData` hook were no longer using the url param supplied after refactoring events to use multiple sources. 

This PR simply removes references to that argument from caller components and the hook, because `fetchEventData` now has that url contained in its file.