### PR TITLE
Upgrade leafy codeblock to 3.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4922,7 +4922,6 @@
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
       "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
-      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^1.1.1",
@@ -4930,12 +4929,27 @@
       }
     },
     "@leafygreen-ui/code": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/code/-/code-3.1.0.tgz",
-      "integrity": "sha512-xcz87oRy6rfovfiWVoojmsAdAW6PgZyXCn/xNzNbUftjnEnjms+Im8W692sh8MFtlnpi08hRF9DznI3Priy0TQ==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/code/-/code-3.4.3.tgz",
+      "integrity": "sha512-Z01iCprvqVl4YFgyj94w56EyAAcVKliUULZBtsiA+6pY10IuG/pH0U0PTmGiibP7VYNCA0QEcYMPBMA4Nr3e9A==",
       "requires": {
-        "@leafygreen-ui/lib": "^4.0.0",
-        "@leafygreen-ui/syntax": "^2.1.0"
+        "@leafygreen-ui/icon": "^5.0.3",
+        "@leafygreen-ui/icon-button": "^5.0.1",
+        "@leafygreen-ui/lib": "^4.4.1",
+        "@leafygreen-ui/syntax": "^2.6.0",
+        "clipboard": "^2.0.6"
+      },
+      "dependencies": {
+        "clipboard": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
+          "integrity": "sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==",
+          "requires": {
+            "good-listener": "^1.2.2",
+            "select": "^1.1.2",
+            "tiny-emitter": "^2.0.0"
+          }
+        }
       }
     },
     "@leafygreen-ui/emotion": {
@@ -4948,29 +4962,49 @@
         "emotion": "^10.0.7"
       }
     },
+    "@leafygreen-ui/icon": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-5.0.3.tgz",
+      "integrity": "sha512-p76qFraOhzeU4XXyFX9sw1N0asgdMpRXVA9XL1/fQAnjWqWyGkAIlbcP/pm2OstHWCr+snGXxT6ICzPkyaT4kA==",
+      "requires": {
+        "@leafygreen-ui/lib": "^4.4.1"
+      }
+    },
+    "@leafygreen-ui/icon-button": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon-button/-/icon-button-5.0.1.tgz",
+      "integrity": "sha512-x+BqMCL0g4uCmcCiIwij8Uuo6MShoU8qXM90QxiqEtQP3S5cYV/tqcRskR8B6SGY07yMDc1pTN8GAPILUOAD9Q==",
+      "requires": {
+        "@leafygreen-ui/emotion": "2.0.1",
+        "@leafygreen-ui/lib": "^4.4.1",
+        "@leafygreen-ui/palette": "2.0.1"
+      }
+    },
     "@leafygreen-ui/lib": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-4.2.0.tgz",
-      "integrity": "sha512-hdjJph/SHz7BImDxBeUiSjbTLF7Khj7tfXpfVXs4rykob4KXFB2tSquUOtDwvMaD3QavdRi+6t8bXLJccLTKKg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-4.4.1.tgz",
+      "integrity": "sha512-ZVa/LlcoWBXLpks5XQ6MsM/f3cMqxxsqD8iQlGkGncJZN8cJ7NnxqtyY7QsbGSHNQzSNJbOtHxg6dpYRuAWcPw==",
       "requires": {
         "@leafygreen-ui/emotion": "^2.0.1",
+        "@testing-library/react": "^8.0.1",
         "facepaint": "^1.2.1",
         "polished": "^2.3.0"
       }
     },
     "@leafygreen-ui/palette": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-2.0.0.tgz",
-      "integrity": "sha512-QA7MKgg46RH+SRJIlSa1ebbrCr1Iijeo7FL3wAG+2vEKoPolpOd165p+q/awGaTe0COj2r1FMu93JvVZ3LJPsQ=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-2.0.1.tgz",
+      "integrity": "sha512-xwD6kOokWvaygxF0T2gnf77HEu68G7EXr1ZrNiNtZzg80Y1V2hikhUNoESWij6g/A6qJZvAiwpseflVo3PnlHQ=="
     },
     "@leafygreen-ui/syntax": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/syntax/-/syntax-2.1.0.tgz",
