### PR TITLE
Add Cypress Github Action (With Caching)

### DIFF
--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -34,7 +34,7 @@ jobs:
                   echo "GATSBY_SITE=devhub" > .env.development; \
                   echo "GATSBY_PARSER_USER=sophstad" >> .env.development; \
                   echo "GATSBY_PARSER_BRANCH=master" >> .env.development; \
-                  echo "GATSBY_SNOOTY_DEV=true" >> .env.production; \
+                  echo "GATSBY_SNOOTY_DEV=true" >> .env.development; \
             - name: Cypress run
               uses: cypress-io/github-action@v1
               with:

--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -40,8 +40,8 @@ jobs:
               with:
                   install: false
                   start: |
-                      npm run build;
-                      npm run serve;
+                      ./node_modules/.bin/gatsby build --prefix-paths;
+                      ./node_modules/.bin/gatsby serve --prefix-paths;
                   wait-on: 'http://localhost:9000'
             - name: Generate artifacts on failure
               uses: actions/upload-artifact@v1

--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -35,14 +35,15 @@ jobs:
                   echo "GATSBY_PARSER_USER=sophstad" >> .env.development; \
                   echo "GATSBY_PARSER_BRANCH=master" >> .env.development; \
                   echo "GATSBY_SNOOTY_DEV=true" >> .env.development; \
+            - name: Build Gatsby
+              run: npm run build
             - name: Cypress run
               uses: cypress-io/github-action@v1
               with:
                   install: false
-                  start: |
-                      ./node_modules/.bin/gatsby build --prefix-paths;
-                      ./node_modules/.bin/gatsby serve --prefix-paths;
+                  start: npm run serve
                   wait-on: 'http://localhost:9000'
+                  config-file: cypress.json
             - name: Generate artifacts on failure
               uses: actions/upload-artifact@v1
               if: failure()

--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -40,8 +40,8 @@ jobs:
               with:
                   install: false
                   start: |
-                      npm run build
-                      npm run serve
+                      npm run build;
+                      npm run serve;
                   wait-on: 'http://localhost:9000'
             - name: Generate artifacts on failure
               uses: actions/upload-artifact@v1

--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -28,13 +28,13 @@ jobs:
               if: steps.cache.outputs.cache-hit == 'true'
               run: ./node_modules/.bin/cypress install
 
-            - name: Create .env.development file
+            - name: Create .env.production file
               run: |
-                  touch .env.development
-                  echo "GATSBY_SITE=devhub" > .env.development; \
-                  echo "GATSBY_PARSER_USER=sophstad" >> .env.development; \
-                  echo "GATSBY_PARSER_BRANCH=master" >> .env.development; \
-                  echo "GATSBY_SNOOTY_DEV=true" >> .env.development; \
+                  touch .env.production
+                  echo "GATSBY_SITE=devhub" > .env.production; \
+                  echo "GATSBY_PARSER_USER=sophstad" >> .env.production; \
+                  echo "GATSBY_PARSER_BRANCH=master" >> .env.production; \
+                  echo "GATSBY_SNOOTY_DEV=true" >> .env.production; \
             - name: Build Gatsby
               run: npm run build
             - name: Cypress run

--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -39,9 +39,10 @@ jobs:
               uses: cypress-io/github-action@v1
               with:
                   install: false
-                  start: npm run develop
-                  wait-on: 'http://localhost:8000'
-                  config-file: cypress.json
+                  start: |
+                      npm run build
+                      npm run serve
+                  wait-on: 'http://localhost:9000'
             - name: Generate artifacts on failure
               uses: actions/upload-artifact@v1
               if: failure()

--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -25,6 +25,7 @@ jobs:
               if: steps.cache.outputs.cache-hit != 'true'
               run: npm ci
             - name: Install Cypress
+              if: steps.cache.outputs.cache-hit == 'true'
               run: ./node_modules/.bin/cypress install
 
             - name: Create .env.development file

