### PR TITLE
Move playlistId logic into Stitch

### DIFF
--- a/src/hooks/use-all-videos.js
+++ b/src/hooks/use-all-videos.js
@@ -2,8 +2,6 @@ import { useEffect, useState } from 'react';
 import fetchTwitchVideos from '../utils/fetch-twitch-videos';
 import fetchYoutubeData from '../utils/fetch-youtube-data';
 
-const YT_PLAYLIST = 'PL4RCxklHWZ9sLmYcronGcCu6HOYCPEcAF';
-
 const useAllVideos = () => {
     const [videos, setVideos] = useState(null);
     const [error, setError] = useState(null);
@@ -13,7 +11,7 @@ const useAllVideos = () => {
         const getVideos = async () => {
             setIsLoading(true);
             try {
-                const youtubeVideos = fetchYoutubeData(YT_PLAYLIST);
+                const youtubeVideos = fetchYoutubeData();
                 const twitchVideos = fetchTwitchVideos();
 
                 const allVideos = await Promise.all([

--- a/src/utils/devhub-api-stitch.js
+++ b/src/utils/devhub-api-stitch.js
@@ -22,10 +22,10 @@ export const requestMDBTwitchVideos = async videoLimit => {
     return result;
 };
 
-export const requestYoutubePlaylist = async (playlistId, maxResults) => {
-    const result = await callDevhubAPIStitchFunction('fetchYoutubeData', {
-        playlistId,
-        maxResults,
-    });
+export const requestYoutubePlaylist = async maxResults => {
+    const result = await callDevhubAPIStitchFunction(
+        'fetchYoutubeData',
+        maxResults
+    );
     return result;
 };

--- a/src/utils/fetch-youtube-data.js
+++ b/src/utils/fetch-youtube-data.js
@@ -17,9 +17,9 @@ const simplifyResponse = responseData => {
     return youtubeJSON;
 };
 
-const fetchYoutubeData = async (playlistId, maxResults = 5) => {
+const fetchYoutubeData = async (maxResults = 5) => {
     try {
-        const response = await requestYoutubePlaylist(playlistId, maxResults);
+        const response = await requestYoutubePlaylist(maxResults);
         if (response) {
             const videoList = response.items.map(simplifyResponse);
             return videoList;


### PR DESCRIPTION
This PR moves the logic for which playlist ID is used for YouTube into Stitch. It also cleans up syntax so we just pass `maxResults` to Stitch and not `{maxResults}`.