-      "integrity": "sha512-8a82HPMoP+7u8qlAkt3rr79JZXUMo4onoXmFerbqeFagtUIvl3bw+RoSrwWGKHuFBNlpOlC0E17dSd7e0GlDxg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/syntax/-/syntax-2.6.0.tgz",
+      "integrity": "sha512-K9a6QldBf7FD/2GK6/zbb4EjSdMPuzezU0BV/7NQMbo2fshy4aWNlTOZc6WXbag0mTxiETF02o1iFQ/FGnVBMQ==",
       "requires": {
-        "@leafygreen-ui/lib": "^4.0.0",
-        "@leafygreen-ui/palette": "^2.0.0",
-        "highlight.js": "^9.15.6"
+        "@leafygreen-ui/lib": "^4.3.0",
+        "@leafygreen-ui/palette": "^2.0.1",
+        "highlight.js": "^9.15.6",
+        "highlightjs-graphql": "^1.0.1"
       }
     },
     "@mdx-js/loader": {
@@ -5412,6 +5446,11 @@
       "requires": {
         "any-observable": "^0.3.0"
       }
+    },
+    "@sheerun/mutationobserver-shim": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
+      "integrity": "sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw=="
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -7764,6 +7803,45 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@testing-library/dom": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-5.6.1.tgz",
+      "integrity": "sha512-Y1T2bjtvQMewffn1CJ28kpgnuvPYKsBcZMagEH0ppfEMZPDc8AkkEnTk4smrGZKw0cblNB3lhM2FMnpfLExlHg==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@sheerun/mutationobserver-shim": "^0.3.2",
+        "aria-query": "3.0.0",
+        "pretty-format": "^24.8.0",
+        "wait-for-expect": "^1.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "pretty-format": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+          "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "ansi-regex": "^4.0.0",
+            "ansi-styles": "^3.2.0",
+            "react-is": "^16.8.4"
+          }
+        }
+      }
+    },
+    "@testing-library/react": {
+      "version": "8.0.9",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-8.0.9.tgz",
+      "integrity": "sha512-I7zd+MW5wk8rQA5VopZgBfxGKUd91jgZ6Vzj2gMqFf2iGGtKwvI5SVTrIJcSFaOXK88T2EUsbsIKugDtoqOcZQ==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@testing-library/dom": "^5.6.1"
+      }
+    },
     "@types/babel-types": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.7.tgz",
@@ -7902,14 +7980,12 @@
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
-      "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==",
-      "dev": true
+      "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg=="
     },
     "@types/istanbul-lib-report": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
       "integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
-      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -7918,7 +7994,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
       "integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
-      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
@@ -8104,7 +8179,6 @@
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.3.tgz",
       "integrity": "sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==",
-      "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
       }
