### PR TITLE
Allow Staging Dev Pages

### DIFF
--- a/src/utils/setup/on-create-page.js
+++ b/src/utils/setup/on-create-page.js
@@ -1,5 +1,6 @@
 const memoizerific = require('memoizerific');
 const { removeExcludedArticles } = require('./remove-excluded-articles');
+const { removePageIfStaged } = require('./remove-page-if-staged');
 const { getNestedValue } = require('../get-nested-value');
 const { getMetadata } = require('../get-metadata');
 
@@ -21,6 +22,8 @@ const DEFAULT_FEATURED_LEARN_SLUGS = [
     'how-to/golang-alexa-skills',
     'how-to/polymorphic-pattern',
 ];
+
+const STAGING_PAGES = ['/academia/', '/media/'];
 
 const requestStitch = async (functionName, ...args) =>
     stitchClient.callFunction(functionName, [metadata, ...args]);
@@ -171,6 +174,7 @@ const onCreatePage = async (
         default:
             break;
     }
+    removePageIfStaged(page, deletePage, STAGING_PAGES);
 };
 
 module.exports = { findArticlesFromSlugs, getLearnPageFilters, onCreatePage };

--- a/src/utils/setup/remove-page-if-staged.js
+++ b/src/utils/setup/remove-page-if-staged.js
@@ -1,0 +1,10 @@
+const removePageIfStaged = (page, deletePage, stagingPages) => {
+    if (
+        process.env.SNOOTY_ENV === 'production' &&
+        stagingPages.includes(page.path)
+    ) {
+        deletePage(page);
+    }
+};
+
+module.exports = { removePageIfStaged };

--- a/tests/utils/remove-page-if-staged.test.js
+++ b/tests/utils/remove-page-if-staged.test.js
@@ -1,0 +1,31 @@
+import { removePageIfStaged } from '../../src/utils/setup/remove-page-if-staged';
+
+it('should properly require specific environment variables at build-time', () => {
+    const oldEnv = process.env;
+    process.env = {
+        ...oldEnv,
+    };
+
+    const testExistingPage = { path: '/academia/' };
+    const testNonExistingPage = { path: '/foo/' };
+
+    let deletePage = jest.fn();
+
+    process.env.SNOOTY_ENV = 'staging';
+    const stagedPages = ['/academia/', '/media/'];
+
+    removePageIfStaged(testExistingPage, deletePage, stagedPages);
+    removePageIfStaged(testNonExistingPage, deletePage, stagedPages);
+
+    // Staged pages should only be removed on production
+    expect(deletePage).toHaveBeenCalledTimes(0);
+
+    process.env.SNOOTY_ENV = 'production';
+    removePageIfStaged(testExistingPage, deletePage, stagedPages);
+    removePageIfStaged(testNonExistingPage, deletePage, stagedPages);
+
+    expect(deletePage).toHaveBeenCalledTimes(1);
+    expect(deletePage.mock.calls[0][0]).toStrictEqual(testExistingPage);
+
+    process.env = oldEnv;
+});


### PR DESCRIPTION
This PR gives us a way to maintain pages "in development" that don't go live to prod. Simply put, if a page is "staged" then we remove it if we are building in a production environment. This allows us to continue to develop these pages locally without anything being publicly available on production.

This approach is pretty simple because we can simply case on `SNOOTY_ENV`, which is `staging` at all times unless we run a job on the workerpool. This might be a bit stricter than we want, but the ability to case on `SNOOTY_ENV` seems like the best solution here.

We also can do things like continue to build cypress tests since `SNOOTY_ENV` is `staging` for CI testing as well, so we can have testing for the correct endpoint in place before a page ships out as well.

I wrote a quick test as well for good measure, if this is good to go I will then add back in the academia page to help us continue to build that out. The media page is almost done so I'm not inclined to bring that back in.