### PR TITLE
Give .live banner 100% width

### DIFF
--- a/src/components/dev-hub/mongodb-live-banner.js
+++ b/src/components/dev-hub/mongodb-live-banner.js
@@ -8,6 +8,7 @@ import { screenSize } from './theme';
 const LiveImage = styled(Image)`
     border-radius: 0;
     margin-bottom: 0;
+    width: 100%;
 `;
 
 const MongodbLiveBanner = () => {


### PR DESCRIPTION
Noticed it wasn't taking the full space on very large displays:
![Screen Shot 2020-05-26 at 5 04 40 PM](https://user-images.githubusercontent.com/9064401/82950495-6606d280-9f73-11ea-968f-f300dabb87e3.png)

This PR:
![Screen Shot 2020-05-26 at 5 08 27 PM](https://user-images.githubusercontent.com/9064401/82950583-8898eb80-9f73-11ea-8f0f-7de260ff9110.png)
