### PR TITLE
Use gatsby-source-mongodb-stitch

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,6 +2,10 @@ const { siteUrl } = require('./src/queries/site-url');
 const { generatePathPrefix } = require('./src/utils/generate-path-prefix');
 const { getMetadata } = require('./src/utils/get-metadata');
 const { articleRssFeed } = require('./src/utils/setup/article-rss-feed');
+const {
+    stitchFetchDocuments,
+} = require('./src/utils/setup/stitch-fetch-documents');
+const { SNOOTY_STITCH_ID } = require('./src/build-constants');
 
 const runningEnv = process.env.NODE_ENV || 'production';
 
@@ -16,6 +20,13 @@ module.exports = {
     plugins: [
         'gatsby-plugin-react-helmet',
         'gatsby-plugin-emotion',
+        {
+            resolve: 'gatsby-source-mongodb-stitch',
+            options: {
+                stitchId: SNOOTY_STITCH_ID,
+                functions: [stitchFetchDocuments(metadata)],
+            },
+        },
         {
             resolve: 'gatsby-plugin-sitemap',
             options: {

--- a/gatsby-config.prod.js
+++ b/gatsby-config.prod.js
@@ -1,6 +1,10 @@
 const { siteUrl } = require('./src/queries/site-url');
 const { getMetadata } = require('./src/utils/get-metadata');
 const { articleRssFeed } = require('./src/utils/setup/article-rss-feed');
+const {
+    stitchFetchDocuments,
+} = require('./src/utils/setup/stitch-fetch-documents');
+const { SNOOTY_STITCH_ID } = require('./src/build-constants');
 
 require('dotenv').config({
     path: '.env.production',
@@ -13,6 +17,13 @@ module.exports = {
     plugins: [
         'gatsby-plugin-react-helmet',
         'gatsby-plugin-emotion',
+        {
+            resolve: 'gatsby-source-mongodb-stitch',
+            options: {
+                stitchId: SNOOTY_STITCH_ID,
+                functions: [stitchFetchDocuments(metadata)],
+            },
+        },
         {
             resolve: 'gatsby-plugin-sitemap',
             options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14498,6 +14498,14 @@
         }
       }
     },
+    "gatsby-source-mongodb-stitch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/gatsby-source-mongodb-stitch/-/gatsby-source-mongodb-stitch-0.1.2.tgz",
+      "integrity": "sha512-APd/Q7dRlr+aoA2ds6nk4VWj8ndupZ0kvukhj6OHl3ynNVyVRel5g+OjudVmQffY7QGqzqsSF0GVw7ZlNEeHMg==",
+      "requires": {
+        "mongodb-stitch-server-sdk": "^4.8.0"
+      }
+    },
     "gatsby-telemetry": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "gatsby-plugin-google-tagmanager": "^2.3.1",
     "gatsby-plugin-react-helmet": "^3.3.1",
     "gatsby-plugin-sitemap": "^2.4.2",
+    "gatsby-source-mongodb-stitch": "^0.1.2",
     "memoizerific": "^1.11.3",
     "mongodb-stitch-browser-sdk": "^4.8.0",
     "mongodb-stitch-server-sdk": "^4.8.0",

--- a/src/utils/setup/stitch-fetch-documents.js
+++ b/src/utils/setup/stitch-fetch-documents.js
@@ -1,0 +1,19 @@
+const { DOCUMENTS_COLLECTION } = require('../../build-constants');
+const { constructDbFilter } = require('./construct-db-filter');
+
+const stitchFetchDocuments = metadata => {
+    const PAGE_ID_PREFIX = `${metadata.project}/${metadata.user}/${metadata.parserBranch}`;
+
+    return {
+        name: 'fetchDocuments',
+        args: [
+            metadata.database,
+            DOCUMENTS_COLLECTION,
+            constructDbFilter(PAGE_ID_PREFIX),
+        ],
+        resultType: 'StitchArticle',
+        getResultId: x => x.page_id,
+    };
+};
+
+module.exports = { stitchFetchDocuments };


### PR DESCRIPTION
Recently a [new plugin to support Stitch functions](https://www.npmjs.com/package/gatsby-source-mongodb-stitch) at Gatsby build-time came out, so this PR adds support for this plugin to the devhub. The plugin is nice because it cuts some logic out of `gatsby-node` and forces us to continue to use the concept of nodes.

There should be no change in functionality.