### PR TITLE
Section header component

### DIFF
--- a/src/components/dev-hub/section-header.js
+++ b/src/components/dev-hub/section-header.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { colorMap, fontSize, screenSize } from './theme';
+import { P } from './text';
+
+const SectionHeader = styled('div')`
+    border-bottom: 1px solid ${colorMap.greyDarkOne};
+    font-size: ${fontSize.small};
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    @media ${screenSize.upToMedium} {
+        display: block;
+    }
+`;
+
+export default ({ text }) => (
+    <SectionHeader>
+        <div>
+            <P>{text}</P>
+        </div>
+    </SectionHeader>
+);

--- a/src/components/dev-hub/section-header.js
+++ b/src/components/dev-hub/section-header.js
@@ -7,16 +7,14 @@ const SectionHeader = styled('div')`
     border-bottom: 1px solid ${colorMap.greyDarkOne};
     font-size: ${fontSize.small};
     letter-spacing: 2px;
-    text-transform: uppercase;
     @media ${screenSize.upToMedium} {
         display: block;
     }
+    text-transform: uppercase;
 `;
 
 export default ({ text }) => (
     <SectionHeader>
-        <div>
-            <P>{text}</P>
-        </div>
+        <P>{text}</P>
     </SectionHeader>
 );

--- a/src/components/dev-hub/section-header.js
+++ b/src/components/dev-hub/section-header.js
@@ -1,19 +1,19 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { colorMap, lineHeight } from './theme';
-import { P } from './text';
+import { P4 } from './text';
 
 const SectionHeader = styled('div')`
     border-bottom: 1px solid ${colorMap.greyDarkOne};
     letter-spacing: 3px;
     text-transform: uppercase;
 `;
-const StyledP = styled(P)`
+const StyledP4 = styled(P4)`
     line-height: ${lineHeight.tiny};
 `;
 
 export default ({ children }) => (
     <SectionHeader>
-        <StyledP>{children}</StyledP>
+        <StyledP4>{children}</StyledP4>
     </SectionHeader>
 );

--- a/src/components/dev-hub/section-header.js
+++ b/src/components/dev-hub/section-header.js
@@ -1,20 +1,19 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { colorMap, fontSize, screenSize } from './theme';
+import { colorMap, lineHeight } from './theme';
 import { P } from './text';
 
 const SectionHeader = styled('div')`
     border-bottom: 1px solid ${colorMap.greyDarkOne};
-    font-size: ${fontSize.small};
-    letter-spacing: 2px;
-    @media ${screenSize.upToMedium} {
-        display: block;
-    }
+    letter-spacing: 3px;
     text-transform: uppercase;
 `;
+const StyledP = styled(P)`
+    line-height: ${lineHeight.tiny};
+`;
 
-export default ({ text }) => (
+export default ({ children }) => (
     <SectionHeader>
-        <P>{text}</P>
+        <StyledP>{children}</StyledP>
     </SectionHeader>
 );

--- a/src/components/dev-hub/section-header.js
+++ b/src/components/dev-hub/section-header.js
@@ -1,19 +1,14 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { colorMap, lineHeight } from './theme';
-import { P4 } from './text';
+import { colorMap } from './theme';
+import { ArticleH2 } from './text';
 
 const SectionHeader = styled('div')`
     border-bottom: 1px solid ${colorMap.greyDarkOne};
-    letter-spacing: 3px;
-    text-transform: uppercase;
-`;
-const StyledP4 = styled(P4)`
-    line-height: ${lineHeight.tiny};
 `;
 
 export default ({ children }) => (
     <SectionHeader>
-        <StyledP4>{children}</StyledP4>
+        <ArticleH2>{children}</ArticleH2>
     </SectionHeader>
 );


### PR DESCRIPTION
This PR adds the section header component that will be used in the `Academia` page. 

<img width="1431" alt="Screen Shot 2020-05-19 at 10 32 07 AM" src="https://user-images.githubusercontent.com/60625579/82339482-12691780-99bc-11ea-8f65-2f35ac22f558.png">
