### PR TITLE
Create github action for CI testing

### DIFF
--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -12,6 +12,17 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: '12.x'
+            - name: Cache node modules
+              uses: actions/cache@v1
+              with:
+                  path: node_modules
+                  key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-
+
+            - name: Install Dependencies
+              if: steps.cache.outputs.cache-hit != 'true'
+              run: npm ci
             - name: Create .env.development file
               run: |
                   touch .env.development
@@ -22,6 +33,7 @@ jobs:
             - name: Cypress run
               uses: cypress-io/github-action@v1
               with:
+                  install: false
                   start: npm run develop
                   wait-on: 'http://localhost:8000'
                   config-file: cypress.json

--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -32,7 +32,7 @@ jobs:
               run: npm ci
             - name: Install Cypress
               if: steps.cypresscache.outputs.cache-hit != 'true'
-              run: npm ci cypress
+              run: npm install cypress
 
             - name: Create .env.development file
               run: |

--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -14,6 +14,7 @@ jobs:
                   node-version: '12.x'
             - name: Cache node modules
               uses: actions/cache@v1
+              id: cache
               with:
                   path: node_modules
                   key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -20,10 +20,20 @@ jobs:
                   key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
                   restore-keys: |
                       ${{ runner.os }}-node-
+            - name: Cache Cypress
+              uses: actions/cache@v1
+              id: cypresscache
+              with:
+                  path: ~/.cache/Cypress
+                  key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
 
             - name: Install Dependencies
               if: steps.cache.outputs.cache-hit != 'true'
               run: npm ci
+            - name: Install Cypress
+              if: steps.cypresscache.outputs.cache-hit != 'true'
+              run: npm ci cypress
+
             - name: Create .env.development file
               run: |
                   touch .env.development

--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -1,0 +1,35 @@
+name: DevHub CI test
+on:
+    pull_request:
+        branches: [master, staging]
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout target branch
+              uses: actions/checkout@v2
+            - name: Use Node.js 12.x
+              uses: actions/setup-node@v1
+              with:
+                  node-version: '12.x'
+            - name: Cache Packages
+              uses: bahmutov/npm-install@v1
+            - name: Create .env.development file
+              run: |
+                  touch .env.development
+                  echo "GATSBY_SITE=devhub" > .env.development; \
+                  echo "GATSBY_PARSER_USER=sophstad" >> .env.development; \
+                  echo "GATSBY_PARSER_BRANCH=master" >> .env.development; \
+                  echo "GATSBY_SNOOTY_DEV=true" >> .env.production; \
+            - name: Cypress run
+              uses: cypress-io/github-action@v1
+              with:
+                  start: npm run develop
+                  wait-on: 'http://localhost:8000'
+                  config-file: cypress.json
+            - name: Generate artifacts on failure
+              uses: actions/upload-artifact@v1
+              if: failure()
+              with:
+                  name: cypress-screenshots
+                  path: cypress/screenshots

--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -24,7 +24,7 @@ jobs:
               uses: actions/cache@v1
               id: cypresscache
               with:
-                  path: ~/.cache/Cypress
+                  path: /home/runner/.cache/Cypress
                   key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
 
             - name: Install Dependencies

--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -12,8 +12,6 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: '12.x'
-            - name: Cache Packages
-              uses: bahmutov/npm-install@v1
             - name: Create .env.development file
               run: |
                   touch .env.development

--- a/.github/workflows/devhub-npm-test.yaml
+++ b/.github/workflows/devhub-npm-test.yaml
@@ -18,6 +18,15 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: '12.x'
-            - name: Cache Packages
-              uses: bahmutov/npm-install@v1
+            - name: Cache node modules
+              uses: actions/cache@v1
+              with:
+                  path: node_modules
+                  key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-
+
+            - name: Install Dependencies
+              if: steps.cache.outputs.cache-hit != 'true'
+              run: npm ci
             - run: npm test

--- a/.github/workflows/devhub-npm-test.yaml
+++ b/.github/workflows/devhub-npm-test.yaml
@@ -20,6 +20,7 @@ jobs:
                   node-version: '12.x'
             - name: Cache node modules
               uses: actions/cache@v1
+              id: cache
               with:
                   path: node_modules
                   key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![DevHub npm test](https://github.com/mongodb/devhub/workflows/DevHub%20npm%20test/badge.svg)
+![DevHub CI test](https://github.com/mongodb/devhub/workflows/DevHub%20ci%20test/badge.svg)
 
 # MongoDB Developer Hub Front-End
 


### PR DESCRIPTION
This PR adds a github action for CI testing a development build of the devhub with cypress to PRs to both staging and master.

**Test Duration (these tests are run in parallel)**
e2e tests run in ~2 minutes 30 seconds (biggest bottlenecks, starting gatsby server, npm installing)
unit tests run in ~1 minute 10 seconds (npm installing)

It looks like modules are cached between jobs (based on npm cache key values lining up), but each one has to `npm install` which can take ~30 seconds. These jobs are done in parallel, however, so it isn't a big cost in terms of overall duration. I also like having these jobs separate to keep workflows smaller and isolate failures.

Cache logs for e2e:
![Screen Shot 2020-04-16 at 10 52 01 AM](https://user-images.githubusercontent.com/9064401/79471796-0c54d500-7fd1-11ea-90de-a8f4349dc018.png)

Cache logs for unit testing:
![Screen Shot 2020-04-16 at 10 51 39 AM](https://user-images.githubusercontent.com/9064401/79471822-14147980-7fd1-11ea-873c-e4eb25331cf1.png)
