### PR TITLE
Remove prefix path use from CI

### DIFF
--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -41,9 +41,8 @@ jobs:
               uses: cypress-io/github-action@v1
               with:
                   install: false
-                  start: npm run serve
-                  wait-on: 'http://localhost:9000/master/devhub/jordanstapinski/HEAD'
-                  config-file: cypress.json
+                  start: ./node_modules/.bin/gatsby serve
+                  wait-on: 'http://localhost:9000'
             - name: Generate artifacts on failure
               uses: actions/upload-artifact@v1
               if: failure()


### PR DESCRIPTION
This PR remove logic using `prefix-paths` from the CI tests, since it seems the `gatsby serve` urls are no longer pointing to a consistent location based on the content directory.