### PR TITLE
Switch parsed data source to CI repo for CI testing

### DIFF
--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -32,7 +32,7 @@ jobs:
               run: |
                   touch .env.production
                   echo "GATSBY_SITE=devhub" > .env.production; \
-                  echo "GATSBY_PARSER_USER=sophstad" >> .env.production; \
+                  echo "GATSBY_PARSER_USER=jordanstapinski" >> .env.production; \
                   echo "GATSBY_PARSER_BRANCH=master" >> .env.production; \
                   echo "GATSBY_SNOOTY_DEV=true" >> .env.production; \
             - name: Build Gatsby
@@ -42,7 +42,7 @@ jobs:
               with:
                   install: false
                   start: npm run serve
-                  wait-on: 'http://localhost:9000/master/devhub/sophstad/HEAD'
+                  wait-on: 'http://localhost:9000/master/devhub/jordanstapinski/HEAD'
                   config-file: cypress.json
             - name: Generate artifacts on failure
               uses: actions/upload-artifact@v1

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,4 @@
 {
-    "baseUrl": "http://localhost:9000/master/devhub/sophstad/HEAD",
+    "baseUrl": "http://localhost:9000/master/devhub/jordanstapinski/HEAD",
     "viewportWidth": 1280
 }


### PR DESCRIPTION
I recently got access to use the snooty parser and store parsed data on Atlas from the DOCSP team, so this PR switches our testing data from using Sophie's parsed data to my integration testing content repo.

This allows us to keep data consistent across CI runs, and also test new cases by customizing our integration testing data to fit our needs (we now can control our own content repo, parse it, test against it, and see it in staging before deployment).