### PR TITLE
Add an RSS Feed for Articles

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,3 +1,6 @@
+const { rssFeedArticleData } = require('./src/queries/rss-feed-article-data');
+const { siteUrl } = require('./src/queries/site-url');
+const { serializeRssData } = require('./src/utils/setup/serialize-rss-data');
 const { generatePathPrefix } = require('./src/utils/generate-path-prefix');
 const { getMetadata } = require('./src/utils/get-metadata');
 
@@ -32,6 +35,20 @@ module.exports = {
             options: {
                 id: 'GTM-GDFN',
                 includeInDevelopment: false,
+            },
+        },
+        {
+            resolve: 'gatsby-plugin-feed',
+            options: {
+                query: siteUrl,
+                feeds: [
+                    {
+                        serialize: serializeRssData,
+                        query: rssFeedArticleData,
+                        output: '/rss.xml',
+                        title: 'MongoDB Developer Hub RSS Feed',
+                    },
+                ],
             },
         },
     ],

--- a/gatsby-config.prod.js
+++ b/gatsby-config.prod.js
@@ -1,3 +1,6 @@
+const { rssFeedArticleData } = require('./src/queries/rss-feed-article-data');
+const { siteUrl } = require('./src/queries/site-url');
+const { serializeRssData } = require('./src/utils/setup/serialize-rss-data');
 const { getMetadata } = require('./src/utils/get-metadata');
 
 require('dotenv').config({
@@ -29,6 +32,20 @@ module.exports = {
             options: {
                 id: 'GTM-GDFN',
                 includeInDevelopment: false,
+            },
+        },
+        {
+            resolve: 'gatsby-plugin-feed',
+            options: {
+                query: siteUrl,
+                feeds: [
+                    {
+                        serialize: serializeRssData,
+                        query: rssFeedArticleData,
+                        output: '/rss.xml',
+                        title: 'MongoDB Developer Hub RSS Feed',
+                    },
+                ],
             },
         },
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -16701,6 +16701,33 @@
         }
       }
     },
+    "gatsby-plugin-feed": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-feed/-/gatsby-plugin-feed-2.4.1.tgz",
+      "integrity": "sha512-4+vdto148cIKPJT7bI9i//opwUu6ZqO5l1WNGAGubByWPLIA47VadcC5GzMHpWVtTMZugnmfotZI8t/3iCNP3w==",
+      "requires": {
+        "@babel/runtime": "^7.8.7",
+        "@hapi/joi": "^15.1.1",
+        "fs-extra": "^8.1.0",
+        "lodash.merge": "^4.6.2",
+        "rss": "^1.2.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+        }
+      }
+    },
     "gatsby-plugin-google-tagmanager": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-google-tagmanager/-/gatsby-plugin-google-tagmanager-2.2.1.tgz",
@@ -23781,6 +23808,11 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
     },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -28902,6 +28934,30 @@
         "inherits": "^2.0.1"
       }
     },
+    "rss": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rss/-/rss-1.2.2.tgz",
+      "integrity": "sha1-UKFpiHYTgTOnT5oF0r3I240nqSE=",
+      "requires": {
+        "mime-types": "2.1.13",
+        "xml": "1.0.1"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.25.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+          "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I="
+        },
+        "mime-types": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+          "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
+          "requires": {
+            "mime-db": "~1.25.0"
+          }
+        }
+      }
+    },
     "rst-selector-parser": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
@@ -33171,6 +33227,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "dotenv": "^8.2.0",
     "gatsby": "^2.20.16",
     "gatsby-plugin-emotion": "^4.2.1",
+    "gatsby-plugin-feed": "^2.4.1",
     "gatsby-plugin-google-tagmanager": "^2.2.1",
     "gatsby-plugin-react-helmet": "^3.2.1",
     "gatsby-plugin-sitemap": "^2.3.1",

--- a/src/queries/rss-feed-article-data.js
+++ b/src/queries/rss-feed-article-data.js
@@ -1,0 +1,11 @@
+const rssFeedArticleData = `
+    query RSSFeedArticleData {
+        allArticle {
+            nodes {
+                slug: id
+            }
+        }
+    }
+`;
+
+module.exports = { rssFeedArticleData };

