### PR TITLE
Fix Codeblock Border on Safari

### DIFF
--- a/src/components/dev-hub/codeblock.js
+++ b/src/components/dev-hub/codeblock.js
@@ -36,12 +36,12 @@ const StyledCode = styled(Code)`
     padding-right: ${size.xlarge};
     padding-top: ${size.large};
     ${({ numdigits }) =>
-        `padding-left: calc(${LEAFY_LINENUMBER_PADDING}px + ${numdigits *
-            size.stripUnit(size.xsmall)}px)`};
+        `padding-left: calc(${LEAFY_LINENUMBER_PADDING}px + ${
+            numdigits * size.stripUnit(size.xsmall)
+        }px)`};
     /* Line Numbers */
     > div {
         background-color: ${colorMap.greyDarkTwo};
-        border: none;
         border-image: linear-gradient(
                 0deg,
                 ${colorMap.sherbet} 0%,
@@ -49,7 +49,8 @@ const StyledCode = styled(Code)`
                 ${colorMap.magenta} 100%
             )
             1;
-        border-right: 2px solid;
+        border-width: 0 2px 0 0;
+        border-right-style: solid;
         color: ${colorMap.greyLightTwo};
         left: 0;
         padding: ${LEAFY_CODEBLOCK_PADDING}px;


### PR DESCRIPTION
This PR fixes an issue only on safari where the codeblock line number border was on all four sides of the `div` (and wider than it should have been). It should only be on the right side. Explicitly setting border widths to 0 fixed this.

Before:
![Screen Shot 2020-04-29 at 1 44 48 PM](https://user-images.githubusercontent.com/9064401/80628875-070b7780-8a20-11ea-97c1-9d686db07a53.png)

After:
![Screen Shot 2020-04-29 at 1 44 55 PM](https://user-images.githubusercontent.com/9064401/80628876-070b7780-8a20-11ea-9e94-f128598500a0.png)
