### PR TITLE
List tab buttons in a single column on mobile

### DIFF
--- a/src/components/dev-hub/tab.js
+++ b/src/components/dev-hub/tab.js
@@ -10,7 +10,7 @@ const Tab = styled('div')`
     border-bottom: 1px solid ${colorMap.greyDarkOne};
     display: flex;
     justify-content: space-between;
-    @media ${screenSize.upToLarge} {
+    @media ${screenSize.upToMedium} {
         display: block;
     }
 `;
@@ -36,9 +36,9 @@ const TabButton = styled('button')`
     transition: 0.3s;
     width: ${TAB_WIDTH};
     ${({ isActive }) => isActive && activeStyles}
-    @media ${screenSize.upToLarge} {
+    @media ${screenSize.upToMedium} {
         display: block;
-        margin:0 auto;
+        margin: 0 auto;
     }
 `;
 

--- a/src/components/dev-hub/tab.js
+++ b/src/components/dev-hub/tab.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
-import { colorMap, size, fontSize } from './theme';
+import { colorMap, size, fontSize, screenSize } from './theme';
 import { P } from './text';
 
 const TAB_WIDTH = '136px';
@@ -10,6 +10,9 @@ const Tab = styled('div')`
     border-bottom: 1px solid ${colorMap.greyDarkOne};
     display: flex;
     justify-content: space-between;
+    @media ${screenSize.upToLarge} {
+        display: block;
+    }
 `;
 
 const activeStyles = css`
@@ -33,6 +36,10 @@ const TabButton = styled('button')`
     transition: 0.3s;
     width: ${TAB_WIDTH};
     ${({ isActive }) => isActive && activeStyles}
+    @media ${screenSize.upToLarge} {
+        display: block;
+        margin:0 auto;
+    }
 `;
 
 const mapTabTextToButton = (textList, activeItem, handleClick) =>


### PR DESCRIPTION
This PR makes minor css changes to list the buttons on the `Tab` component in a single column (as opposed two) on mobiles. 