### PR TITLE
Card (media source) badge component

### DIFF
--- a/src/components/dev-hub/card-badge.js
+++ b/src/components/dev-hub/card-badge.js
@@ -1,54 +1,45 @@
 import React from 'react';
 import { colorMap, size } from './theme';
 import { P5 } from './text';
-import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 
 const CardBadge = styled('div')`
-    align: left;
     bottom: 0;
     background-color: ${colorMap.greyDarkThree};
     display: inline-block;
-    font-family: 'Akzidenz-Grotesk';
+    font-family: akzidenz;
+    letter-spacing: 1px;
     margin: ${size.default};
     padding: 1px ${size.xsmall};
     position: absolute;
     text-transform: uppercase;
-    ${props =>
-        props.color &&
-        css`
-            border: 1px solid ${props.color};'
-        `}
+    ${({ color }) => color && `border: 1px solid ${color}`}
 `;
 
-export default ({ contentType, color = '' }) => {
+const determineColor = contentType => {
     switch (contentType) {
         case 'youtube':
         case 'twitch':
-            return (
-                <CardBadge color={color || colorMap.salmon}>
-                    <P5 collapse>
-                        <strong>{contentType + ' video'}</strong>
-                    </P5>
-                </CardBadge>
-            );
+            return colorMap.salmon;
         case 'podcast':
-            return (
-                <CardBadge color={color || colorMap.yellow}>
-                    <P5 collapse>
-                        <strong>{contentType}</strong>
-                    </P5>
-                </CardBadge>
-            );
+            return colorMap.yellow;
         case 'article':
-            return (
-                <CardBadge color={color || colorMap.teal}>
-                    <P5 collapse>
-                        <strong>{contentType}</strong>
-                    </P5>
-                </CardBadge>
-            );
+            return colorMap.teal;
         default:
             return null;
     }
+};
+
+export default ({ contentType, color = '' }) => {
+    return (
+        <CardBadge color={color || determineColor(contentType)}>
+            <P5 collapse>
+                <strong>
+                    {contentType === 'youtube' || contentType === 'twitch'
+                        ? contentType + ' video'
+                        : contentType}
+                </strong>
+            </P5>
+        </CardBadge>
+    );
 };

--- a/src/components/dev-hub/card-badge.js
+++ b/src/components/dev-hub/card-badge.js
@@ -6,7 +6,6 @@ import styled from '@emotion/styled';
 const CardBadge = styled('div')`
     bottom: 0;
     background-color: ${colorMap.greyDarkThree};
-    display: inline-block;
     font-family: akzidenz;
     letter-spacing: 1px;
     margin: ${size.default};
@@ -30,16 +29,15 @@ const determineColor = contentType => {
     }
 };
 
-export default ({ contentType, color = '' }) => {
-    return (
-        <CardBadge color={color || determineColor(contentType)}>
-            <P5 collapse>
-                <strong>
-                    {contentType === 'youtube' || contentType === 'twitch'
-                        ? contentType + ' video'
-                        : contentType}
-                </strong>
-            </P5>
-        </CardBadge>
-    );
-};
+const badgeContent = contentType =>
+    contentType === 'youtube' || contentType === 'twitch'
+        ? contentType + ' video'
+        : contentType;
+
+export default ({ contentType, color = '' }) => (
+    <CardBadge color={color || determineColor(contentType)}>
+        <P5 bold collapse>
+            {badgeContent(contentType)}
+        </P5>
+    </CardBadge>
+);

--- a/src/components/dev-hub/card-badge.js
+++ b/src/components/dev-hub/card-badge.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { colorMap, size } from './theme';
+import { P5 } from './text';
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+
+const CardBadge = styled('div')`
+    align: left;
+    bottom: 0;
+    background-color: ${colorMap.greyDarkThree};
+    display: inline-block;
+    font-family: 'Akzidenz-Grotesk';
+    margin: ${size.default};
+    padding: 1px ${size.xsmall};
+    position: absolute;
+    text-transform: uppercase;
+    ${props =>
+        props.color &&
+        css`
+            border: 1px solid ${props.color};'
+        `}
+`;
+
+export default ({ contentType, color = '' }) => {
+    switch (contentType) {
+        case 'youtube':
+        case 'twitch':
+            return (
+                <CardBadge color={color || colorMap.salmon}>
+                    <P5 collapse>
+                        <strong>{contentType + ' video'}</strong>
+                    </P5>
+                </CardBadge>
+            );
+        case 'podcast':
+            return (
+                <CardBadge color={color || colorMap.yellow}>
+                    <P5 collapse>
+                        <strong>{contentType}</strong>
+                    </P5>
+                </CardBadge>
+            );
+        case 'article':
+            return (
+                <CardBadge color={color || colorMap.teal}>
+                    <P5 collapse>
+                        <strong>{contentType}</strong>
+                    </P5>
+                </CardBadge>
+            );
+        default:
+            return null;
+    }
+};

--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -8,6 +8,7 @@ import { getNestedText } from '../../utils/get-nested-text';
 import { getTagLinksFromMeta } from '../../utils/get-tag-links-from-meta';
 import getTwitchThumbnail from '../../utils/get-twitch-thumbnail';
 import VideoModal from './video-modal';
+import CardBadge from './card-badge';
 
 const CardContainer = styled('div')`
     display: grid;
@@ -53,7 +54,6 @@ export default React.memo(({ videos, articles, podcasts, limit = 9 }) => {
     const hasMore = videos.length
         ? videos.length > visibleCards
         : articles.length > visibleCards;
-
     return (
         <>
             <CardContainer>
@@ -70,6 +70,12 @@ export default React.memo(({ videos, articles, podcasts, limit = 9 }) => {
                                 description={getNestedText(
                                     article['meta-description']
                                 )}
+                                badge={
+                                    <CardBadge
+                                        key={article['_id']}
+                                        contentType="article"
+                                    />
+                                }
                             />
                         ))}
 
@@ -87,6 +93,12 @@ export default React.memo(({ videos, articles, podcasts, limit = 9 }) => {
                                         image={getThumbnailUrl(video)}
                                         title={video.title}
                                         description={video.description}
+                                        badge={
+                                            <CardBadge
+                                                key={video.mediaType}
+                                                contentType={video.mediaType}
+                                            />
+                                        }
                                     />
                                 }
                                 thumbnail={getThumbnailUrl(video)}
@@ -102,6 +114,12 @@ export default React.memo(({ videos, articles, podcasts, limit = 9 }) => {
                                 image={getThumbnailUrl(podcast)}
                                 title={podcast.title}
                                 description={podcast.description}
+                                badge={
+                                    <CardBadge
+                                        key={podcast.mediaType}
+                                        contentType={podcast.mediaType}
+                                    />
+                                }
                             />
                         ))}
             </CardContainer>

--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -8,7 +8,6 @@ import { getNestedText } from '../../utils/get-nested-text';
 import { getTagLinksFromMeta } from '../../utils/get-tag-links-from-meta';
 import getTwitchThumbnail from '../../utils/get-twitch-thumbnail';
 import VideoModal from './video-modal';
-import CardBadge from './card-badge';
 
 const CardContainer = styled('div')`
     display: grid;
@@ -70,12 +69,7 @@ export default React.memo(({ videos, articles, podcasts, limit = 9 }) => {
                                 description={getNestedText(
                                     article['meta-description']
                                 )}
-                                badge={
-                                    <CardBadge
-                                        key={article['_id']}
-                                        contentType="article"
-                                    />
-                                }
+                                badge="article"
                             />
                         ))}
 
@@ -93,12 +87,7 @@ export default React.memo(({ videos, articles, podcasts, limit = 9 }) => {
                                         image={getThumbnailUrl(video)}
                                         title={video.title}
                                         description={video.description}
-                                        badge={
-                                            <CardBadge
-                                                key={video.mediaType}
-                                                contentType={video.mediaType}
-                                            />
-                                        }
+                                        badge={video.mediaType}
                                     />
                                 }
                                 thumbnail={getThumbnailUrl(video)}
@@ -114,12 +103,7 @@ export default React.memo(({ videos, articles, podcasts, limit = 9 }) => {
                                 image={getThumbnailUrl(podcast)}
                                 title={podcast.title}
                                 description={podcast.description}
-                                badge={
-                                    <CardBadge
-                                        key={podcast.mediaType}
-                                        contentType={podcast.mediaType}
-                                    />
-                                }
+                                badge={podcast.mediaType}
                             />
                         ))}
             </CardContainer>

--- a/src/components/dev-hub/card.js
+++ b/src/components/dev-hub/card.js
@@ -132,7 +132,7 @@ const Card = ({
                 {!collapseImage && (
                     <ImageWrapper>
                         {image && <Image src={image} alt="" />}
-                        <CardBadge contentType={badge} />
+                        {badge && <CardBadge contentType={badge} />}
                     </ImageWrapper>
                 )}
                 {title && (

--- a/src/components/dev-hub/card.js
+++ b/src/components/dev-hub/card.js
@@ -27,6 +27,7 @@ const ImageWrapper = styled('div')`
     overflow: hidden;
     padding: 0;
     width: 100%;
+    position: relative;
 `;
 const hoverStyles = css`
     &:hover,
@@ -99,6 +100,7 @@ const Card = ({
     maxDescriptionLines = 3,
     maxTitleLines = 2,
     onClick,
+    badge,
     to,
     tags,
     target,
@@ -129,6 +131,7 @@ const Card = ({
                 {!collapseImage && (
                     <ImageWrapper>
                         {image && <Image src={image} alt="" />}
+                        {badge}
                     </ImageWrapper>
                 )}
                 {title && (

--- a/src/components/dev-hub/card.js
+++ b/src/components/dev-hub/card.js
@@ -5,6 +5,7 @@ import { animationSpeed, colorMap, lineHeight, size, fontSize } from './theme';
 import { H5, P } from './text';
 import Link from './link';
 import TagList from './blog-tag-list';
+import CardBadge from './card-badge';
 
 const Image = styled('img')`
     border-radius: ${size.small};
@@ -131,7 +132,7 @@ const Card = ({
                 {!collapseImage && (
                     <ImageWrapper>
                         {image && <Image src={image} alt="" />}
-                        {badge}
+                        <CardBadge contentType={badge} />
                     </ImageWrapper>
                 )}
                 {title && (


### PR DESCRIPTION
This PR adds a card badge component that makes it easier to identify the source of a media content. The badges are placed on the bottom left side of the thumbnail images. 

<img width="342" alt="Screen Shot 2020-05-07 at 12 18 50 PM" src="https://user-images.githubusercontent.com/60625579/81319141-3abc5200-905d-11ea-97be-3ee6a7499d49.png">
