### PR TITLE
Allow Authors to Exclude Learn Page Articles

### DIFF
--- a/src/utils/setup/on-create-page.js
+++ b/src/utils/setup/on-create-page.js
@@ -1,4 +1,5 @@
 const memoizerific = require('memoizerific');
+const { removeExcludedArticles } = require('./remove-excluded-articles');
 const { getNestedValue } = require('../get-nested-value');
 const { getMetadata } = require('../get-metadata');
 
@@ -123,16 +124,21 @@ const onCreatePage = async (
     actions,
     inheritedStitchClient,
     homeFeaturedArticles,
-    learnFeaturedArticles
+    learnFeaturedArticles,
+    excludedLearnPageArticles
 ) => {
     const { createPage, deletePage } = actions;
     stitchClient = inheritedStitchClient;
     switch (page.path) {
         case '/learn/':
             const allArticles = await getAllArticles();
-            const filters = await getLearnPageFilters(allArticles);
-            const featuredLearnArticles = findArticlesFromSlugs(
+            const learnPageArticles = removeExcludedArticles(
                 allArticles,
+                excludedLearnPageArticles
+            );
+            const filters = await getLearnPageFilters(learnPageArticles);
+            const featuredLearnArticles = findArticlesFromSlugs(
+                learnPageArticles,
                 learnFeaturedArticles || DEFAULT_FEATURED_LEARN_SLUGS,
                 MAX_LEARN_PAGE_FEATURED_ARTICLES
             );
@@ -141,7 +147,7 @@ const onCreatePage = async (
                 ...page,
                 context: {
                     ...page.context,
-                    allArticles,
+                    allArticles: learnPageArticles,
                     featuredArticles: featuredLearnArticles,
                     filters,
                 },

--- a/src/utils/setup/remove-excluded-articles.js
+++ b/src/utils/setup/remove-excluded-articles.js
@@ -1,0 +1,25 @@
+const removeExcludedArticles = (allArticles, excludedLearnPageArticles) => {
+    if (excludedLearnPageArticles && excludedLearnPageArticles.length) {
+        const filteredArticles = allArticles.filter(
+            article =>
+                !excludedLearnPageArticles.find(excludedArticle =>
+                    article.query_fields.slug.match(
+                        new RegExp(`^/?${excludedArticle}$`)
+                    )
+                )
+        );
+        // Warn writers if not all excludes were found
+        if (
+            allArticles.length - excludedLearnPageArticles.length <
+            filteredArticles.length
+        ) {
+            console.warn(
+                'Not all articles requested were excluded from the learn page. Please double check article slugs for the page group.'
+            );
+        }
+        return filteredArticles;
+    }
+    return allArticles;
+};
+
+module.exports = { removeExcludedArticles };

--- a/tests/utils/remove-excluded-articles.test.js
+++ b/tests/utils/remove-excluded-articles.test.js
@@ -1,0 +1,31 @@
+const {
+    removeExcludedArticles,
+} = require('../../src/utils/setup/remove-excluded-articles');
+
+it('should remove specific articles from an array of all articles', () => {
+    const includedArticleSlug = '/included';
+    const excludedArticleSlug = '/excluded';
+    const allArticles = [
+        { query_fields: { slug: includedArticleSlug } },
+        { query_fields: { slug: excludedArticleSlug } },
+    ];
+    const articlesToExclude = [];
+
+    expect(
+        removeExcludedArticles(allArticles, articlesToExclude)
+    ).toStrictEqual(allArticles);
+
+    articlesToExclude.push(excludedArticleSlug);
+    expect(
+        removeExcludedArticles(allArticles, articlesToExclude)
+    ).toStrictEqual([{ query_fields: { slug: includedArticleSlug } }]);
+
+    // Don't log this next warning out for this test
+    const warn = console.warn;
+    console.warn = jest.fn();
+    expect(
+        removeExcludedArticles(allArticles, ['/include/exclude'])
+    ).toStrictEqual(allArticles);
+
+    console.warn = warn;
+});


### PR DESCRIPTION
This PR enables the front-end to remove requested articles from being shown on the learn page. We are expecting this to come from the back-end as `learnPageExclude` as one of the page groups.

Specifically, if an article is requested to be removed from the learn page:
- We still create the article as normal
- We still show the article in the `tag` pages
- We do not show the article on the learn page
- We do not count the article in the filters on the learn page

I wrote a unit test for the exclusion, as well as locally checked a value for `learnPageExclude` to check out the behavior.