### PR TITLE
Fix related pages by using refuri and fileid

### DIFF
--- a/src/components/dev-hub/related-articles.js
+++ b/src/components/dev-hub/related-articles.js
@@ -43,6 +43,7 @@ const getCardParamsFromRelatedType = (relatedArticle, slugTitleMapping) => {
     const name = relatedArticle.name
         ? relatedArticle.name
         : relatedArticle.type;
+    console.log(relatedArticle);
     switch (name) {
         case 'doc':
             const target = relatedArticle.target;
@@ -58,13 +59,13 @@ const getCardParamsFromRelatedType = (relatedArticle, slugTitleMapping) => {
             return { image, target, title };
         case 'literal':
             return {
-                image: ARTICLE_PLACEHOLDER,
+                image: relatedArticle.image || ARTICLE_PLACEHOLDER,
                 target: null,
                 title: dlv(relatedArticle, ['children', 0, 'value'], ''),
             };
         case 'reference':
             return {
-                image: ARTICLE_PLACEHOLDER,
+                image: relatedArticle.image || ARTICLE_PLACEHOLDER,
                 target: relatedArticle.refuri,
                 title: dlv(relatedArticle, ['children', 0, 'value'], ''),
             };

--- a/src/components/dev-hub/related-articles.js
+++ b/src/components/dev-hub/related-articles.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import dlv from 'dlv';
+import { withPrefix } from 'gatsby';
 import styled from '@emotion/styled';
 import ARTICLE_PLACEHOLDER from '../../images/1x/MDB-and-Node.js.png';
 import Card from './card';
@@ -47,7 +48,9 @@ const getCardParamsFromRelatedType = (relatedArticle, slugTitleMapping) => {
         case 'doc':
             const target = relatedArticle.target;
             const slug = target && target.slice(1, target.length);
-            const image = relatedArticle.image || ARTICLE_PLACEHOLDER;
+            const image = relatedArticle.image
+                ? withPrefix(relatedArticle.image)
+                : ARTICLE_PLACEHOLDER;
             const title = dlv(slugTitleMapping, [slug, 0, 'value'], '');
             if (title === '') {
                 console.error(
@@ -58,13 +61,17 @@ const getCardParamsFromRelatedType = (relatedArticle, slugTitleMapping) => {
             return { image, target, title };
         case 'literal':
             return {
-                image: relatedArticle.image || ARTICLE_PLACEHOLDER,
+                image: relatedArticle.image
+                    ? withPrefix(relatedArticle.image)
+                    : ARTICLE_PLACEHOLDER,
                 target: null,
                 title: dlv(relatedArticle, ['children', 0, 'value'], ''),
             };
         case 'reference':
             return {
-                image: relatedArticle.image || ARTICLE_PLACEHOLDER,
+                image: relatedArticle.image
+                    ? withPrefix(relatedArticle.image)
+                    : ARTICLE_PLACEHOLDER,
                 target: relatedArticle.refuri,
                 title: dlv(relatedArticle, ['children', 0, 'value'], ''),
             };

--- a/src/components/dev-hub/related-articles.js
+++ b/src/components/dev-hub/related-articles.js
@@ -43,7 +43,6 @@ const getCardParamsFromRelatedType = (relatedArticle, slugTitleMapping) => {
     const name = relatedArticle.name
         ? relatedArticle.name
         : relatedArticle.type;
-    console.log(relatedArticle);
     switch (name) {
         case 'doc':
             const target = relatedArticle.target;

--- a/src/utils/setup/get-related-pages-with-images.js
+++ b/src/utils/setup/get-related-pages-with-images.js
@@ -5,7 +5,7 @@ const getRelatedPagesWithImages = (pageNodes, RESOLVED_REF_DOC_MAPPING) => {
     const relatedPageInfo = related.map(r => {
         // Handle `reference` and `ref_role` types
         const target = r.target || r.refuri || r.fileid;
-        const slug = target && target.slice(1, target.length);
+        const slug = target && target.slice(1);
         return {
             ...r,
             target,

--- a/src/utils/setup/get-related-pages-with-images.js
+++ b/src/utils/setup/get-related-pages-with-images.js
@@ -2,14 +2,20 @@ const dlv = require('dlv');
 
 const getRelatedPagesWithImages = (pageNodes, RESOLVED_REF_DOC_MAPPING) => {
     const related = dlv(pageNodes, 'query_fields.related', []);
-    const relatedPageInfo = related.map(r => ({
-        image: dlv(
-            RESOLVED_REF_DOC_MAPPING,
-            [r.target, 'query_fields', 'atf-image'],
-            null
-        ),
-        ...r,
-    }));
+    const relatedPageInfo = related.map(r => {
+        // Handle `reference` and `ref_role` types
+        const target = r.target || r.refuri || r.fileid;
+        const slug = target && target.slice(1, target.length);
+        return {
+            ...r,
+            target,
+            image: dlv(
+                RESOLVED_REF_DOC_MAPPING,
+                [slug, 'query_fields', 'atf-image'],
+                null
+            ),
+        };
+    });
     return relatedPageInfo;
 };
 

--- a/tests/utils/get-related-pages-with-images.test.js
+++ b/tests/utils/get-related-pages-with-images.test.js
@@ -2,12 +2,12 @@ import { getRelatedPagesWithImages } from '../../src/utils/setup/get-related-pag
 
 it('should get pages and images for posts related to an article', () => {
     const articleData = {
-        '/foo': {
+        foo: {
             query_fields: {
                 'atf-image': 'IMAGE_FILE',
             },
         },
-        '/bar': {
+        bar: {
             query_fields: {},
         },
     };
@@ -28,7 +28,7 @@ it('should get pages and images for posts related to an article', () => {
     expect(getRelatedPagesWithImages(blankArticle, articleData)).toEqual([]);
     expect(
         getRelatedPagesWithImages(articleWithRelatedImage, articleData)[0].image
-    ).toBe(articleData['/foo'].query_fields['atf-image']);
+    ).toBe(articleData.foo.query_fields['atf-image']);
     expect(
         getRelatedPagesWithImages(articleWithoutRelatedImage, articleData)[0]
             .image


### PR DESCRIPTION
This PR solves [DEVHUB-124](https://jira.mongodb.org/browse/DEVHUB-124).

The issue was the data we were getting back for related articles was different from what we previously had. Before we just got `target` for all types of article links (internal and external). Now they are sending multiple types of related articles back with different fields for each based on whether they use the `doc` directive or try as a link (what Lauren was doing). This PR will handle both cases for robustness:

A "reference" type
![Screen Shot 2020-05-12 at 12 15 08 PM](https://user-images.githubusercontent.com/9064401/81719008-79ca1900-944a-11ea-9038-4bf723650081.png)

A "ref_role" type
![Screen Shot 2020-05-12 at 12 15 17 PM](https://user-images.githubusercontent.com/9064401/81719009-79ca1900-944a-11ea-9104-69aca2b91387.png)

Neither of these had `target` so building related articles would fail. Also, these values have leading slashes, which older values did not.

This PR optionally checks for any possible field that could have the slug/url: `target` (not sure if this is even in use anymore), `refuri`, and `fileid` to account for different types. It also removes the leading slash to solve issues getting the title and image and uses the `image` should it exist for related articles of any type (`reference` or `ref-doc`) should the content writers prefer one syntax over the other. 

The tests also had to be updated for this change. I also plan to add a cypress test for these images in a bit more detail.

This PR:
![Screen Shot 2020-05-12 at 12 20 52 PM](https://user-images.githubusercontent.com/9064401/81719476-1ee4f180-944b-11ea-992b-b382571dab70.png)


