### PR TITLE
Mobile Article Layout Issues

### DIFF
--- a/src/components/ListTable.js
+++ b/src/components/ListTable.js
@@ -20,6 +20,10 @@ const Table = styled('table')`
     }
 `;
 
+const TableContainer = styled('div')`
+    overflow-x: auto;
+`;
+
 const ListTable = ({ nodeData, nodeData: { children }, ...rest }) => {
     const title = getNestedValue(['argument', 0, 'value'], nodeData);
     const headerRowCount =
@@ -45,7 +49,7 @@ const ListTable = ({ nodeData, nodeData: { children }, ...rest }) => {
     }
 
     return (
-        <div>
+        <TableContainer>
             <H5>{title}</H5>
             <Table
                 className={[
@@ -71,7 +75,7 @@ const ListTable = ({ nodeData, nodeData: { children }, ...rest }) => {
                     stubColumnCount={stubColumnCount}
                 />
             </Table>
-        </div>
+        </TableContainer>
     );
 };
 

--- a/src/components/dev-hub/global-nav.js
+++ b/src/components/dev-hub/global-nav.js
@@ -75,8 +75,11 @@ export default () => {
         <GlobalNav>
             <NavContent>
                 <HomeLink to="/">
-                    {!isMobile && <DevLeafDesktop width="185px" />}
-                    {isMobile && <DevLeafMobile width={size.xxlarge} />}
+                    {isMobile ? (
+                        <DevLeafMobile width={size.xxlarge} />
+                    ) : (
+                        <DevLeafDesktop />
+                    )}
                 </HomeLink>
                 <NavLink to="/learn">Learn</NavLink>
                 <NavLink to="/community">Community</NavLink>

--- a/src/hooks/use-media.js
+++ b/src/hooks/use-media.js
@@ -5,27 +5,27 @@ import { useEffect, useState } from 'react';
 const isClient = typeof window === 'object';
 
 const useMedia = (query, defaultState = false) => {
-    const [state, setState] = useState(
-        isClient ? () => window.matchMedia(query).matches : defaultState
-    );
+    const [state, setState] = useState(defaultState);
 
     useEffect(() => {
-        let mounted = true;
-        const mql = window.matchMedia(query);
-        const onChange = () => {
-            if (!mounted) {
-                return;
-            }
-            setState(!!mql.matches);
-        };
+        if (isClient) {
+            let mounted = true;
+            const mql = window.matchMedia(query);
+            const onChange = () => {
+                if (!mounted) {
+                    return;
+                }
+                setState(!!mql.matches);
+            };
 
-        mql.addListener(onChange);
-        setState(mql.matches);
+            mql.addListener(onChange);
+            setState(mql.matches);
 
-        return () => {
-            mounted = false;
-            mql.removeListener(onChange);
-        };
+            return () => {
+                mounted = false;
+                mql.removeListener(onChange);
+            };
+        }
     }, [query]);
 
     return state;

--- a/tests/unit/__snapshots__/ListTable.test.js.snap
+++ b/tests/unit/__snapshots__/ListTable.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`when rendering a list table with fixed widths renders correctly 1`] = `
-<div>
+<div
+  class="css-7px7m2-TableContainer eb066o61"
+>
   <h5
     class="css-y9iyt1-H5-commonHeading-bottomMargin e1top8004"
   />
@@ -63,7 +65,9 @@ exports[`when rendering a list table with fixed widths renders correctly 1`] = `
 `;
 
 exports[`when rendering a list-table directive renders correctly 1`] = `
-<div>
+<div
+  class="css-7px7m2-TableContainer eb066o61"
+>
   <h5
     class="css-y9iyt1-H5-commonHeading-bottomMargin e1top8004"
   />


### PR DESCRIPTION
This PR fixes two things for mobile articles:
- Adds an overflow to the table directive component to allow tables to be scrollable horizontally (This is broken on articles such as [this one](https://developer.mongodb.com/article/map-terms-concepts-sql-mongodb) in prod)
- Fixes the `useMedia` hook during static rendering. While building, the hook value is the default value, and then gets re-calculated when served. This fixes an issue with the top nav where refreshing on an article page would look like this:
![Screen Shot 2020-04-17 at 3 50 57 PM](https://user-images.githubusercontent.com/9064401/79608811-a432eb80-80c3-11ea-95c6-4608aa51a791.png)

Not 100% sure why this works, but the component is now properly re-rendering with the updated hook value, so this seems to have fixed a logical issue in the `useEffect` of `useMedia`.