### PR TITLE
1:1 Aspect Ratio For Any Card Image

### DIFF
--- a/src/components/dev-hub/card.js
+++ b/src/components/dev-hub/card.js
@@ -10,11 +10,15 @@ import VideoModal from './video-modal';
 import Badge from './badge';
 
 const Image = styled('img')`
+    bottom: 0;
     border-radius: ${size.small};
     display: block;
-    height: 100%;
+    left: 0;
+    margin: auto;
     overflow: hidden;
-    position: relative;
+    position: absolute;
+    right: 0;
+    top: 0;
     width: 100%;
     ${props =>
         props.gradient &&
@@ -25,12 +29,14 @@ const Image = styled('img')`
 `;
 
 const ImageWrapper = styled('div')`
+    background-color: black;
     border-radius: ${size.small};
     margin-bottom: ${size.medium};
     overflow: hidden;
-    padding: 0;
-    width: 100%;
+    /* Create 1:1 aspect ratio using top padding */
+    padding: 100% 0 0;
     position: relative;
+    width: 100%;
 `;
 const hoverStyles = css`
     &:hover,


### PR DESCRIPTION
Before, we were always given square images for our cards, so we didn't have any issues with different aspect ratios causing different size cards. Unfortunately, YouTube thumbnails don't come in 1:1 aspect ratios, so we were getting this effect:

![Screen Shot 2020-05-20 at 11 00 38 AM](https://user-images.githubusercontent.com/9064401/82462250-58d87800-9a89-11ea-9d85-49a25c2fc848.png)

This PR updates the Card Image logic to always fit the image into a 1:1 aspect ratio box so even if an image isn't a square, we will make it one. We take the initial image, center it, and fill the rest of the space so it matches other aspect ratio images. We get this done by using [padding-top against a 100% width](https://css-tricks.com/aspect-ratio-boxes/). We end up with this:

![Screen Shot 2020-05-20 at 11 10 17 AM](https://user-images.githubusercontent.com/9064401/82463239-912c8600-9a8a-11ea-9504-bf3c9b4486d5.png)
