### PR TITLE
Update form element sizes

### DIFF
--- a/src/components/dev-hub/input-label.js
+++ b/src/components/dev-hub/input-label.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { colorMap, layer } from './theme';
+import { colorMap, fontSize, layer, lineHeight } from './theme';
 
 export const InputLabel = styled('label')`
     background: linear-gradient(
@@ -8,7 +8,10 @@ export const InputLabel = styled('label')`
         transparent 50%,
         ${colorMap.greyDarkTwo} 50%
     );
+    color: ${colorMap.greyLightTwo};
     font-family: 'Fira Mono', monospace;
+    font-size: ${fontSize.small};
+    line-height: ${lineHeight.tiny};
     left: ${({ labelAbsoluteLeft }) => labelAbsoluteLeft}px;
     position: absolute;
     top: ${({ labelStartTop }) => labelStartTop}px;

--- a/src/components/dev-hub/input.js
+++ b/src/components/dev-hub/input.js
@@ -7,23 +7,24 @@ import {
     FORM_ELEMENT_BORDER,
     gradientMap,
     layer,
+    lineHeight,
     size,
 } from './theme';
 import Label from './input-label';
 
-const LABEL_ABSOLUTE_LEFT = 22;
-const LABEL_END_TOP = -14;
-const LABEL_START_TOP = 9;
+const LABEL_ABSOLUTE_LEFT = 18;
+const LABEL_END_TOP = -10;
+const LABEL_START_TOP = 0;
 
 const StyledInput = styled('input')`
     background-color: ${colorMap.greyDarkTwo};
     border: ${FORM_ELEMENT_BORDER} solid transparent;
     color: ${colorMap.devWhite};
     font-family: 'Fira Mono', monospace;
-    font-size: ${fontSize.default};
+    font-size: ${fontSize.small};
+    line-height: ${lineHeight.small};
     outline: none;
-    padding: ${({ narrow }) =>
-        narrow ? `${size.small} ${size.medium}` : size.medium};
+    padding: ${({ narrow }) => (narrow ? `6px ${size.default}` : size.default)};
     position: relative;
     width: 100%;
     :focus {

--- a/src/components/dev-hub/select.js
+++ b/src/components/dev-hub/select.js
@@ -4,11 +4,18 @@ import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import ArrowheadIcon from './icons/arrowhead-icon';
 import { P } from './text';
-import { colorMap, gradientMap, layer, size } from './theme';
+import {
+    colorMap,
+    fontSize,
+    gradientMap,
+    lineHeight,
+    layer,
+    size,
+} from './theme';
 
 const BORDER_SIZE = 2;
 const OPTIONS_POSITION_OFFSET = 58;
-const OPTIONS_POSITION_OFFSET_NARROW = 48;
+const OPTIONS_POSITION_OFFSET_NARROW = 38;
 
 const activeSelectStyles = css`
     border: ${BORDER_SIZE}px solid;
@@ -20,9 +27,9 @@ const Option = styled('li')`
     background-color: ${colorMap.greyDarkOne};
     color: ${colorMap.greyLightTwo};
     display: block;
+    font-size: ${fontSize.small};
     overflow: hidden;
-    padding: ${({ narrow }) =>
-        narrow ? `${size.small} ${size.medium}` : size.medium};
+    padding: ${`6px ${size.default}`};
     text-overflow: ellipsis;
     white-space: nowrap;
     :focus,
@@ -35,7 +42,7 @@ const Option = styled('li')`
 const Options = styled('ul')`
     border: ${BORDER_SIZE}px solid;
     border-image: ${gradientMap.violentMagentaOrange} 1;
-    border-top: none;
+    border-width: 0 ${BORDER_SIZE}px ${BORDER_SIZE}px;
     /* account for border above */
     left: -${BORDER_SIZE}px;
     padding: 0;
@@ -65,9 +72,10 @@ const SelectedOption = styled('div')`
     background-color: ${colorMap.greyDarkTwo};
     color: ${colorMap.devWhite};
     display: flex;
+    font-size: ${fontSize.small};
+    line-height: ${lineHeight.small};
     justify-content: space-between;
-    padding: ${({ narrow }) =>
-        narrow ? `${size.small} ${size.medium}` : size.medium};
+    padding: ${({ narrow }) => (narrow ? `6px ${size.default}` : size.default)};
     position: relative;
 `;
 const FormSelect = ({

--- a/src/components/dev-hub/text-area.js
+++ b/src/components/dev-hub/text-area.js
@@ -11,19 +11,19 @@ import {
 } from './theme';
 import Label from './input-label';
 
-const LABEL_ABSOLUTE_LEFT = 22;
-const LABEL_END_TOP = -14;
-const LABEL_START_TOP = 9;
+const LABEL_ABSOLUTE_LEFT = 18;
+const LABEL_END_TOP = -10;
+const LABEL_START_TOP = 0;
 
 const StyledTextArea = styled('textarea')`
     background-color: ${colorMap.greyDarkTwo};
     border: ${FORM_ELEMENT_BORDER} solid transparent;
     color: ${colorMap.devWhite};
     font-family: 'Fira Mono', monospace;
-    font-size: ${fontSize.default};
+    font-size: ${fontSize.small};
     height: 180px;
     outline: none;
-    padding: ${size.medium};
+    padding: ${size.default};
     position: relative;
     resize: none;
     width: 100%;


### PR DESCRIPTION
Our form element sizes were off compared to the original design spec. Not sure how this happened, but this PR adjusts the `input`, `textarea` and `select` components to be 60px tall by default and 40px tall with the `narrow` prop.

24px tall line height + 2 * 16px padding + 2*2px border = 60px for default
24px tall line height + 2 * 6px padding + 2*2px border = 40px for narrow