--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -1,0 +1,49 @@
+name: DevHub CI test
+on:
+    pull_request:
+        branches: [master, staging]
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout target branch
+              uses: actions/checkout@v2
+            - name: Use Node.js 12.x
+              uses: actions/setup-node@v1
+              with:
+                  node-version: '12.x'
+            - name: Cache node modules
+              uses: actions/cache@v1
+              id: cache
+              with:
+                  path: node_modules
+                  key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-
+
+            - name: Install Dependencies
+              if: steps.cache.outputs.cache-hit != 'true'
+              run: npm ci
+            - name: Install Cypress
+              run: ./node_modules/.bin/cypress install
+
+            - name: Create .env.development file
+              run: |
+                  touch .env.development
+                  echo "GATSBY_SITE=devhub" > .env.development; \
+                  echo "GATSBY_PARSER_USER=sophstad" >> .env.development; \
+                  echo "GATSBY_PARSER_BRANCH=master" >> .env.development; \
+                  echo "GATSBY_SNOOTY_DEV=true" >> .env.production; \
+            - name: Cypress run
+              uses: cypress-io/github-action@v1
+              with:
+                  install: false
+                  start: npm run develop
+                  wait-on: 'http://localhost:8000'
+                  config-file: cypress.json
+            - name: Generate artifacts on failure
+              uses: actions/upload-artifact@v1
+              if: failure()
+              with:
+                  name: cypress-screenshots
+                  path: cypress/screenshots

--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -42,7 +42,7 @@ jobs:
               with:
                   install: false
                   start: npm run serve
-                  wait-on: 'http://localhost:9000'
+                  wait-on: 'http://localhost:9000/master/devhub/sophstad/HEAD'
                   config-file: cypress.json
             - name: Generate artifacts on failure
               uses: actions/upload-artifact@v1

--- a/.github/workflows/devhub-npm-test.yaml
+++ b/.github/workflows/devhub-npm-test.yaml
@@ -18,6 +18,16 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: '12.x'
-            - name: Cache Packages
-              uses: bahmutov/npm-install@v1
+            - name: Cache node modules
+              uses: actions/cache@v1
+              id: cache
+              with:
+                  path: node_modules
+                  key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-
+
+            - name: Install Dependencies
+              if: steps.cache.outputs.cache-hit != 'true'
+              run: npm ci
             - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![DevHub npm test](https://github.com/mongodb/devhub/workflows/DevHub%20npm%20test/badge.svg)
+![DevHub CI test](https://github.com/mongodb/devhub/workflows/DevHub%20ci%20test/badge.svg)
 
 # MongoDB Developer Hub Front-End
 

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,4 @@
 {
-    "baseUrl": "http://localhost:9000",
+    "baseUrl": "http://localhost:9000/master/devhub/sophstad/HEAD",
     "viewportWidth": 1280
 }

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,4 @@
 {
-    "baseUrl": "http://localhost:8000",
+    "baseUrl": "http://localhost:9000",
     "viewportWidth": 1280
 }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,9 +24,14 @@ Cypress.Commands.add('mockEventsApi', () => {
 // https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/stubbing-spying__window-fetch#readme
 
 Cypress.Commands.add('visitWithoutFetch', path => {
-    cy.visit(path, {
-        onBeforeLoad(win) {
-            delete win.fetch;
-        },
-    });
+    cy.readFile('node_modules/whatwg-fetch/dist/fetch.umd.js').then(
+        polyfill => {
+            cy.visit(path, {
+                onBeforeLoad(win) {
+                    delete win.fetch;
+                    win.eval(polyfill);
+                },
+            });
+        }
+    );
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11684,6 +11684,13 @@
       "requires": {
         "node-fetch": "2.1.2",
         "whatwg-fetch": "2.0.4"
+      },
+      "dependencies": {
+        "whatwg-fetch": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+          "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+        }
       }
     },
     "cross-spawn": {
@@ -32950,9 +32957,9 @@
       }
     },
     "whatwg-fetch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "typeface-fira-mono": "0.0.72",
     "webpack": "^4.42.1",
     "webpack-cli": "^3.3.11",
-    "webpack-dev-server": "^3.10.3"
+    "webpack-dev-server": "^3.10.3",
+    "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",


### PR DESCRIPTION
This PR adds a github action for CI testing a development build of the devhub with cypress to PRs to both staging and master. Furthermore, this PR adds conditional `npm install`ing only if a cached copy of `node_modules` is unavailable.

**Test Duration** (these tests are run in parallel)
e2e tests run in ~2 minutes
unit tests run in ~1 minute

I resolved issues with `npm installing` if a cache is available for `node_modules` which cut times down significantly on both test jobs. Restoring the cache still takes a bit of time, but this is likely because it is ~200MB compressed. Caching here is still faster than a fresh install.