### PR TITLE
Add image, other meta to rss feed

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,8 +1,7 @@
-const { rssFeedArticleData } = require('./src/queries/rss-feed-article-data');
 const { siteUrl } = require('./src/queries/site-url');
-const { serializeRssData } = require('./src/utils/setup/serialize-rss-data');
 const { generatePathPrefix } = require('./src/utils/generate-path-prefix');
 const { getMetadata } = require('./src/utils/get-metadata');
+const { articleRssFeed } = require('./src/utils/setup/article-rss-feed');
 
 const runningEnv = process.env.NODE_ENV || 'production';
 
@@ -41,14 +40,7 @@ module.exports = {
             resolve: 'gatsby-plugin-feed',
             options: {
                 query: siteUrl,
-                feeds: [
-                    {
-                        serialize: serializeRssData,
-                        query: rssFeedArticleData,
-                        output: '/rss.xml',
-                        title: 'MongoDB Developer Hub RSS Feed',
-                    },
-                ],
+                feeds: [articleRssFeed],
             },
         },
     ],

--- a/gatsby-config.prod.js
+++ b/gatsby-config.prod.js
@@ -1,7 +1,6 @@
-const { rssFeedArticleData } = require('./src/queries/rss-feed-article-data');
 const { siteUrl } = require('./src/queries/site-url');
-const { serializeRssData } = require('./src/utils/setup/serialize-rss-data');
 const { getMetadata } = require('./src/utils/get-metadata');
+const { articleRssFeed } = require('./src/utils/setup/article-rss-feed');
 
 require('dotenv').config({
     path: '.env.production',
@@ -38,14 +37,7 @@ module.exports = {
             resolve: 'gatsby-plugin-feed',
             options: {
                 query: siteUrl,
-                feeds: [
-                    {
-                        serialize: serializeRssData,
-                        query: rssFeedArticleData,
-                        output: '/rss.xml',
-                        title: 'MongoDB Developer Hub RSS Feed',
-                    },
-                ],
+                feeds: [articleRssFeed],
             },
         },
     ],

--- a/src/utils/setup/article-rss-feed.js
+++ b/src/utils/setup/article-rss-feed.js
@@ -1,0 +1,14 @@
+const { rssFeedArticleData } = require('../../queries/rss-feed-article-data');
+const { serializeRssData } = require('./serialize-rss-data');
+
+const articleRssFeed = {
+    serialize: serializeRssData,
+    query: rssFeedArticleData,
+    output: '/rss.xml',
+    title: 'MongoDB Developer Hub RSS Feed',
+    image_url: 'https://media.mongodb.org/favicon.ico',
+    site_url: 'https://developer.mongodb.com',
+    feed_url: 'https://developer.mongodb.com/rss.xml',
+};
+
+module.exports = { articleRssFeed };


### PR DESCRIPTION
This PR uses our favicon for the RSS feed, and also adds `site_url` and `feed_url` which are passed to the rss `feedOptions` [here](https://www.npmjs.com/package/rss#itemoptions) through Gatsby.

I also pulled this object out of the config files and just reference it in config and config-prod instead.

This adds the following node to the RSS XML:
![Screen Shot 2020-04-23 at 10 46 47 AM](https://user-images.githubusercontent.com/9064401/80113056-cc9d6880-854f-11ea-9173-b8999254daad.png)

Not sure the best way to preview this, but it seems this is the correct field for `rss` to have the favicon.