### PR TITLE
Add leafygreen checkbox

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,2 +1,3 @@
 import '@storybook/addon-knobs/register';
 import '@storybook/addon-docs/register';
+import '@storybook/addon-actions/register';

--- a/package-lock.json
+++ b/package-lock.json
@@ -3077,6 +3077,15 @@
         "@types/yargs": "^13.0.0"
       }
     },
+    "@leafygreen-ui/checkbox": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/checkbox/-/checkbox-4.0.1.tgz",
+      "integrity": "sha512-Y5CQ/rO1RwyDYrHP7hsndtYpYMpDtYkpPmTJLRBlZpyKLmw7rcDrv+rgnWBWLmzdwj7zGdC+JxTy1wJJQelx2A==",
+      "requires": {
+        "@leafygreen-ui/lib": "^4.0.0",
+        "@leafygreen-ui/theme": "^2.0.0"
+      }
+    },
     "@leafygreen-ui/code": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/@leafygreen-ui/code/-/code-3.4.3.tgz",
@@ -3143,6 +3152,11 @@
         "highlight.js": "^9.15.6",
         "highlightjs-graphql": "^1.0.1"
       }
+    },
+    "@leafygreen-ui/theme": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/theme/-/theme-2.0.0.tgz",
+      "integrity": "sha512-nwSSBNy0+Hoa7RsDCYMijDstn0Vi5tWTn9sr1K7HNdpNQbRImQ5shfhf4cr2jR1Yvu7Np5zf3jlkSlAppWeR0Q=="
     },
     "@mdx-js/loader": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@babel/preset-react": "^7.9.4",
     "@emotion/core": "^10.0.28",
     "@emotion/styled": "^10.0.27",
+    "@leafygreen-ui/checkbox": "^4.0.1",
     "@leafygreen-ui/code": "^3.4.3",
     "copy-to-clipboard": "^3.3.1",
     "css-loader": "^3.5.3",

--- a/src/components/dev-hub/stories/form.stories.mdx
+++ b/src/components/dev-hub/stories/form.stories.mdx
@@ -1,7 +1,9 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { action } from '@storybook/addon-actions';
 import Input from '../input';
 import Select from '../select';
 import TextArea from '../text-area';
+import Checkbox from '@leafygreen-ui/checkbox';
 
 <Meta title="Forms" />
 
@@ -65,5 +67,15 @@ or a narrow select
 <Preview>
     <Story name="textarea">
         <TextArea placeholder="Email Address" />
+    </Story>
+</Preview>
+
+### Checkbox
+
+We are using the [LeafyGreen Checkbox](https://github.com/mongodb/leafygreen-ui/tree/master/packages/checkbox) component for our forms
+
+<Preview>
+    <Story name="checkbox">
+        <Checkbox label="checkbox" onChange={action('checkbox ticked')} />
     </Story>
 </Preview>


### PR DESCRIPTION
For forms, we are also going to be using the leafygreen checkbox. This PR adds this package in and also creates a quick story for it. Should be simple enough to use with our forms.

![Screen Shot 2020-05-19 at 9 56 41 AM](https://user-images.githubusercontent.com/9064401/82335294-20686980-99b7-11ea-9ba3-aa30af7b2cd9.png)
