### PR TITLE
Bump Prettier to 2.0.4

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
-  "singleQuote": true,
-  "tabWidth": 4,
-  "trailingComma": "es5"
+    "arrowParens": "avoid",
+    "singleQuote": true,
+    "tabWidth": 4,
+    "trailingComma": "es5"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7475,6 +7475,12 @@
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
           "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
           "dev": true
+        },
+        "prettier": {
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+          "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+          "dev": true
         }
       }
     },
@@ -26613,9 +26619,9 @@
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.4.tgz",
+      "integrity": "sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w==",
       "dev": true
     },
     "pretty-bytes": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "jest": "^25.3.0",
     "jest-puppeteer": "^4.4.0",
     "lint-staged": "^10.1.3",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.4",
     "puppeteer": "^2.1.1"
   }
 }


### PR DESCRIPTION
This PR bumps `prettier` to v2.0.4 (like mitx), with the `allowParens: avoid` option set in the `.prettierrc` file.