### PR TITLE
Add cypress testing for article pages

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,4 @@
 {
-    "baseUrl": "http://localhost:8000",
+    "baseUrl": "http://localhost:9000/master/devhub/jordanstapinski/HEAD",
     "viewportWidth": 1280
 }

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,4 @@
 {
-    "baseUrl": "http://localhost:9000/master/devhub/jordanstapinski/HEAD",
+    "baseUrl": "http://localhost:8000",
     "viewportWidth": 1280
 }

--- a/cypress/integration/article.js
+++ b/cypress/integration/article.js
@@ -1,0 +1,124 @@
+const ARTICLE_WITH_SERIES_URL =
+    '/article/3-things-to-know-switch-from-sql-mongodb/';
+const PROD_ARTICLE_URL = `https://developer.mongodb.com${ARTICLE_WITH_SERIES_URL}`;
+
+const ARTICLE_TITLE = '3 Things to Know When You Switch from SQL to MongoDB';
+const ARTICLE_DESCRIPTION =
+    'Discover the 3 things you need to know when you switch from SQL to MongoDB';
+const SERIES_TITLE = 'SQL to MongoDB';
+
+// Images
+const ATF_IMAGE = '/images/atf-images/illustrations/sql-mdb.png';
+const TWITTER_IMAGE =
+    'https://developer.mongodb.com/images/social/twitter/twitter-sql-mdb.png';
+const OG_IMAGE =
+    'https://developer.mongodb.com/images/social/open-graph/og-sql-mdb.png';
+
+// Social Media Links
+const FACEBOOK_SHARE_URL = `https://www.facebook.com/sharer/sharer.php?u=${PROD_ARTICLE_URL}`;
+const LINKEDIN_SHARE_URL = `https://www.linkedin.com/shareArticle?url=${PROD_ARTICLE_URL}`;
+const OG_URL =
+    'http://developer.mongodb.com/article/3-things-to-know-switch-from-sql-mongodb';
+const TWITTER_SHARE_URL = `https://twitter.com/intent/tweet?url=${PROD_ARTICLE_URL}&text=3%20Things%20to%20Know%20When%20You%20Switch%20from%20SQL%20to%20MongoDB`;
+
+const SOCIAL_URLS = [LINKEDIN_SHARE_URL, TWITTER_SHARE_URL, FACEBOOK_SHARE_URL];
+
+describe('Sample Article Page', () => {
+    it('should have a descriptive header', () => {
+        cy.visit(ARTICLE_WITH_SERIES_URL).then(() => {
+            cy.get('header').within(() => {
+                // Check title
+                cy.contains(ARTICLE_TITLE);
+                // Check pubdate
+                cy.contains('Published: Apr 01, 2020');
+                // Check tags
+                cy.checkTagListProperties();
+                // Check author
+                cy.contains('Lauren Schaefer')
+                    .should('have.prop', 'href')
+                    .and('include', '/author/lauren-schaefer');
+                // Check ATF
+                cy.get('div')
+                    .should('have.css', 'background-image')
+                    .and('include', ATF_IMAGE);
+            });
+        });
+    });
+
+    it('should have links to share content on social media', () => {
+        cy.get('[data-test="article-share-links"]').within(() => {
+            cy.get('a').each((link, index) => {
+                // Index 0 is the copy to clipboard functionality
+                // TODO: UI test clipboard link copy
+                if (index !== 0) {
+                    const url = SOCIAL_URLS[index - 1];
+                    cy.wrap(link).should('have.prop', 'href', url);
+                }
+            });
+        });
+    });
+
+    it('should have links to sub-headings in the article', () => {
+        cy.get('h2')
+            .its('length')
+            .then(numSubheadings => {
+                // Contents list should be triggered by a tooltip click
+                cy.get('[data-test="contents-list"]').should('not.exist');
+                cy.get('[data-test="contents-tooltip"]').click();
+                cy.get('[data-test="contents-list"]').within(() => {
+                    cy.get('a').should('have.length', numSubheadings);
+                    // Need to force because this lies within a tooltip
+                    cy.contains('Embrace Document Diversity').click({
+                        force: true,
+                    });
+                    cy.url().should('include', '#embrace-document-diversity');
+                });
+            });
+    });
+
+    it('should be a part of an article series', () => {
+        // Check series title
+        cy.get('[data-test="series"]').within(() => {
+            cy.contains(SERIES_TITLE);
+            cy.get('a').should('have.length', 3);
+            // Check other one goes to article
+            cy.get('a')
+                .first()
+                .should('have.prop', 'href')
+                .and('include', '/article/map-terms-concepts-sql-mongodb');
+        });
+    });
+
+    it('should have proper SEO, open graph, and twitter tags', () => {
+        // Check title eqists
+        cy.title().should('eq', ARTICLE_TITLE).end();
+
+        // Check og tags
+        cy.checkMetaContentProperty('property="og:type"', 'article');
+        cy.checkMetaContentProperty('property="og:title"', ARTICLE_TITLE);
+        cy.checkMetaContentProperty(
+            'property="og:url"',
+            // This would match the PROD_ARTICLE_URL but it has http and not https
+            OG_URL
+        );
+        cy.checkMetaContentProperty(
+            'property="og:description"',
+            ARTICLE_DESCRIPTION
+        );
+        cy.checkMetaContentProperty('property="og:image"', OG_IMAGE);
+
+        // Check Twitter tags
+        cy.checkMetaContentProperty(
+            'name="twitter:creator"',
+            '@Lauren_Schaefer'
+        );
+        cy.checkMetaContentProperty('name="twitter:card"', 'summary');
+        cy.checkMetaContentProperty('name="twitter:site"', '@mongodb');
+        cy.checkMetaContentProperty('property="twitter:title"', ARTICLE_TITLE);
+        cy.checkMetaContentProperty(
+            'property="twitter:description"',
+            ARTICLE_DESCRIPTION
+        );
+        cy.checkMetaContentProperty('name="twitter:image"', TWITTER_IMAGE);
+    });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -7,6 +7,13 @@ Cypress.Commands.add('useBodyReference', () => {
     cy.get('body').as('body');
 });
 
+Cypress.Commands.add('checkTagListProperties', () => {
+    cy.get('ul li a')
+        .first()
+        .should('have.attr', 'href')
+        .should('match', /\/(tag|product|language)/);
+});
+
 // Basic sanity checks for an article card (image, title, tags, etc)
 Cypress.Commands.add('checkArticleCard', card => {
     cy.get(card).within(() => {
@@ -14,15 +21,14 @@ Cypress.Commands.add('checkArticleCard', card => {
         cy.get('h5').should('not.be.empty');
         // Description
         cy.get('p').should('not.be.empty');
-        cy.get('img')
-            .should('have.attr', 'src')
-            .should('not.be.empty');
+        cy.get('img').should('have.attr', 'src').should('not.be.empty');
         // Tags
-        cy.get('ul li a')
-            .first()
-            .should('have.attr', 'href')
-            .should('match', /\/(tag|product|language)/);
+        cy.checkTagListProperties();
     });
+});
+
+Cypress.Commands.add('checkMetaContentProperty', (query, value) => {
+    cy.get(`head meta[${query}]`).should('have.prop', 'content', value);
 });
 
 // Mock data from events servers

--- a/src/components/dev-hub/article-share-footer.js
+++ b/src/components/dev-hub/article-share-footer.js
@@ -41,7 +41,7 @@ const ArticleShareFooter = ({ tags, title, url }) => {
     return (
         <ArticleShareArea>
             <BlogTagList tags={tags} />
-            <BlogShareLinks>
+            <BlogShareLinks data-test="article-share-links">
                 <Tooltip
                     position="bottom"
                     trigger={

--- a/src/components/dev-hub/contents-menu.js
+++ b/src/components/dev-hub/contents-menu.js
@@ -82,7 +82,12 @@ const ContentsMenu = ({ title, headingNodes, ...props }) => {
             position={'right'}
             trigger={
                 <HoverTooltip
-                    trigger={<StyledListIcon {...props} />}
+                    trigger={
+                        <StyledListIcon
+                            data-test="contents-tooltip"
+                            {...props}
+                        />
+                    }
                     text="Contents"
                     {...props}
                 />
@@ -90,7 +95,7 @@ const ContentsMenu = ({ title, headingNodes, ...props }) => {
             maxWidth={400}
         >
             <H5 bold>{title}</H5>
-            <Contents>
+            <Contents data-test="contents-list">
                 {headingNodes.map(({ id, title }) => {
                     const isactive = id === activeItem ? 'true' : null;
                     return (

--- a/src/components/dev-hub/series.js
+++ b/src/components/dev-hub/series.js
@@ -172,7 +172,7 @@ const SeriesIcon = ({ active }) => (
 );
 
 const Series = ({ children, currentStep, name }) => (
-    <SeriesContainer>
+    <SeriesContainer data-test="series">
         <SeriesNameContainer>
             <DescriptiveText collapse>More from this series</DescriptiveText>
             <H3 collapse>{name}</H3>


### PR DESCRIPTION
This PR adds cypress testing for a specific article off of the integration content repo (`/article/3-things-to-know-switch-from-sql-mongodb/`).

I added the following general tests:
- Tested the header is populated with all of the important information
- Tested the contents menu brings the user to a specific header when requested
- Social URLs to LinkedIn, Twitter, Facebook work as expected
- A series is shown with links populated
- Proper SEO/meta tags are maintained (checking various fields on `meta` to ensure og/meta fields are populated as we expect)