### PR TITLE
Fix Learn/Article iPad Layout Issues

### DIFF
--- a/src/components/dev-hub/filter-bar.js
+++ b/src/components/dev-hub/filter-bar.js
@@ -18,7 +18,7 @@ const ResponsiveFlexContainer = styled('div')`
     align-items: center;
     display: flex;
     justify-content: space-between;
-    @media ${screenSize.upToMedium} {
+    @media ${screenSize.upToLarge} {
         display: block;
     }
 `;
@@ -29,7 +29,7 @@ const FilterBar = styled('div')`
     h3 {
         flex: 2;
     }
-    @media ${screenSize.upToMedium} {
+    @media ${screenSize.upToLarge} {
         display: block;
     }
 `;
@@ -41,13 +41,13 @@ const FilterLabel = styled('span')`
 const SelectWrapper = styled('div')`
     margin: 0 ${size.small};
     min-width: 250px;
-    @media ${screenSize.upToMedium} {
+    @media ${screenSize.upToLarge} {
         margin: ${size.small} 0;
     }
 `;
 
 const HeadingText = styled(H3)`
-    @media ${screenSize.upToMedium} {
+    @media ${screenSize.upToLarge} {
         margin-bottom: ${size.default};
     }
 `;

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -48,7 +48,7 @@ const Header = styled('header')`
     background: ${colorMap.devBlack};
     margin-bottom: ${size.xlarge};
     padding: ${size.xlarge} ${size.medium};
-    @media ${screenSize.upToMedium} {
+    @media ${screenSize.upToLarge} {
         margin-bottom: ${size.large};
     }
 `;

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -103,20 +103,23 @@ const ArticleContent = styled('article')`
     max-width: ${size.maxContentWidth};
     padding-left: ${size.small};
     padding-right: ${size.small};
+    @media ${screenSize.upToLarge} {
+        margin: 0 auto;
+    }
 `;
 const Icons = styled('div')`
     margin: ${size.tiny} ${size.default};
     span {
         padding: 0 ${size.tiny};
     }
-    @media ${screenSize.smallAndUp} {
+    @media ${screenSize.largeAndUp} {
         display: flex;
         flex-direction: column;
         span:not(:first-of-type) {
             margin-top: ${size.small};
         }
     }
-    @media ${screenSize.upToSmall} {
+    @media ${screenSize.upToLarge} {
         margin: 0 ${size.small};
         span:not(:first-of-type) {
             margin-left: ${size.small};
@@ -125,7 +128,7 @@ const Icons = styled('div')`
 `;
 const Container = styled('div')`
     margin: 0 auto;
-    @media ${screenSize.smallAndUp} {
+    @media ${screenSize.largeAndUp} {
         display: flex;
         justify-content: center;
     }


### PR DESCRIPTION
This PR fixes layout overflow issues for the learn page and articles specifically on resolutions near the iPad (~760px). There were some points where the desktop layout was overflowing or inaccessible so this PR addresses them by switching to the mobile view at this point:

- Learn page filters were overflowing
- Article page share/TOC buttons (towards the top) layout was also overflowing (likely what was being seen on Ken's article.

Before:
![Screen Shot 2020-04-20 at 10 26 59 AM](https://user-images.githubusercontent.com/9064401/79763378-ffe2bc00-82f1-11ea-8920-d7d75e408c0a.png)
![Screen Shot 2020-04-20 at 10 27 27 AM](https://user-images.githubusercontent.com/9064401/79763379-007b5280-82f2-11ea-99bf-39f51eb98c87.png)


After:
![Screen Shot 2020-04-20 at 10 27 54 AM](https://user-images.githubusercontent.com/9064401/79763344-f48f9080-82f1-11ea-98a4-36e1bf03aa96.png)
![Screen Shot 2020-04-20 at 10 28 20 AM](https://user-images.githubusercontent.com/9064401/79763345-f48f9080-82f1-11ea-857b-db6949ce6e56.png)
