### PR TITLE
Create an iframe twitch fallback component

### DIFF
--- a/src/components/dev-hub/twitch-fallback-card.js
+++ b/src/components/dev-hub/twitch-fallback-card.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import Card from './card';
+import { screenSize } from './theme';
+
+const StyledIframe = styled('iframe')`
+    height: 100%;
+    width: 100%;
+    border: none;
+`;
+
+const TwitchCard = styled(Card)`
+    height: 100%;
+    width: 100%;
+    @media ${screenSize.upToLarge} {
+        height: 300px;
+    }
+`;
+
+// Fallback iframe for twitch
+const TwitchFallbackCard = ({ maxWidth }) => (
+    <TwitchCard collapseImage maxWidth={maxWidth}>
+        <StyledIframe
+            title="MongoDB Twitch"
+            src="https://player.twitch.tv/?channel=MongoDB&parent=developer.mongodb.com&muted=true"
+            frameborder="0"
+            scrolling="no"
+            allowfullscreen="true"
+        />
+    </TwitchCard>
+);
+
+export default TwitchFallbackCard;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -19,8 +19,7 @@ import GradientUnderline from '../components/dev-hub/gradient-underline';
 import homepageBackground from '../images/1x/homepage-background.png';
 import ProjectSignUpForm from '../components/dev-hub/project-sign-up-form';
 import useTwitchApi from '../hooks/use-twitch-api';
-import { Modal } from '../components/dev-hub/modal';
-import VideoEmbed from '../components/dev-hub/video-embed';
+import TwitchFallbackCard from '../components/dev-hub/twitch-fallback-card';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 import { getFeaturedCardFields } from '../utils/get-featured-card-fields';
 import getTwitchThumbnail from '../utils/get-twitch-thumbnail';
@@ -176,8 +175,13 @@ export default ({ pageContext: { featuredArticles } }) => {
                 </Hero>
                 <FeatureSection altBackground data-test="twitch">
                     <MediaBlock
+                        mediaWidth={MEDIA_WIDTH}
                         mediaComponent={
-                            twitchVideo && <Thumbnail video={twitchVideo} />
+                            twitchVideo ? (
+                                <Thumbnail video={twitchVideo} />
+                            ) : (
+                                <TwitchFallbackCard maxWidth={MEDIA_WIDTH} />
+                            )
                         }
                     >
                         <SectionContent>


### PR DESCRIPTION
This PR creates a component used if Twitch API calls fail/give us `null` video data. A question on this iframe:
- Using the channel id always checks for streams, there is no way to just get the last video without an ID. We could hardcode a video ID since more often than not the team won't be streaming, does this make sense here?

Desktop:
![Screen Shot 2020-05-07 at 5 11 01 PM](https://user-images.githubusercontent.com/9064401/81346545-74568280-9088-11ea-9ace-574606b2ba8e.png)

Mobile:
![Screen Shot 2020-05-07 at 5 11 18 PM](https://user-images.githubusercontent.com/9064401/81346547-74568280-9088-11ea-9436-edf3204205af.png)
