### PR TITLE
Center Play Button on Twitch Preview

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -98,9 +98,13 @@ const ThumbnailCard = styled(Card)`
 `;
 
 const ThumbnailButton = styled(Button)`
-    left: 40%;
+    left: 0;
+    right: 0;
+    top: 0;
+    /* Account for bottom margin and title of card */
+    bottom: 52px;
+    margin: auto;
     position: absolute;
-    top: 35%;
 `;
 
 const SIZE_TOKEN = '%{width}x%{height}';


### PR DESCRIPTION
This PR fixes the play button on the thumbnail for the Twitch video thumbnail on the home page to be properly centered.

Staging:
![Screen Shot 2020-04-16 at 4 23 26 PM](https://user-images.githubusercontent.com/9064401/79503193-bdbe2f80-7ffe-11ea-9666-bbe64f03a7be.png)

This PR:
![Screen Shot 2020-04-16 at 4 22 22 PM](https://user-images.githubusercontent.com/9064401/79503211-c4e53d80-7ffe-11ea-8d12-cc388fcf39a0.png)

