### PR TITLE
Create a Slider Component

### DIFF
--- a/src/components/dev-hub/slider.js
+++ b/src/components/dev-hub/slider.js
@@ -1,0 +1,83 @@
+import React, { useMemo } from 'react';
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+import { colorMap, gradientMap, size } from './theme';
+import { P3 } from './text';
+
+const RANGE_BUFFER_SIZE = '6px';
+
+const inputThumbStyle = css`
+    -webkit-appearance: none;
+    background: ${colorMap.sherbet};
+    background-size: 100%;
+    border: none;
+    border-radius: 50%;
+    cursor: pointer;
+    height: ${size.default};
+    margin-top: -${RANGE_BUFFER_SIZE};
+    width: ${size.default};
+`;
+
+const inputTrackStyle = percentage => css`
+    border-radius: ${RANGE_BUFFER_SIZE};
+    background: ${gradientMap.magentaSalmonSherbet} ${colorMap.greyDarkTwo};
+    background-repeat: no-repeat;
+    background-size: ${`${percentage}%`} 100%;
+    height: 4px;
+    margin-bottom: ${RANGE_BUFFER_SIZE};
+    margin-top: ${RANGE_BUFFER_SIZE};
+`;
+
+const SliderContainer = styled('div')`
+    align-items: center;
+    display: flex;
+    width: 100%;
+`;
+
+const StyledInput = styled('input')`
+    -webkit-appearance: none;
+    background: none;
+    width: 100%;
+    /* Style the input "thumb" */
+    ::-webkit-slider-thumb {
+        ${inputThumbStyle};
+    }
+    ::-moz-range-thumb {
+        ${inputThumbStyle};
+    }
+    /* Style the input "track" */
+    ::-webkit-slider-runnable-track {
+        ${({ percentage }) => inputTrackStyle(percentage)};
+    }
+    ::-moz-range-track {
+        ${({ percentage }) => inputTrackStyle(percentage)};
+    }
+`;
+
+const SliderLabelText = styled(P3)`
+    font-family: 'Fira Mono';
+    margin: 0 ${size.default};
+`;
+
+const Slider = ({ current, currentLabel, onChange, total, totalLabel }) => {
+    const sliderPercentage = useMemo(() => Math.ceil((current / total) * 100), [
+        current,
+        total,
+    ]);
+    return (
+        <SliderContainer>
+            <SliderLabelText>{currentLabel || current}</SliderLabelText>
+            <StyledInput
+                min={0}
+                max={total}
+                onInput={e => onChange(e.target.value)}
+                percentage={sliderPercentage}
+                type="range"
+                value={current}
+            />
+            <SliderLabelText>{totalLabel || total}</SliderLabelText>
+        </SliderContainer>
+    );
+};
+
+export default Slider;

--- a/src/components/dev-hub/stories/slider.stories.mdx
+++ b/src/components/dev-hub/stories/slider.stories.mdx
@@ -1,0 +1,19 @@
+import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { action } from '@storybook/addon-actions';
+import Slider from '../slider';
+import { useState } from 'react';
+
+<Meta title="Slider" />
+
+# Slider
+
+The `Slider` allows for easy hooking into state to not only update the slider but also access `onChange` events. The `current` value can be updated programatically. There is also support for custom labels: `currentLabel` and `totalLabel`.
+
+<Preview>
+    <Story name="Slider">
+        {() => {
+            const [value, setValue] = useState(10);
+            return <Slider current={value} total={100} onChange={setValue} />;
+        }}
+    </Story>
+</Preview>


### PR DESCRIPTION
This PR creates a Slider component using `<input type="range" />`, which we will use when playing podcasts. It supports props for state management by parents, and works on chrome, ff, and safari!

I also made a quick story for it.

![Screen Shot 2020-05-15 at 3 31 02 PM](https://user-images.githubusercontent.com/9064401/82089487-b3588980-96c1-11ea-8878-95be3b3ba067.png)
