### PR TITLE
Use Stitch for Twitch Streams

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -30,11 +30,4 @@ export const ADMONITIONS = [
     'warning',
 ];
 
-// Twitch API constants
-export const TWITCH_API_ENDPOINT = 'https://api.twitch.tv/helix/';
-export const TWITCH_CLIENT_ID = '041r2glmgub2pt357ss0la44j2sz95';
-export const TWITCH_MDB_CHANNEL_ID = '467752938';
-export const TWITCH_HEADERS = { 'Client-ID': TWITCH_CLIENT_ID };
-export const TWITCH_STREAMS_URL = `${TWITCH_API_ENDPOINT}streams?user_id=${TWITCH_MDB_CHANNEL_ID}`;
-
 export const STITCH_AUTH_APP_ID = 'devhubauthentication-lidpq';

--- a/src/hooks/use-twitch-api.js
+++ b/src/hooks/use-twitch-api.js
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
+import { requestMDBTwitchStream } from '../utils/devhub-api-stitch';
 import fetchTwitchVideos from '../utils/fetch-twitch-videos';
-import { get } from '../utils/request';
-import { TWITCH_HEADERS, TWITCH_STREAMS_URL } from '../constants';
 
 /**
  * @param {Object} config
@@ -21,10 +20,7 @@ export default ({ getStream = true, videoLimit = 1 } = {}) => {
         try {
             // Get stream
             if (getStream) {
-                const streamResp = await get(
-                    TWITCH_STREAMS_URL,
-                    TWITCH_HEADERS
-                );
+                const streamResp = await requestMDBTwitchStream();
                 // since we're only interested in one channel just get the first
                 currentStream = streamResp.data[0];
                 if (currentStream) {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -152,6 +152,7 @@ export default ({ pageContext: { featuredArticles } }) => {
                                         twitchVideo.thumbnailUrl
                                     )}
                                     maxWidth={MEDIA_WIDTH}
+                                    title={twitchVideo.title}
                                     videoModalThumbnail={getTwitchThumbnail(
                                         twitchVideo.thumbnailUrl,
                                         1200

--- a/src/utils/devhub-api-stitch.js
+++ b/src/utils/devhub-api-stitch.js
@@ -9,6 +9,11 @@ const callDevhubAPIStitchFunction = async (fnName, ...fnArgs) => {
     }
 };
 
+export const requestMDBTwitchStream = async () => {
+    const result = await callDevhubAPIStitchFunction('fetchMDBTwitchStream');
+    return result;
+};
+
 export const requestMDBTwitchVideos = async videoLimit => {
     const result = await callDevhubAPIStitchFunction(
         'fetchMDBTwitchVideos',


### PR DESCRIPTION
This PR is the last piece of work for moving existing APIs to Stitch, and also finishes migrating our Twitch use to the New Twitch API.

This PR incorporates a new Stitch function called `fetchMDBTwitchStream`, which is very similar to work done for Twitch Videos into the codebase by adding a new wrapper to call Stitch and incorporating it in the hook used by the homepage to check streams before checking videos.

Now, on the homepage we should see the old card back again (although there is no stream right now, a video does show) and no 401 errors in the console. The title was also missing from this card so I added it back in.