### PR TITLE
WIP Index/Learn Pages Layout Tweaks

### DIFF
--- a/src/components/dev-hub/media-block.js
+++ b/src/components/dev-hub/media-block.js
@@ -43,7 +43,7 @@ const MediaBlockContainer = styled('div')`
 const MediaWrapper = styled('div')`
     grid-area: image;
     @media ${screenSize.largeAndUp} {
-        margin-right: ${size.medium};
+        ${({ reverse }) => !reverse && `margin-right: ${size.medium};`};
     }
     max-width: 100%;
     > img {
@@ -76,7 +76,9 @@ const MediaBlock = ({
         mediaWidth={mediaWidth}
         className={className}
     >
-        {mediaComponent && <MediaWrapper>{mediaComponent}</MediaWrapper>}
+        {mediaComponent && (
+            <MediaWrapper reverse={reverse}>{mediaComponent}</MediaWrapper>
+        )}
         <ContentWrapper>{children}</ContentWrapper>
     </MediaBlockContainer>
 );

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -247,6 +247,7 @@ export default ({ pageContext: { featuredArticles } }) => {
                                 maxWidth={MEDIA_WIDTH}
                             ></Card>
                         }
+                        mediaWidth={MEDIA_WIDTH}
                         reverse
                     >
                         <SectionContent>

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -15,6 +15,7 @@ import { getTagLinksFromMeta } from '../utils/get-tag-links-from-meta';
 
 const FEATURED_ARTICLE_MAX_WIDTH = '1200px';
 const FEATURED_ARTICLE_CARD_WIDTH = '410px';
+const PRIMARY_FEATURED_ARTICLE_WIDTH = '790px';
 
 const MainFeatureGrid = styled('div')`
     @media ${screenSize.mediumAndUp} {
@@ -48,6 +49,12 @@ const SecondArticle = styled(Card)`
 
 const LastArticle = styled(Card)`
     grid-area: tertiary;
+`;
+
+const InnerCard = styled(Card)`
+    height: 100%;
+    padding-bottom: ${size.tiny};
+    padding-top: 0;
 `;
 
 const Header = styled('header')`
@@ -146,19 +153,24 @@ const FeaturedArticles = ({ articles }) => {
     return (
         <MainFeatureGrid>
             <PrimarySection>
-                <MediaBlock
-                    mediaComponent={<PrimaryImage src={image} alt="" />}
-                    mediaWidth={360}
+                <Card
+                    collapseImage
+                    to={slug}
+                    maxWidth={PRIMARY_FEATURED_ARTICLE_WIDTH}
                 >
-                    <Card
-                        collapseImage
-                        maxDescriptionLines={4}
-                        to={slug}
-                        title={title}
-                        description={description}
-                        tags={getTagLinksFromMeta(tags)}
-                    />
-                </MediaBlock>
+                    <MediaBlock
+                        mediaComponent={<PrimaryImage src={image} alt="" />}
+                        mediaWidth={360}
+                    >
+                        <InnerCard
+                            collapseImage
+                            maxDescriptionLines={4}
+                            title={title}
+                            description={description}
+                            tags={getTagLinksFromMeta(tags)}
+                        />
+                    </MediaBlock>
+                </Card>
             </PrimarySection>
             <SecondaryFeaturedArticle
                 article={articles[1]}

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -13,6 +13,9 @@ import { buildQueryString, parseQueryString } from '../utils/query-string';
 import { getFeaturedCardFields } from '../utils/get-featured-card-fields';
 import { getTagLinksFromMeta } from '../utils/get-tag-links-from-meta';
 
+const FEATURED_ARTICLE_MAX_WIDTH = '1200px';
+const FEATURED_ARTICLE_CARD_WIDTH = '410px';
+
 const MainFeatureGrid = styled('div')`
     @media ${screenSize.mediumAndUp} {
         display: grid;
@@ -21,6 +24,9 @@ const MainFeatureGrid = styled('div')`
             'primary tertiary';
         grid-gap: ${size.medium};
         margin-top: ${size.large};
+    }
+    @media ${screenSize.largeAndUp} {
+        grid-template-columns: auto ${FEATURED_ARTICLE_CARD_WIDTH};
     }
 `;
 
@@ -51,6 +57,12 @@ const Header = styled('header')`
     @media ${screenSize.upToLarge} {
         margin-bottom: ${size.large};
     }
+`;
+
+const HeaderContent = styled('div')`
+    max-width: ${FEATURED_ARTICLE_MAX_WIDTH};
+    margin-left: auto;
+    margin-right: auto;
 `;
 
 const Article = styled('article')`
@@ -194,8 +206,10 @@ export default ({
                 <title>Learn - {metadata.title}</title>
             </Helmet>
             <Header>
-                <H2>Make better, faster applications</H2>
-                <FeaturedArticles articles={featuredArticles} />
+                <HeaderContent>
+                    <H2>Make better, faster applications</H2>
+                    <FeaturedArticles articles={featuredArticles} />
+                </HeaderContent>
             </Header>
             <Article>
                 <StyledFilterBar


### PR DESCRIPTION
This PR addresses the following design concerns on the index and learn pages from the design feedback:

- Fixes the alignment of the events section image to properly align with the grid (also updated media block to not provide right margin for reversed layouts to images)
- Centers the entire featured article section on the learn page
- Makes the entire primary featured article area selectable (puts into a card)

Index page layout before/after:
![Screen Shot 2020-04-20 at 4 43 41 PM](https://user-images.githubusercontent.com/9064401/79798046-5a960b00-8326-11ea-8e0d-f6cfc1b0d2aa.png)
![Screen Shot 2020-04-20 at 4 43 28 PM](https://user-images.githubusercontent.com/9064401/79798045-59fd7480-8326-11ea-9742-bb7dcb66cfea.png)

Learn Page before/after:
![Screen Shot 2020-04-20 at 4 46 12 PM](https://user-images.githubusercontent.com/9064401/79798121-831e0500-8326-11ea-9370-e356aed0c36e.png)
![Screen Shot 2020-04-20 at 4 46 33 PM](https://user-images.githubusercontent.com/9064401/79798122-831e0500-8326-11ea-8edb-e13abec89c15.png)
