### PR TITLE
Use withPrefix for internal doc links

### DIFF
--- a/src/components/dev-hub/related-articles.js
+++ b/src/components/dev-hub/related-articles.js
@@ -46,8 +46,10 @@ const getCardParamsFromRelatedType = (relatedArticle, slugTitleMapping) => {
         : relatedArticle.type;
     switch (name) {
         case 'doc':
-            const target = relatedArticle.target;
-            const slug = target && target.slice(1, target.length);
+            const slug =
+                relatedArticle.target && relatedArticle.target.slice(1);
+            // 'doc' is for internal articles, so links should be prefixed
+            const target = withPrefix(relatedArticle.target);
             const image = relatedArticle.image
                 ? withPrefix(relatedArticle.image)
                 : ARTICLE_PLACEHOLDER;


### PR DESCRIPTION
Normally with `Links` and `Cards` we use the `to` prop for internal links so we don't have to put `withPrefix` everywhere. With related articles, we have both internal and external references, so we cannot be 100% sure which prop to use so we default to `href` instead of `to`.

This led to a small issue for internal related articles, because we were using `href` but not `to` we have to add `withPrefix` so any url prefix is maintained. You can see a broken related article [here](http://docs-devhub-staging.s3-website-us-east-1.amazonaws.com/b10d18e/devhub/docsworker-xlarge/05-12-20-2/quickstart/bson-data-types-decimal128). Funny enough is that this will break on staging but not prod, since prod has no url prefix.

This PR adds a `withPrefix` call for internal doc references for internal articles, so `:doc:` rST directive use will work for content writers on staging and prod as expected.