### PR TITLE
Center Featured Learn Content, Expand Index Events

### DIFF
--- a/src/components/dev-hub/media-block.js
+++ b/src/components/dev-hub/media-block.js
@@ -43,7 +43,7 @@ const MediaBlockContainer = styled('div')`
 const MediaWrapper = styled('div')`
     grid-area: image;
     @media ${screenSize.largeAndUp} {
-        margin-right: ${size.medium};
+        ${({ reverse }) => !reverse && `margin-right: ${size.medium};`};
     }
     max-width: 100%;
     > img {
@@ -76,7 +76,9 @@ const MediaBlock = ({
         mediaWidth={mediaWidth}
         className={className}
     >
-        {mediaComponent && <MediaWrapper>{mediaComponent}</MediaWrapper>}
+        {mediaComponent && (
+            <MediaWrapper reverse={reverse}>{mediaComponent}</MediaWrapper>
+        )}
         <ContentWrapper>{children}</ContentWrapper>
     </MediaBlockContainer>
 );

--- a/src/components/dev-hub/media-block.js
+++ b/src/components/dev-hub/media-block.js
@@ -26,7 +26,7 @@ const gridStructure = ({ reverse, flexible }) => css`
     @media ${screenSize.upToLarge} {
         /* If flexible is true, this will allow media block to allow content to stack on smaller screens */
         ${flexible &&
-            `grid-template-areas: 'image'
+        `grid-template-areas: 'image'
         'content';`}
     }
 `;
@@ -43,7 +43,10 @@ const MediaBlockContainer = styled('div')`
 const MediaWrapper = styled('div')`
     grid-area: image;
     @media ${screenSize.largeAndUp} {
-        ${({ reverse }) => !reverse && `margin-right: ${size.medium};`};
+        ${({ reverse }) =>
+            reverse
+                ? `margin-left: ${size.medium};`
+                : `margin-right: ${size.medium};`};
     }
     max-width: 100%;
     > img {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -247,6 +247,7 @@ export default ({ pageContext: { featuredArticles } }) => {
                                 maxWidth={MEDIA_WIDTH}
                             ></Card>
                         }
+                        mediaWidth={MEDIA_WIDTH}
                         reverse
                     >
                         <SectionContent>

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -13,6 +13,9 @@ import { buildQueryString, parseQueryString } from '../utils/query-string';
 import { getFeaturedCardFields } from '../utils/get-featured-card-fields';
 import { getTagLinksFromMeta } from '../utils/get-tag-links-from-meta';
 
+const FEATURED_ARTICLE_MAX_WIDTH = '1200px';
+const FEATURED_ARTICLE_CARD_WIDTH = '410px';
+
 const MainFeatureGrid = styled('div')`
     @media ${screenSize.mediumAndUp} {
         display: grid;
@@ -21,6 +24,9 @@ const MainFeatureGrid = styled('div')`
             'primary tertiary';
         grid-gap: ${size.medium};
         margin-top: ${size.large};
+    }
+    @media ${screenSize.largeAndUp} {
+        grid-template-columns: auto ${FEATURED_ARTICLE_CARD_WIDTH};
     }
 `;
 
@@ -51,6 +57,12 @@ const Header = styled('header')`
     @media ${screenSize.upToLarge} {
         margin-bottom: ${size.large};
     }
+`;
+
+const HeaderContent = styled('div')`
+    max-width: ${FEATURED_ARTICLE_MAX_WIDTH};
+    margin-left: auto;
+    margin-right: auto;
 `;
 
 const Article = styled('article')`
@@ -194,8 +206,10 @@ export default ({
                 <title>Learn - {metadata.title}</title>
             </Helmet>
             <Header>
-                <H2>Make better, faster applications</H2>
-                <FeaturedArticles articles={featuredArticles} />
+                <HeaderContent>
+                    <H2>Make better, faster applications</H2>
+                    <FeaturedArticles articles={featuredArticles} />
+                </HeaderContent>
             </Header>
             <Article>
                 <StyledFilterBar


### PR DESCRIPTION
This PR fixes two layout issues:

1. The events section of the index page was not taking up the full width. This was because the media width was not properly passed to the media block. I also removed right margin from the media element if it is reversed.
2. Centers featured content horizontally on the learn page.

Before:
![Screen Shot 2020-04-23 at 3 28 43 PM](https://user-images.githubusercontent.com/9064401/80141218-3846fc00-8577-11ea-94d4-3ef06f1bd1a4.png)
![Screen Shot 2020-04-23 at 3 28 55 PM](https://user-images.githubusercontent.com/9064401/80141219-3846fc00-8577-11ea-8581-79dd8a0821a8.png)


After:
![Screen Shot 2020-04-23 at 3 28 29 PM](https://user-images.githubusercontent.com/9064401/80141241-3f6e0a00-8577-11ea-9b79-c90ca48f7321.png)
![Screen Shot 2020-04-23 at 3 28 07 PM](https://user-images.githubusercontent.com/9064401/80141239-3f6e0a00-8577-11ea-883c-d862497d5765.png)
