### PR TITLE
Fix Chrome Play Button Flashing Bug

### DIFF
--- a/src/components/dev-hub/layout.js
+++ b/src/components/dev-hub/layout.js
@@ -51,6 +51,7 @@ const Main = styled('main')`
 `;
 
 const GlobalWrapper = styled('div')`
+    background: ${colorMap.pageBackground};
     display: flex;
     flex-direction: column;
     justify-content: space-between;


### PR DESCRIPTION
This PR fixes an odd chrome-only bug. When on the index page and hovering over the play button in the twitch video modal, the background would flash white momentarily.

Adding a background to the `GlobalWrapper` seemed to address the problem.

Before:
![Screen Shot 2020-04-29 at 11 32 35 AM](https://user-images.githubusercontent.com/9064401/80615528-ca368500-8a0d-11ea-9e42-021fc75c5d67.png)


After:
![Screen Shot 2020-04-29 at 11 34 21 AM](https://user-images.githubusercontent.com/9064401/80615540-cdca0c00-8a0d-11ea-9c99-fbde54a12e9a.png)
