### PR TITLE
Update Community Forums Links

### DIFF
--- a/src/components/dev-hub/global-footer.js
+++ b/src/components/dev-hub/global-footer.js
@@ -30,7 +30,7 @@ const siteLinks = [
     },
     {
         name: 'Community Forums',
-        url: 'https://community.mongodb.com/',
+        url: 'https://developer.mongodb.com/community/forums',
     },
 ];
 const iconstyles = css`

--- a/src/pages/community/index.js
+++ b/src/pages/community/index.js
@@ -105,7 +105,10 @@ export default () => {
                         Have a burning question you want to ask? Looking for a
                         community of like minded developers?
                     </P>
-                    <Button primary href="https://community.mongodb.com/">
+                    <Button
+                        primary
+                        href="https://developer.mongodb.com/community/forums"
+                    >
                         Join
                     </Button>
                 </HeroContent>


### PR DESCRIPTION
This PR satisfies [DEVHUB-129](https://jira.mongodb.org/browse/DEVHUB-129). This PR updates the links to the community forums to reference the location on the developer subdomain.

This change was made in two places, as requested:
- The global footer "Community Forums"
- The "join" button on `/community`