### PR TITLE
Handle Academia Form Submits

### DIFF
--- a/src/components/dev-hub/academia-sign-up-form.js
+++ b/src/components/dev-hub/academia-sign-up-form.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import styled from '@emotion/styled';
+import { submitAcademiaForm } from '../../utils/devhub-api-stitch';
 import { colorMap, size, screenSize } from './theme';
 import { P, ArticleH3 } from './text';
 import Input from './input';
@@ -28,6 +29,11 @@ const StyledSectionText = styled(ArticleH3)`
     color: ${colorMap.greyLightTwo};
     font-family: akzidenz;
     font-weight: normal;
+`;
+
+const StyledSuccessState = styled(SuccessState)`
+    margin-bottom: ${size.xlarge};
+    margin-top: ${size.xlarge};
 `;
 
 const InstructorSection = styled('div')`
@@ -70,8 +76,7 @@ const Form = React.memo(({ setSuccess, success }) => {
     const handleSubmit = async e => {
         e.preventDefault();
         setCanSubmit(false);
-        setSuccess(true);
-        const obj = {
+        const data = {
             first_name: firstName,
             last_name: lastName,
             email,
@@ -79,8 +84,14 @@ const Form = React.memo(({ setSuccess, success }) => {
             institution_type: institutionType,
             agree_to_email: agreeToEmail,
         };
-
+        const response = await submitAcademiaForm(data);
         //TODO: communicate with the backend here
+        if (response.success) {
+            setSuccess(true);
+        } else {
+            setCanSubmit(true);
+            setSuccess(false);
+        }
     };
 
     return (
@@ -188,7 +199,7 @@ const Form = React.memo(({ setSuccess, success }) => {
 const AcademiaSignUpForm = () => {
     const [success, setSuccess] = useState(null);
     if (success) {
-        return <SuccessState>Thank you for joining!</SuccessState>;
+        return <StyledSuccessState>Thank you for joining!</StyledSuccessState>;
     }
     return <Form setSuccess={setSuccess} success={success} />;
 };

--- a/src/components/dev-hub/success-state.js
+++ b/src/components/dev-hub/success-state.js
@@ -11,8 +11,8 @@ const SuccessContainer = styled('div')`
     }
 `;
 
-const SuccessState = ({ children }) => (
-    <SuccessContainer>
+const SuccessState = ({ children, ...props }) => (
+    <SuccessContainer {...props}>
         <SuccessIcon />
         <H3>{children}</H3>
     </SuccessContainer>

--- a/src/utils/devhub-api-stitch.js
+++ b/src/utils/devhub-api-stitch.js
@@ -29,3 +29,11 @@ export const requestYoutubePlaylist = async maxResults => {
     );
     return result;
 };
+
+export const submitAcademiaForm = async academiaData => {
+    const result = await callDevhubAPIStitchFunction(
+        'submitAcademiaRegistration',
+        academiaData
+    );
+    return result;
+};


### PR DESCRIPTION
This PR adds logic for sending academia form data to a new Stitch function called `submitAcademiaRegistration`, which performs an insert into Atlas with this data. I also have a Stitch trigger setup for handling writes to Atlas (ideally to send a notification to Lieke) but this piece is incomplete.

Here we can see the data in Atlas:
<img width="1440" alt="Screen Shot 2020-05-26 at 2 45 53 PM" src="https://user-images.githubusercontent.com/9064401/82938606-1539ae80-9f60-11ea-9233-67f3b7d654c1.png">
