### PR TITLE
Storybook entry for the badge component and card-list changes

### DIFF
--- a/src/components/dev-hub/badge.js
+++ b/src/components/dev-hub/badge.js
@@ -3,7 +3,7 @@ import { colorMap, size } from './theme';
 import { P5 } from './text';
 import styled from '@emotion/styled';
 
-const CardBadge = styled('div')`
+const Badge = styled('div')`
     bottom: 0;
     background-color: ${colorMap.greyDarkThree};
     font-family: akzidenz;
@@ -35,9 +35,9 @@ const badgeContent = contentType =>
         : contentType;
 
 export default ({ contentType, color = '' }) => (
-    <CardBadge color={color || determineColor(contentType)}>
+    <Badge color={color || determineColor(contentType)}>
         <P5 bold collapse>
             {badgeContent(contentType)}
         </P5>
-    </CardBadge>
+    </Badge>
 );

--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -36,7 +36,7 @@ const HasMoreButtonContainer = styled('div')`
 
 const getThumbnailUrl = media => {
     return media.mediaType === 'twitch'
-        ? getTwitchThumbnail(media.thumbnailUrl, 1000)
+        ? getTwitchThumbnail(media.thumbnailUrl)
         : media.thumbnailUrl;
 };
 

--- a/src/components/dev-hub/card.js
+++ b/src/components/dev-hub/card.js
@@ -7,7 +7,7 @@ import { H5, P } from './text';
 import Link from './link';
 import TagList from './blog-tag-list';
 import VideoModal from './video-modal';
-import CardBadge from './card-badge';
+import Badge from './badge';
 
 const Image = styled('img')`
     border-radius: ${size.small};
@@ -133,7 +133,7 @@ const Card = ({
                                 thumbnail={videoModalThumbnail || image}
                             />
                         )}
-                        {badge && <CardBadge contentType={badge} />}
+                        {badge && <Badge contentType={badge} />}
                     </ImageWrapper>
                 )}
                 {title && (

--- a/src/components/dev-hub/stories/badge.stories.mdx
+++ b/src/components/dev-hub/stories/badge.stories.mdx
@@ -6,7 +6,7 @@ import { colorMap } from '../theme';
 
 # Badge
 
-Badges can be used to label contents. It accepts two parameters: `contentType` and `color`.
+Badges can be used to label contents. They are `position: absolute` by default and accept two parameters: `contentType` and `color`.
 * The `contentType` variable defines the text that goes inside the badge.
 * The optional `color` variable defines the color of the borders around the badge.
 

--- a/src/components/dev-hub/stories/badge.stories.mdx
+++ b/src/components/dev-hub/stories/badge.stories.mdx
@@ -1,0 +1,53 @@
+import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import Badge from '../badge';
+import { colorMap } from '../theme';
+
+<Meta title="Badge" />
+
+# Badge
+
+Badges can be used to label contents. It accepts two parameters: `contentType` and `color`.
+* The `contentType` variable defines the text that goes inside the badge.
+* The optional `color` variable defines the color of the borders around the badge.
+
+<Preview>
+    <Story name="custom-badge">
+        <div style={{position:'relative', height: '50px'}}>
+            <Badge contentType={'badge'} color={colorMap.teal}/>
+        </div>
+    </Story>
+</Preview>
+
+`Articles`, `Podcasts`, `Youtube`, and `Twitch` contents have predetermined texts and border colors.
+
+<Preview>
+    <Story name="badge-youtube">
+        <div style={{position:'relative', height: '50px'}}>
+            <Badge contentType={'youtube'}/>
+        </div>
+    </Story>
+</Preview>
+
+<Preview>
+    <Story name="badge-twitch">
+        <div style={{position:'relative', height: '50px'}}>
+            <Badge contentType={'twitch'}/>
+        </div>
+    </Story>
+</Preview>
+
+<Preview>
+    <Story name="badge-podcast">
+        <div style={{position:'relative', height: '50px'}}>
+            <Badge contentType={'podcast'}/>
+        </div>
+    </Story>
+</Preview>
+
+<Preview>
+    <Story name="badge-articles">
+        <div style={{position:'relative', height: '50px'}}>
+            <Badge contentType={'article'}/>
+        </div>
+    </Story>
+</Preview>


### PR DESCRIPTION
This PR documents the `Badge` component on storybook and makes the thumbnail images for twitch videos square to match the other cards (Youtube thumbnails are still in progress). It also renames the `CardBadge` component to `Badge` since its use is not restricted to just `Card` components. 