### PR TITLE
Switch 'target' to 'fileid' for related articles

### DIFF
--- a/src/components/dev-hub/related-articles.js
+++ b/src/components/dev-hub/related-articles.js
@@ -45,7 +45,7 @@ const getCardParamsFromRelatedType = (relatedArticle, slugTitleMapping) => {
         : relatedArticle.type;
     switch (name) {
         case 'doc':
-            const target = relatedArticle.target;
+            const target = relatedArticle.fileid;
             const slug = target && target.slice(1, target.length);
             const image = relatedArticle.image || ARTICLE_PLACEHOLDER;
             const title = dlv(slugTitleMapping, [slug, 0, 'value'], '');


### PR DESCRIPTION
This solves half of the problem for [DEVHUB-124](https://jira.mongodb.org/browse/DEVHUB-124).

Looks like the data of returned articles docs either changed or was different from what was expected. Locally I was able to recreate the issue. On the newest parser version (0.4.6) this is what data we get for a related `doc`:

![Screen Shot 2020-05-12 at 11 22 14 AM](https://user-images.githubusercontent.com/9064401/81712805-0e307d80-9443-11ea-822d-72abae6a8d6d.png)

Unfortunately, the image is blank and so is target. Since fileid and target are identical I switched to using `fileid` which should solve the related article not showing up. As for the image, I can dig into this some more as well.