--- a/src/queries/rss-feed-article-data.js
+++ b/src/queries/rss-feed-article-data.js
@@ -3,6 +3,8 @@ const rssFeedArticleData = `
         allArticle {
             nodes {
                 slug: id
+                title
+                description
             }
         }
     }

--- a/src/queries/rss-feed-article-data.js
+++ b/src/queries/rss-feed-article-data.js
@@ -1,10 +1,11 @@
 const rssFeedArticleData = `
     query RSSFeedArticleData {
-        allArticle {
+        allArticle(sort: {fields: pubdate, order: DESC}) {
             nodes {
                 slug: id
-                title
                 description
+                pubdate
+                title
             }
         }
     }

--- a/src/queries/site-url.js
+++ b/src/queries/site-url.js
@@ -1,0 +1,11 @@
+const siteUrl = `
+  {
+    site {
+      siteMetadata {
+        siteUrl
+      }
+    }
+  }
+`;
+
+module.exports = { siteUrl };

--- a/src/utils/setup/create-article-node.js
+++ b/src/utils/setup/create-article-node.js
@@ -17,6 +17,7 @@ const createArticleNode = (
         const content = {
             title: getNestedText(doc.query_fields['title']),
             description: getNestedText(doc.query_fields['meta-description']),
+            pubdate: doc.query_fields['pubdate'],
         };
         createNode({
             id: slug,

--- a/src/utils/setup/create-article-node.js
+++ b/src/utils/setup/create-article-node.js
@@ -10,7 +10,10 @@ const createArticleNode = (
 ) => {
     const filename = getNestedValue(['filename'], doc) || '';
     const isArticlePage =
-        !filename.includes('images/') && filename.endsWith('.txt');
+        !filename.includes('images/') &&
+        filename.endsWith('.txt') &&
+        // Remove extraneous src/index.txt file in devhub-content repo
+        filename !== 'index.txt';
     const slug = doc.page_id.replace(`${PAGE_ID_PREFIX}/`, '');
     slugContentMapping[slug] = doc;
     if (isArticlePage) {

--- a/src/utils/setup/create-article-page.js
+++ b/src/utils/setup/create-article-page.js
@@ -16,7 +16,6 @@ const createArticlePage = (
     createPage
 ) => {
     const pageNodes = slugContentMapping[page];
-
     if (pageNodes && Object.keys(pageNodes).length > 0) {
         const template = getTemplate(
             getNestedValue(['ast', 'options', 'template'], pageNodes)

--- a/src/utils/setup/serialize-rss-data.js
+++ b/src/utils/setup/serialize-rss-data.js
@@ -1,5 +1,6 @@
 const serializeRssData = ({ query: { site, allArticle } }) =>
     allArticle.nodes.map(article => ({
+        date: article.pubdate,
         description: article.description,
         title: article.title,
         url: site.siteMetadata.siteUrl + article.slug,

--- a/src/utils/setup/serialize-rss-data.js
+++ b/src/utils/setup/serialize-rss-data.js
@@ -3,7 +3,7 @@ const serializeRssData = ({ query: { site, allArticle } }) =>
         date: article.pubdate,
         description: article.description,
         title: article.title,
-        url: site.siteMetadata.siteUrl + article.slug,
+        url: `${site.siteMetadata.siteUrl}/${article.slug}`,
     }));
 
 module.exports = { serializeRssData };

--- a/src/utils/setup/serialize-rss-data.js
+++ b/src/utils/setup/serialize-rss-data.js
@@ -1,5 +1,5 @@
 const serializeRssData = ({ query: { site, allArticle } }) =>
-    allArticle.map(article => ({
+    allArticle.nodes.map(article => ({
         description: article.description,
         title: article.title,
         url: site.siteMetadata.siteUrl + article.slug,

--- a/src/utils/setup/serialize-rss-data.js
+++ b/src/utils/setup/serialize-rss-data.js
@@ -1,0 +1,8 @@
+const serializeRssData = ({ query: { site, allArticle } }) =>
+    allArticle.map(article => ({
+        description: article.description,
+        title: article.title,
+        url: site.siteMetadata.siteUrl + article.slug,
+    }));
+
+module.exports = { serializeRssData };

--- a/tests/utils/create-article-node.test.js
+++ b/tests/utils/create-article-node.test.js
@@ -3,6 +3,7 @@ import { createArticleNode } from '../../src/utils/setup/create-article-node';
 describe('Should properly postprocess an article node after it is fetched', () => {
     const pageIdPrefix = 'test-pages/test';
     const articleDescription = 'Article Description';
+    const articlePubdate = '2030-01-01';
     const articleSlug = 'article/test-article';
     const articleTitle = 'Test Article';
     const articleNode = {
@@ -10,8 +11,9 @@ describe('Should properly postprocess an article node after it is fetched', () =
             children: [],
         },
         query_fields: {
-            title: [{ type: 'text', value: articleTitle }],
             'meta-description': [{ type: 'text', value: articleDescription }],
+            pubdate: articlePubdate,
+            title: [{ type: 'text', value: articleTitle }],
         },
         filename: `${articleSlug}.txt`,
         page_id: `${pageIdPrefix}/${articleSlug}`,
@@ -72,11 +74,13 @@ describe('Should properly postprocess an article node after it is fetched', () =
         expect(createdArticleNode.internal.type).toBe('Article');
         expect(createdArticleNode.title).toBe(articleTitle);
         expect(createdArticleNode.description).toBe(articleDescription);
+        expect(createdArticleNode.pubdate).toBe(articlePubdate);
 
         expect(createdArticleNode.internal.contentDigest).not.toBeUndefined();
         expect(createContentDigest.mock.calls.length).toBe(1);
         const contentToDigest = {
             title: articleTitle,
+            pubdate: articlePubdate,
             description: articleDescription,
         };
         expect(createContentDigest.mock.calls[0][0]).toStrictEqual(


### PR DESCRIPTION
This PR uses the [gatsby-plugin-feed](https://www.gatsbyjs.org/packages/gatsby-plugin-feed/) plugin to add an RSS feed for our articles at `/rss.xml` on production builds. GitHub won't let me attach an 'xml' file here, so I took a screenshot (and am happy to share the file on request).

For each article I included:
- Title
- Description
- Link
- Published Date

with results sorted so the newest articles are first. I'm not sure what else we would want to add in here.

![Screen Shot 2020-04-15 at 5 19 31 PM](https://user-images.githubusercontent.com/9064401/79390311-7a4fbc80-7f3d-11ea-9f47-38bbc6519091.png)
