### PR TITLE
Add blockquote, video stories, update other stories

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = ({ config }) => {
     const createCompiler = require('@storybook/addon-docs/mdx-compiler-plugin');
     // Transpile Gatsby module because Gatsby includes un-transpiled ES6 code.
@@ -20,8 +22,14 @@ module.exports = ({ config }) => {
         require.resolve('babel-plugin-remove-graphql-queries'),
     ];
 
-    // Prefer Gatsby ES6 entrypoint (module) over commonjs (main) entrypoint
-    config.resolve.mainFields = ['browser', 'module', 'main'];
+    config.resolve = {
+        // Alias preview for Image component loading
+        alias: {
+            previewSetup: path.resolve(__dirname, '../preview/noop.js'),
+        },
+        // Prefer Gatsby ES6 entrypoint (module) over commonjs (main) entrypoint
+        mainFields: ['browser', 'module', 'main'],
+    };
 
     config.module.rules.push({
         test: /\.(stories|story)\.mdx$/,

--- a/src/components/dev-hub/icons/icons.stories.mdx
+++ b/src/components/dev-hub/icons/icons.stories.mdx
@@ -77,7 +77,7 @@ Here are all of the `icons` we use.
         <div style={{display: 'flex', flexDirection: 'row', justifyContent: 'space-evenly' }}>
             <FacebookIcon color={colorMap.teal} />
             <TwitterIcon color={colorMap.salmon} />
-            <Twitch color={colorMap.yellow} />
+            <TwitchIcon color={colorMap.yellow} />
             <ListIcon color={colorMap.magenta} />
             <EnvelopeIcon color={colorMap.violet} />
             <LinkIcon color={colorMap.lightGreen} />

--- a/src/components/dev-hub/stories/blockquote.stories.mdx
+++ b/src/components/dev-hub/stories/blockquote.stories.mdx
@@ -1,0 +1,28 @@
+import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import Blockquote from '../blockquote';
+import { colorMap } from '../theme';
+
+<Meta title="Blockquote" />
+
+# Blockquote
+
+The blockquote is a callout for some children provided. The children are passed
+through to the component factory to ensure proper components are applied.
+
+<Preview style={{ background: colorMap.devBlack }}>
+    <Story name="blockquote">
+      <Blockquote
+        nodeData={{
+            children: [
+                {
+                    name: 'text',
+                    type: 'text',
+                    value:
+                        "If you didn't set up your free cluster on MongoDB Atlas, now is a great time to do so. You have all the instructions in this blog post.",
+                },
+            ],
+        }}
+    ></Blockquote>
+    </Story>
+</Preview>
+

--- a/src/components/dev-hub/stories/card.stories.mdx
+++ b/src/components/dev-hub/stories/card.stories.mdx
@@ -12,7 +12,7 @@ A card can have a link, image, title, and description.
 
 <Preview>
     <Story name="default card">
-        <div>
+        <div style={{display: 'flex'}}>
             <Card
                 distinct
                 image={mockCardImage}
@@ -36,7 +36,7 @@ Cards can also have a list of tags associated with them (max 5 tags).
 
 <Preview>
     <Story name="tag-list card">
-        <div>
+        <div style={{display: 'flex'}}>
             <Card
                 distinct
                 image={mockCardImage}
@@ -64,7 +64,7 @@ the max number of lines a title can have using the `maxTitleLines` prop.
 
 <Preview>
     <Story name="no-image card">
-        <div>
+        <div style={{display: 'flex'}}>
             <Card
                 width="300px"
                 title="I'm a card with a really really really really really really really really really really long title"

--- a/src/components/dev-hub/stories/chart.stories.mdx
+++ b/src/components/dev-hub/stories/chart.stories.mdx
@@ -8,7 +8,25 @@ import Chart from '../chart';
 We support embedded MongoDB Charts through the component factory for articles.
 
 <Preview>
-    <Story name="Chart">
+    <Story name="Chart (dark theme)">
+        <Chart
+            nodeData={{
+                options: {
+                    id: '28dc1e9e-27a5-4259-ad5b-0f2b1bc9ff5e',
+                    width: 760,
+                    align: 'center',
+                    height: 570,
+                    url: 'https://charts.mongodb.com/charts-coronavirus-lwlvn',
+                },
+            }}
+        />
+    </Story>
+</Preview>
+
+By default we use a dark theme, but this can be toggled in `nodeData.options`.
+
+<Preview>
+    <Story name="Chart (light theme)">
         <div>
             <Chart
                 nodeData={{
@@ -20,18 +38,6 @@ We support embedded MongoDB Charts through the component factory for articles.
                         url:
                             'https://charts.mongodb.com/charts-coronavirus-lwlvn',
                         theme: 'light',
-                    },
-                }}
-            />
-            <Chart
-                nodeData={{
-                    options: {
-                        id: '28dc1e9e-27a5-4259-ad5b-0f2b1bc9ff5e',
-                        width: 760,
-                        align: 'center',
-                        height: 570,
-                        url:
-                            'https://charts.mongodb.com/charts-coronavirus-lwlvn',
                     },
                 }}
             />

--- a/src/components/dev-hub/stories/codeblock.stories.mdx
+++ b/src/components/dev-hub/stories/codeblock.stories.mdx
@@ -33,11 +33,19 @@ namespace CSharpTutorials
 
 # Code Block
 
-CodeBlocks can render code across programming languages such as JavaScript and C#.
+`CodeBlock`s can render code across programming languages such as JavaScript and C#.
+The `CodeBlock` is built off of the [LeafyGreen `Code` component](https://github.com/mongodb/leafygreen-ui/tree/master/packages/code).
+
 <Preview>
     <Story name="code block javascript">
         <CodeBlock nodeData={{ value: codeSample }} />
     </Story>
+</Preview>
+
+The `CodeBlock` by default tries to guess syntax highlighting, but the `lang` field
+in `nodeData` can be used to specify a language to highlight (based on Leafy's Code `lang` prop).
+
+<Preview>
     <Story name="code block c#">
         <CodeBlock nodeData={{ value: cSharpCodeSample, lang: 'csp' }} />
     </Story>

--- a/src/components/dev-hub/stories/series.stories.mdx
+++ b/src/components/dev-hub/stories/series.stories.mdx
@@ -6,6 +6,14 @@ import { colorMap } from '../theme';
 
 # Article Series
 
+An article series is an ordered list of articles where an article can have one of
+three "positions": `past`, `active`, or `upcoming`.
+
+* A `past` article is one that is before the `active` article in the series.
+* An `active` article is the one the reader is looking at.
+* An `upcoming` article is any article that follows after the `active` article in the 
+series.
+
 <Preview style={{ background: colorMap.devBlack }}>
     <Story name="article series">
         {() => {

--- a/src/components/dev-hub/stories/video-embed.stories.mdx
+++ b/src/components/dev-hub/stories/video-embed.stories.mdx
@@ -1,0 +1,35 @@
+import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import VideoEmbed from '../video-embed.js';
+import TWITCH_IMG from '../../../images/1x/Community-card-illustration.png';
+
+<Meta title="Video Embed" />
+
+# Video Embed
+
+We can embed videos from YouTube
+
+<Preview>
+    <Story name="YouTube Embedded Video">
+        <VideoEmbed
+            nodeData={{
+                argument: [{ value: 'Yx7OCVfeXlY' }],
+                name: 'youtube',
+            }}
+        />
+    </Story>
+</Preview>
+
+We can also embed videos from Twitch (and provide custom thumbnails with the
+`thumbnail` prop)
+
+<Preview>
+    <Story name="Twitch Embedded Video">
+        <VideoEmbed
+            nodeData={{
+                argument: [{ value: '601256367' }],
+                name: 'twitch',
+            }}
+            thumbnail="https://static-cdn.jtvnw.net/cf_vods/d2nvs31859zcd8/10f667dc39f04f52c24a_mongodb_37710862064_1425764118/thumb/thumb0-550x550.jpg"
+        />
+    </Story>
+</Preview>


### PR DESCRIPTION
This PR adds two new stories to storybook for `BlockQuote` and `VideoEmbed` and also adds mdx docs updates for the following stories (to clean up a bit):
- `Card`
- `Icons`
- `Chart`
- `Codeblock`
- `Series`

You can check these out by running the storybook