### PR TITLE
Add Integration Testing for the Community Page

### DIFF
--- a/cypress/fixtures/eventData.json
+++ b/cypress/fixtures/eventData.json
@@ -1,0 +1,22 @@
+[
+    {
+        "_id": "5e5d64282529760dbd303904",
+        "node_type": "event",
+        "node_type_attributes": {
+            "event_start": "2030-09-16T14:00:00.000Z",
+            "event_end": "2030-09-16T23:00:00.000Z",
+            "event_city": "London",
+            "event_type": "MongoDB",
+            "event_country": "United Kingdom"
+        },
+        "title": "MongoDB.local London",
+        "status": "published",
+        "published_at": "2020-03-02T19:49:00.000Z",
+        "content_expires_at": "2030-09-17T05:00:00.000Z",
+        "expired_redirect_to": "https://mongodb.com/local",
+        "url": "https://www.eventbrite.com/e/mongodblocal-london-2020-tickets-92125823819",
+        "url_type": "external",
+        "updated_at": "2020-03-20T16:52:23.223Z",
+        "created_at": "2020-03-02T19:53:12.074Z"
+    }
+]

--- a/cypress/fixtures/liveEventData.json
+++ b/cypress/fixtures/liveEventData.json
@@ -1,0 +1,34 @@
+{
+    "links": { "next": null, "previous": null },
+    "count": 1,
+    "results": [
+        {
+            "id": 10,
+            "title": "MongoDB.live Watch Party",
+            "chapter": {
+                "chapter_location": "Philadelphia, PA (US)",
+                "city": "Philadelphia",
+                "country": "US",
+                "country_name": "United States of America",
+                "id": 159,
+                "state": "PA",
+                "timezone": "America/New_York",
+                "title": "Philadelphia",
+                "relative_url": "/philadelphia/",
+                "url": "https://live.mongodb.com/philadelphia/"
+            },
+            "start_date": "2030-06-09T09:00:00-04:00",
+            "end_date": "2030-06-10T18:00:00-04:00",
+            "url": "https://live.mongodb.com/events/details/mongodb-philadelphia-presents-mongodblive-watch-party/",
+            "status": "Published"
+        }
+    ],
+    "status_counter": {
+        "Pending": 0,
+        "Draft": 1,
+        "Completed": 10,
+        "Live": 1,
+        "Canceled": 1,
+        "Published": 13
+    }
+}

--- a/cypress/integration/community.js
+++ b/cypress/integration/community.js
@@ -1,0 +1,41 @@
+describe('Community Page', () => {
+    it('should have some events', () => {
+        cy.mockEventsApi();
+        cy.visitWithoutFetch('/community');
+        cy.wait(['@getEvents', '@getLiveEvents']);
+        cy.get('[data-test="event"]').should('have.length', 2);
+    });
+    it('should correctly render events from the live.mongodb.com API', () => {
+        cy.get('[data-test="event"]')
+            .first()
+            .should('have.attr', 'href')
+            .should('contain', 'mongodblive-watch-party');
+        cy.get('[data-test="event"]')
+            .first()
+            .within(() => {
+                // Check basic event information still renders
+                cy.contains('MongoDB.live Watch Party');
+                cy.contains('Philadelphia');
+                cy.contains('US');
+            });
+    });
+    it('should correctly render events from the www.mongodb.com API', () => {
+        cy.get('[data-test="event"]')
+            .last()
+            .should('have.attr', 'href')
+            .should('contain', 'mongodblocal-london-2020');
+        cy.get('[data-test="event"]')
+            .last()
+            .within(() => {
+                // Check basic event information still renders
+                cy.contains('MongoDB.local London');
+                cy.contains('London');
+                cy.contains('United Kingdom');
+            });
+    });
+    it('should have a link to all of the events', () => {
+        cy.contains('See all events')
+            .should('have.attr', 'href')
+            .should('contain', '/community/events');
+    });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,10 +23,6 @@ Cypress.Commands.add('mockEventsApi', () => {
 // we can fallback to XMLHttpRequests
 // https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/stubbing-spying__window-fetch#readme
 
-Cypress.on('window:before:load', win => {
-    delete win.fetch;
-});
-
 Cypress.Commands.add('visitWithoutFetch', path => {
     cy.visit(path, {
         onBeforeLoad(win) {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,15 +1,3 @@
-// ***********************************************
-// This example commands.js shows you how to
-// create various custom commands and overwrite
-// existing commands.
-//
-// For more comprehensive examples of custom
-// commands please read more here:
-// https://on.cypress.io/custom-commands
-// ***********************************************
-//
-//
-// -- This is a parent command --
 Cypress.Commands.add('closeModal', () => {
     cy.get('[data-test="modal-close"]').click();
 });
@@ -17,4 +5,32 @@ Cypress.Commands.add('closeModal', () => {
 // Keep a reference to the body dom element to reference later even in "within" blocks
 Cypress.Commands.add('useBodyReference', () => {
     cy.get('body').as('body');
+});
+
+// Mock data from events servers
+Cypress.Commands.add('mockEventsApi', () => {
+    cy.fixture('liveEventData.json').as('liveEventData');
+    cy.fixture('eventData.json').as('eventData');
+    cy.server();
+    cy.route(
+        '**/api/event/all/1?sort=-node_type_attributes.event_start',
+        '@eventData'
+    ).as('getEvents');
+    cy.route('**/api/event?status=Live', '@liveEventData').as('getLiveEvents');
+});
+
+// To stub requests with Cypress, we must remove fetch from the browser so
+// we can fallback to XMLHttpRequests
+// https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/stubbing-spying__window-fetch#readme
+
+Cypress.on('window:before:load', win => {
+    delete win.fetch;
+});
+
+Cypress.Commands.add('visitWithoutFetch', path => {
+    cy.visit(path, {
+        onBeforeLoad(win) {
+            delete win.fetch;
+        },
+    });
 });

--- a/src/components/dev-hub/events.js
+++ b/src/components/dev-hub/events.js
@@ -111,6 +111,7 @@ const Event = ({ event, maxTitleLines = 2, ...props }) => {
 
     return (
         <StyledEvent
+            data-test="event"
             onMouseEnter={() => setLocationColor(colorMap.greyLightOne)}
             onMouseLeave={() => setLocationColor(colorMap.greyLightThree)}
             target="_blank"


### PR DESCRIPTION
This PR adds new integration testing for the `/community` page.

Since we might not want to continuously hit the events APIs, I was able to [mock them through cypress](https://docs.cypress.io/guides/guides/network-requests.html#Testing-Strategies). 

Interestingly enough, cypress can't mock `fetch`, so there are [some workarounds](https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/stubbing-spying__window-fetch#readme) they recommend to do so (by deleting fetch on navigating to that page).

I added testing for the following pieces:
- mock a www.mongodb.com event API response and check the event object created is correct (with external link)
- mock a live.mongodb.com event API response and check the event object created is correct (with external link)
- check the "see all events" link references the correct page