### PR TITLE
Fix codeblock border

### DIFF
--- a/src/components/dev-hub/codeblock.js
+++ b/src/components/dev-hub/codeblock.js
@@ -15,7 +15,7 @@ const CodeContainer = styled('div')`
     width: 100%;
     /* The leafygreen Code component adds a wrapper div which can't be styled using emotion */
     > div:first-of-type {
-        border-radius: ${size.small};
+        border: none;
         width: 100%;
     }
 `;
@@ -30,7 +30,8 @@ const CopyContainer = styled('div')`
 `;
 
 const StyledCode = styled(Code)`
-    border-radius: ${size.xsmall};
+    border: 1px solid ${colorMap.greyDarkThree};
+    border-radius: ${size.small};
     line-height: ${lineHeight.xsmall};
     padding-right: ${size.xlarge};
     padding-top: ${size.large};


### PR DESCRIPTION
I thought I had added this into the codeblock dep update but it looks like I missed it.

This PR updates the border on the codeblock to be uniform throughout:

![Screen Shot 2020-04-15 at 3 14 02 PM](https://user-images.githubusercontent.com/9064401/79378839-022ccb00-7f2c-11ea-9ac9-9321c29684a3.png)
