### PR TITLE
Reorganize Series Logic for Past/Upcoming Series Items

### DIFF
--- a/src/components/dev-hub/article-series.js
+++ b/src/components/dev-hub/article-series.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import dlv from 'dlv';
+import Series from './series';
+
+const ArticleSeries = ({ allSeriesForArticle, slugTitleMapping, title }) => {
+    // Handle if this article is not in a series or no series are defined
+    if (!allSeriesForArticle) return null;
+    const getMappedSeries = seriesSlugs => {
+        if (!seriesSlugs || !seriesSlugs.length) return null;
+
+        let hasSeenActiveSlug = false;
+        const getSeriesArticlePosition = articleTitle => {
+            // Find if an article is the current one in the series, or is upcoming/past
+            if (hasSeenActiveSlug) {
+                return 'upcoming';
+            } else if (articleTitle === title) {
+                hasSeenActiveSlug = true;
+                return 'active';
+            }
+            return 'past';
+        };
+
+        const mappedSeries = seriesSlugs.map(slug => {
+            const title = dlv(slugTitleMapping, [slug, 0, 'value'], slug);
+            const position = getSeriesArticlePosition(title);
+            return {
+                position,
+                slug,
+                title,
+            };
+        });
+        return mappedSeries;
+    };
+
+    return Object.keys(allSeriesForArticle).map(series => {
+        const seriesItems = getMappedSeries(allSeriesForArticle[series]);
+        return <Series name={series}>{seriesItems}</Series>;
+    });
+};
+
+export default ArticleSeries;

--- a/src/components/dev-hub/series.js
+++ b/src/components/dev-hub/series.js
@@ -73,8 +73,10 @@ const SeriesBreadcrumbs = styled('div')`
 
 const SeriesContainer = styled('div')`
     display: flex;
+    margin-bottom: ${size.large};
     @media ${screenSize.upToMedium} {
         flex-direction: column;
+        margin-bottom: ${size.medium};
     }
 `;
 
@@ -169,7 +171,7 @@ const SeriesIcon = ({ active }) => (
     </BulletIcon>
 );
 
-const Series = ({ activeStepIndex, children, name }) => (
+const Series = ({ children, name }) => (
     <SeriesContainer>
         <SeriesNameContainer>
             <DescriptiveText collapse>More from this series</DescriptiveText>
@@ -177,9 +179,9 @@ const Series = ({ activeStepIndex, children, name }) => (
         </SeriesNameContainer>
         <SeriesBreadcrumbs>
             <SeriesList>
-                {children.map(({ title, slug }, i) => {
+                {children.map(({ position, title, slug }) => {
                     // TODO: Add styling for past and upcoming series articles
-                    const isActive = i === activeStepIndex;
+                    const isActive = position === 'active';
                     return (
                         <Breadcrumb>
                             <SeriesIcon active={isActive} />

--- a/src/components/dev-hub/series.js
+++ b/src/components/dev-hub/series.js
@@ -82,7 +82,6 @@ const SeriesLink = styled(Link)`
     font-family: 'Fira Mono', monospace;
     font-size: ${fontSize.default};
     text-decoration: none;
-    ${({ active }) => active && activeLinkStyles};
     @media ${screenSize.upToMedium} {
         font-size: ${fontSize.default};
     }
