### PR TITLE
Fix default props in card-list, update CardContainer

### DIFF
--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -41,20 +41,26 @@ const getThumbnailUrl = media => {
         : media.thumbnailUrl;
 };
 
-export default React.memo(
-    ({ videos = [], articles = [], podcasts = [], limit = 9 }) => {
-        const [visibleCards, setVisibleCards] = useState(limit);
+// TODO: Update this component to take one array of items and map to cards based
+// on the item type
+export default React.memo(({ videos, articles, podcasts, limit = 9 }) => {
+    videos = videos || [];
+    articles = articles || [];
+    podcasts = podcasts || [];
+    const [visibleCards, setVisibleCards] = useState(limit);
 
-        //TODO: modify once the tab component is ready
-        const hasMore = videos.length
-            ? videos.length > visibleCards
-            : articles.length > visibleCards;
+    //TODO: modify once the tab component is ready to use single array of items
+    const hasMore = videos.length
+        ? videos.length > visibleCards
+        : articles.length > visibleCards;
 
-        return (
-            <>
-                {articles.length > 0 && (
-                    <CardContainer>
-                        {articles.slice(0, visibleCards).map(article => (
+    return (
+        <>
+            <CardContainer>
+                {articles.length > 0 &&
+                    articles
+                        .slice(0, visibleCards)
+                        .map(article => (
                             <ArticleCard
                                 to={article['slug']}
                                 key={article['_id']}
@@ -66,12 +72,11 @@ export default React.memo(
                                 )}
                             />
                         ))}
-                    </CardContainer>
-                )}
 
-                {videos.length > 0 && (
-                    <CardContainer>
-                        {videos.slice(0, visibleCards).map(video => (
+                {videos.length > 0 &&
+                    videos
+                        .slice(0, visibleCards)
+                        .map(video => (
                             <VideoModal
                                 key={video.videoId}
                                 id={video.videoId}
@@ -87,12 +92,11 @@ export default React.memo(
                                 thumbnail={getThumbnailUrl(video)}
                             />
                         ))}
-                    </CardContainer>
-                )}
 
-                {podcasts.length > 0 && (
-                    <CardContainer>
-                        {podcasts.slice(0, visibleCards).map(podcast => (
+                {podcasts.length > 0 &&
+                    podcasts
+                        .slice(0, visibleCards)
+                        .map(podcast => (
                             <ArticleCard
                                 key={podcast.title}
                                 image={getThumbnailUrl(podcast)}
@@ -100,23 +104,19 @@ export default React.memo(
                                 description={podcast.description}
                             />
                         ))}
-                    </CardContainer>
-                )}
+            </CardContainer>
 
-                {hasMore && (
-                    <HasMoreButtonContainer>
-                        <Button
-                            secondary
-                            pagination
-                            onClick={() =>
-                                setVisibleCards(visibleCards + limit)
-                            }
-                        >
-                            Load more
-                        </Button>
-                    </HasMoreButtonContainer>
-                )}
-            </>
-        );
-    }
-);
+            {hasMore && (
+                <HasMoreButtonContainer>
+                    <Button
+                        secondary
+                        pagination
+                        onClick={() => setVisibleCards(visibleCards + limit)}
+                    >
+                        Load more
+                    </Button>
+                </HasMoreButtonContainer>
+            )}
+        </>
+    );
+});

--- a/src/pages/media.js
+++ b/src/pages/media.js
@@ -16,7 +16,7 @@ export default () => {
     return (
         <Layout>
             {(isLoading || isLoadingPodcasts) && <P>Loading...</P>}
-            {videos && <CardList videos={videos} podcasts={podcasts} />}
+            <CardList videos={videos} podcasts={podcasts} />
             {(error || errorPodcasts) && (
                 <P>Check back later for upcoming media contents</P>
             )}


### PR DESCRIPTION
This PR does a few things with the `CardList`:

1. Fixes an issue with default props where instead of using default values, we null check and use `[]` if passed `null` (we were being passed `null` which overrode the previous default).
2. Moves `<CardContainer>` in `CardList` to wrap all the cards
3. Adds commentary about future work to come with this component to handle different types of items and articles.

Pages to check:
- /learn
- /tag
- /media