### PR TITLE
Move YT API Key into env files

### DIFF
--- a/src/utils/fetch-youtube-data.js
+++ b/src/utils/fetch-youtube-data.js
@@ -2,7 +2,6 @@ import { buildQueryString } from '../utils/query-string';
 import dlv from 'dlv';
 
 const API_ENDPOINT = 'https://www.googleapis.com/youtube/v3/playlistItems';
-const YT_API_KEY = 'AIzaSyB2V7htFuJNO2RDrYFzGBzfYmyDVzfK6Yw';
 
 // Fetches data from youtube api
 
@@ -24,7 +23,7 @@ const simplifyResponse = responseData => {
 const fetchYoutubeData = async (PLAYLIST_ID, maxResults = 5) => {
     const options = {
         playlistId: PLAYLIST_ID,
-        key: YT_API_KEY,
+        key: process.env.YT_API_KEY,
         part: 'snippet',
         maxResults: maxResults,
     };


### PR DESCRIPTION
**This would require DOCSP to add the YT_API_KEY in the .env files in jobs**

This PR pulls the YouTube API Key out of the fetch util and reads from the `.env.*` files. Not sure which other API keys we would want to move out? This was the only one I saw (Twitch has ClientID but most of that code will likely move out of our repo soon anyway).