### PR TITLE
Update community callout for forums

### DIFF
--- a/src/pages/community/index.js
+++ b/src/pages/community/index.js
@@ -100,10 +100,10 @@ export default () => {
                 showImageOnMobile={false}
             >
                 <HeroContent>
-                    <H2 bold>Find Your Place</H2>
+                    <H2 bold>Join the Community Forums</H2>
                     <P>
-                        Have a burning question you want to ask? Looking for a
-                        community of like minded developers?
+                        Collaborate with other MongoDB users. Solve problems.
+                        Build the future.
                     </P>
                     <Button
                         primary


### PR DESCRIPTION
This PR changes the callout for linking to forums on the community page to the copy requested in [DEVHUB-143](https://jira.mongodb.org/browse/DEVHUB-143)

<img width="1415" alt="Screen Shot 2020-05-26 at 3 21 27 PM" src="https://user-images.githubusercontent.com/9064401/82941583-972bd680-9f64-11ea-8142-e0368e446b19.png">