@@ -8112,8 +8186,7 @@
     "@types/yargs-parser": {
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
-      "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
-      "dev": true
+      "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg=="
     },
     "@types/yoga-layout": {
       "version": "1.9.1",
@@ -12432,9 +12505,7 @@
     "delegate": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "delegates": {
       "version": "1.0.0",
@@ -17116,8 +17187,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "dev": true,
-      "optional": true,
       "requires": {
         "delegate": "^3.1.2"
       }
@@ -17585,9 +17654,14 @@
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
     "highlight.js": {
-      "version": "9.16.2",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.16.2.tgz",
-      "integrity": "sha512-feMUrVLZvjy0oC7FVJQcSQRqbBq9kwqnYE4+Kj9ZjbHh3g+BisiPgF49NyQbVLNdrL/qqZr3Ca9yOKwgn2i/tw=="
+      "version": "9.18.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.1.tgz",
+      "integrity": "sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg=="
+    },
+    "highlightjs-graphql": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/highlightjs-graphql/-/highlightjs-graphql-1.0.1.tgz",
+      "integrity": "sha512-g5kt/orsUJTjIt5pgs/uvi78kXndpCtYwzE7H3D0d07r3ETs9oHSZHD0EGaRPndiQ/4EYXt12rnsDkljn3ilAA=="
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -17705,13 +17779,13 @@
       "dev": true
     },
     "html-tokenize": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/html-tokenize/-/html-tokenize-2.0.0.tgz",
-      "integrity": "sha1-izqaXetHXK5qb5ZxYA0sIKspglE=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-tokenize/-/html-tokenize-2.0.1.tgz",
+      "integrity": "sha512-QY6S+hZ0f5m1WT8WffYN+Hg+xm/w5I8XeUcAq/ZYP5wVC8xbKi4Whhru3FtrAebD5EhBW8rmFzkDI6eCAuFe2w==",
       "requires": {
         "buffer-from": "~0.1.1",
         "inherits": "~2.0.1",
-        "minimist": "~0.0.8",
+        "minimist": "~1.2.5",
         "readable-stream": "~1.0.27-1",
         "through2": "~0.4.1"
       },
@@ -17727,9 +17801,9 @@
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "object-keys": {
           "version": "0.4.0",
@@ -28988,9 +29062,7 @@
     "select": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "dev": true,
-      "optional": true
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
     },
     "select-hose": {
       "version": "2.0.0",
@@ -31141,9 +31213,7 @@
     "tiny-emitter": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "tinycolor2": {
       "version": "1.4.1",
@@ -32220,6 +32290,11 @@
         "webidl-conversions": "^4.0.2",
         "xml-name-validator": "^3.0.0"
       }
+    },
+    "wait-for-expect": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.3.0.tgz",
+      "integrity": "sha512-8fJU7jiA96HfGPt+P/UilelSAZfhMBJ52YhKzlmZQvKEZU2EcD1GQ0yqGB6liLdHjYtYAoGVigYwdxr5rktvzA=="
     },
     "wait-on": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@babel/preset-react": "^7.9.4",
     "@emotion/core": "^10.0.28",
     "@emotion/styled": "^10.0.27",
-    "@leafygreen-ui/code": "^3.1.0",
+    "@leafygreen-ui/code": "^3.4.3",
     "copy-to-clipboard": "^3.3.1",
     "css-loader": "^3.5.1",
     "dlv": "^1.1.3",

--- a/src/components/dev-hub/codeblock.js
+++ b/src/components/dev-hub/codeblock.js
@@ -15,6 +15,7 @@ const CodeContainer = styled('div')`
     width: 100%;
     /* The leafygreen Code component adds a wrapper div which can't be styled using emotion */
     > div:first-of-type {
+        border-radius: ${size.small};
         width: 100%;
     }
 `;
@@ -62,12 +63,13 @@ const CodeBlock = ({ nodeData: { lang = null, value } }) => {
     const numDigits = useMemo(() => Math.floor(Math.log10(numLines) + 1), [
         numLines,
     ]);
+    // Leafy expects 'csp' as 'cs'
+    const language = lang === 'csp' ? 'cs' : lang || 'auto';
     return (
         <CodeContainer>
             <StyledCode
-                // remove this lang !== 'csp' hack once LG supports cs
-                // https://github.com/highlightjs/highlight.js/blob/master/SUPPORTED_LANGUAGES.md
-                language={lang && lang !== 'csp' ? lang : 'auto'}
+                copyable={false}
+                language={language}
                 numdigits={numDigits}
                 showLineNumbers
                 variant="dark"


### PR DESCRIPTION
This PR upgrades the leafy codeblock to v3.4.3. Additionally I made the following tweaks:

- The codeblock README lists `csp` as a valid shorthand for csharp, but it actually expects `cs`. I singled this case out in the component language logic.
- Added the `copyable={false}` prop
- Cleaned up borders around the code component

![Screen Shot 2020-04-15 at 1 17 03 PM](https://user-images.githubusercontent.com/9064401/79367418-e02b4c80-7f1b-11ea-8dc8-723aa5c02a54.png)