@@ -124,7 +123,6 @@ const BulletIcon = styled('div')`
     @media ${screenSize.upToMedium} {
         margin-right: 20px;
     }
-    ${({ active }) => active && activeLiStyles};
 `;
 
 const SeriesList = styled('ul')`
@@ -165,13 +163,13 @@ const SeriesNameContainer = styled('div')`
 `;
 
 const SeriesIcon = ({ active }) => (
-    <BulletIcon active={active}>
+    <BulletIcon css={active && activeLiStyles}>
         {/* x29BF is bull's eye bullet, x25E6 is hollow bullet */}
         {active ? <>&#x29BF;</> : <>&#x25E6;</>}
     </BulletIcon>
 );
 
-const Series = ({ children, currentStep, name }) => (
+const Series = ({ activeStepIndex, children, name }) => (
     <SeriesContainer>
         <SeriesNameContainer>
             <DescriptiveText collapse>More from this series</DescriptiveText>
@@ -179,12 +177,16 @@ const Series = ({ children, currentStep, name }) => (
         </SeriesNameContainer>
         <SeriesBreadcrumbs>
             <SeriesList>
-                {children.map(({ title, slug }) => {
-                    const isActive = title === currentStep;
+                {children.map(({ title, slug }, i) => {
+                    // TODO: Add styling for past and upcoming series articles
+                    const isActive = i === activeStepIndex;
                     return (
-                        <Breadcrumb active={isActive}>
+                        <Breadcrumb>
                             <SeriesIcon active={isActive} />
-                            <SeriesLink active={isActive} to={slug}>
+                            <SeriesLink
+                                to={slug}
+                                css={isActive && activeLinkStyles}
+                            >
                                 {title}
                             </SeriesLink>
                         </Breadcrumb>

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -89,14 +89,20 @@ const ArticleSeries = ({ allSeriesForArticle, slugTitleMapping, title }) => {
         return mappedSeries;
     };
 
-    return Object.keys(allSeriesForArticle).map(series => (
-        <>
-            <Series name={series} currentStep={title}>
-                {getMappedSeries(allSeriesForArticle[series])}
-            </Series>
-            <br />
-        </>
-    ));
+    return Object.keys(allSeriesForArticle).map(series => {
+        const seriesItems = getMappedSeries(allSeriesForArticle[series]);
+        const activeSeriesIndex = seriesItems.findIndex(
+            seriesItem => seriesItem.title === title
+        );
+        return (
+            <>
+                <Series name={series} activeStepIndex={activeSeriesIndex}>
+                    {seriesItems}
+                </Series>
+                <br />
+            </>
+        );
+    });
 };
 
 const ArticleContent = styled('article')`

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -10,7 +10,7 @@ import Layout from '../components/dev-hub/layout';
 import RelatedArticles from '../components/dev-hub/related-articles';
 import { screenSize, size } from '../components/dev-hub/theme';
 import SEO from '../components/dev-hub/SEO';
-import Series from '../components/dev-hub/series';
+import ArticleSeries from '../components/dev-hub/article-series';
 import { getTagLinksFromMeta } from '../utils/get-tag-links-from-meta';
 import { getTagPageUriComponent } from '../utils/get-tag-page-uri-component';
 import { toDateString } from '../utils/format-dates';
@@ -67,42 +67,6 @@ const getContent = nodes => {
     }
 
     return nodesWeActuallyWant;
-};
-
-const ArticleSeries = ({ allSeriesForArticle, slugTitleMapping, title }) => {
-    // Handle if this article is not in a series or no series are defined
-    if (!allSeriesForArticle) return null;
-    // Handle if this series is not defined in the top-level content TOML file
-    const getMappedSeries = seriesSlugs => {
-        if (!seriesSlugs || !seriesSlugs.length) return null;
-        const mappedSeries = seriesSlugs.map(slug => {
-            const articleTitle = dlv(
-                slugTitleMapping,
-                [slug, 0, 'value'],
-                slug
-            );
-            return {
-                slug,
-                title: articleTitle,
-            };
-        });
-        return mappedSeries;
-    };
-
-    return Object.keys(allSeriesForArticle).map(series => {
-        const seriesItems = getMappedSeries(allSeriesForArticle[series]);
-        const activeSeriesIndex = seriesItems.findIndex(
-            seriesItem => seriesItem.title === title
-        );
-        return (
-            <>
-                <Series name={series} activeStepIndex={activeSeriesIndex}>
-                    {seriesItems}
-                </Series>
-                <br />
-            </>
-        );
-    });
 };
 
 const ArticleContent = styled('article')`


### PR DESCRIPTION
This PR lays some logical groundwork for an upcoming change to the series component. We are going to want to style links a bit differently whether its article is before or after the current one in the series (to promote continuing the series).

This PR changes logic to pass the active item index in the series to the series component instead of the title, so it will be easier to get past or upcoming series items by comparing indices.

I also moved conditional styling into the css prop.

Upcoming design (not in this PR):
![Screen Shot 2020-04-24 at 2 40 58 PM](https://user-images.githubusercontent.com/9064401/80246080-d3a0a580-8639-11ea-937f-7c3d0be36959.png)
