### PR TITLE
Add lazy loading to article, card images

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -95,6 +95,7 @@ export default class Image extends Component {
 
         return (
             <img
+                loading="lazy"
                 src={this.getImgData(process.env.PREVIEW_MODE, imgSrc)}
                 alt={altText}
                 css={ArticleImageStyle(captioned, customAlign, scale)}

--- a/src/components/dev-hub/card.js
+++ b/src/components/dev-hub/card.js
@@ -124,7 +124,7 @@ const Card = ({
             <div>
                 {!collapseImage && (
                     <ImageWrapper>
-                        {image && <Image src={image} alt="" />}
+                        {image && <Image loading="lazy" src={image} alt="" />}
                         {video && (
                             <VideoModal
                                 id={video.videoId}

--- a/tests/unit/__snapshots__/Figure.test.js.snap
+++ b/tests/unit/__snapshots__/Figure.test.js.snap
@@ -8,6 +8,7 @@ exports[`renders correctly 1`] = `
   <img
     alt="/images/firstcluster.png"
     css="You have tried to stringify object returned from \`css\` function. It isn't supposed to be used directly (e.g. as value of the \`className\` prop), but rather handed to emotion so it can handle it (e.g. as value of \`css\` prop)."
+    loading="lazy"
     src="/images/firstcluster.png"
   />
 </figure>
@@ -21,6 +22,7 @@ exports[`renders lightbox correctly when specified as an option 1`] = `
   <img
     alt="/images/firstcluster.png"
     css="You have tried to stringify object returned from \`css\` function. It isn't supposed to be used directly (e.g. as value of the \`className\` prop), but rather handed to emotion so it can handle it (e.g. as value of \`css\` prop)."
+    loading="lazy"
     src="/images/firstcluster.png"
   />
 </figure>


### PR DESCRIPTION
This PR adds the `loading="lazy"` attribute to:
- Images within articles
- Images on cards

I also checked out the network tab and verified it didn't load certain images until they were close to the viewport, neat!

Some snapshots needed to be updated due to the new attribute