### PR TITLE
Generalize Twitch Video Logic

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -152,3 +152,11 @@ export const devhubMapping = {
     nodejs: 'Node.js',
     java: 'Java',
 };
+
+// Twitch API constants
+export const TWITCH_API_ENDPOINT = 'https://api.twitch.tv/helix/';
+export const TWITCH_CLIENT_ID = '041r2glmgub2pt357ss0la44j2sz95';
+export const TWITCH_MDB_CHANNEL_ID = '467752938';
+export const TWITCH_headers = { 'Client-ID': TWITCH_CLIENT_ID };
+export const TWITCH_STREAMS_URL = `${TWITCH_API_ENDPOINT}streams?user_id=${TWITCH_MDB_CHANNEL_ID}`;
+export const TWITCH_VIDEO_URL = `${TWITCH_API_ENDPOINT}videos?user_id=${TWITCH_MDB_CHANNEL_ID}&first=`;

--- a/src/constants.js
+++ b/src/constants.js
@@ -157,6 +157,6 @@ export const devhubMapping = {
 export const TWITCH_API_ENDPOINT = 'https://api.twitch.tv/helix/';
 export const TWITCH_CLIENT_ID = '041r2glmgub2pt357ss0la44j2sz95';
 export const TWITCH_MDB_CHANNEL_ID = '467752938';
-export const TWITCH_headers = { 'Client-ID': TWITCH_CLIENT_ID };
+export const TWITCH_HEADERS = { 'Client-ID': TWITCH_CLIENT_ID };
 export const TWITCH_STREAMS_URL = `${TWITCH_API_ENDPOINT}streams?user_id=${TWITCH_MDB_CHANNEL_ID}`;
 export const TWITCH_VIDEO_URL = `${TWITCH_API_ENDPOINT}videos?user_id=${TWITCH_MDB_CHANNEL_ID}&first=`;

--- a/src/utils/fetch-twitch-videos.js
+++ b/src/utils/fetch-twitch-videos.js
@@ -1,13 +1,7 @@
 import { get } from './request';
 
-const TWITCH_API_ENDPOINT = 'https://api.twitch.tv/helix/';
-const CLIENT_ID = '041r2glmgub2pt357ss0la44j2sz95';
-const MDB_CHANNEL_ID = '467752938';
-const video_URL = `${TWITCH_API_ENDPOINT}videos?user_id=${MDB_CHANNEL_ID}&first=`;
-const headers = { 'Client-ID': CLIENT_ID };
-
 // Fetches videos from twitch api
-const fetchTwitchVideos = async (videoLimit = 1) => {
+const fetchTwitchVideos = async (headers, video_URL, videoLimit = 1) => {
     try {
         const videoResp = await get(video_URL + videoLimit, headers);
         // return the whole array of videos, but ignore pagination for now

--- a/src/utils/fetch-twitch-videos.js
+++ b/src/utils/fetch-twitch-videos.js
@@ -1,0 +1,22 @@
+import { get } from './request';
+
+const TWITCH_API_ENDPOINT = 'https://api.twitch.tv/helix/';
+const CLIENT_ID = '041r2glmgub2pt357ss0la44j2sz95';
+const MDB_CHANNEL_ID = '467752938';
+const video_URL = `${TWITCH_API_ENDPOINT}videos?user_id=${MDB_CHANNEL_ID}&first=`;
+const headers = { 'Client-ID': CLIENT_ID };
+
+// Fetches videos from twitch api
+const fetchTwitchVideos = async (videoLimit = 1) => {
+    try {
+        const videoResp = await get(video_URL + videoLimit, headers);
+        // return the whole array of videos, but ignore pagination for now
+        return videoResp.data;
+    } catch (error) {
+        console.error(error);
+    }
+
+    return [];
+};
+
+export default fetchTwitchVideos;

--- a/src/utils/use-twitch-api.js
+++ b/src/utils/use-twitch-api.js
@@ -1,13 +1,11 @@
 import { useState, useEffect, useCallback } from 'react';
+import fetchTwitchVideos from '../utils/fetch-twitch-videos';
 import { get } from './request';
-
-const TWITCH_API_ENDPOINT = 'https://api.twitch.tv/helix/';
-const CLIENT_ID = '041r2glmgub2pt357ss0la44j2sz95';
-const MDB_CHANNEL_ID = '467752938';
-const STREAMS_URL = `${TWITCH_API_ENDPOINT}streams?user_id=${MDB_CHANNEL_ID}`;
-const video_URL = `${TWITCH_API_ENDPOINT}videos?user_id=${MDB_CHANNEL_ID}&first=`;
-
-const headers = { 'Client-ID': CLIENT_ID };
+import {
+    TWITCH_headers,
+    TWITCH_STREAMS_URL,
+    TWITCH_VIDEO_URL,
+} from '../constants';
 
 /**
  * @param {Object} config
@@ -27,7 +25,10 @@ export default ({ getStream = true, videoLimit = 1 } = {}) => {
         try {
             // Get stream
             if (getStream) {
-                const streamResp = await get(STREAMS_URL, headers);
+                const streamResp = await get(
+                    TWITCH_STREAMS_URL,
+                    TWITCH_headers
+                );
                 // since we're only interested in one channel just get the first
                 currentStream = streamResp.data[0];
                 if (currentStream) {
@@ -37,9 +38,13 @@ export default ({ getStream = true, videoLimit = 1 } = {}) => {
             }
             //get videos
             if (!currentStream && videoLimit) {
-                const videoResp = await get(video_URL + videoLimit, headers);
+                const videoRespData = await fetchTwitchVideos(
+                    TWITCH_headers,
+                    TWITCH_VIDEO_URL,
+                    videoLimit
+                );
                 // return the whole array of videos, but ignore pagination for now
-                setVideos(videoResp.data);
+                setVideos(videoRespData);
             }
         } catch (error) {
             console.error(error);

--- a/src/utils/use-twitch-api.js
+++ b/src/utils/use-twitch-api.js
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import fetchTwitchVideos from '../utils/fetch-twitch-videos';
 import { get } from './request';
 import {
-    TWITCH_headers,
+    TWITCH_HEADERS,
     TWITCH_STREAMS_URL,
     TWITCH_VIDEO_URL,
 } from '../constants';
@@ -27,7 +27,7 @@ export default ({ getStream = true, videoLimit = 1 } = {}) => {
             if (getStream) {
                 const streamResp = await get(
                     TWITCH_STREAMS_URL,
-                    TWITCH_headers
+                    TWITCH_HEADERS
                 );
                 // since we're only interested in one channel just get the first
                 currentStream = streamResp.data[0];
@@ -39,7 +39,7 @@ export default ({ getStream = true, videoLimit = 1 } = {}) => {
             //get videos
             if (!currentStream && videoLimit) {
                 const videoRespData = await fetchTwitchVideos(
-                    TWITCH_headers,
+                    TWITCH_HEADERS,
                     TWITCH_VIDEO_URL,
                     videoLimit
                 );


### PR DESCRIPTION
Pulled out just the logic for accessing videos from `useTwitchApi.js` to reuse it for the video/media page.