### PR TITLE
Create new stacking context for blockquote

### DIFF
--- a/src/components/dev-hub/blockquote.js
+++ b/src/components/dev-hub/blockquote.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import ComponentFactory from '../ComponentFactory';
-import { colorMap, gradientMap, size } from './theme';
+import { colorMap, gradientMap, layer, size } from './theme';
 import { createShadowElement } from './utils';
 
 const BLOCKQUOTE_OFFSET = 10;
@@ -43,14 +43,25 @@ const BlockquoteContainer = styled('div')`
     }
 `;
 
+const BlockquoteStackingContext = styled('div')`
+    position: relative;
+    z-index: ${layer.front};
+`;
+
 const Blockquote = ({ nodeData: { children }, ...rest }) => (
-    <BlockquoteContainer>
-        <StyledBlockquote>
-            {children.map((element, index) => (
-                <ComponentFactory {...rest} nodeData={element} key={index} />
-            ))}
-        </StyledBlockquote>
-    </BlockquoteContainer>
+    <BlockquoteStackingContext>
+        <BlockquoteContainer>
+            <StyledBlockquote>
+                {children.map((element, index) => (
+                    <ComponentFactory
+                        {...rest}
+                        nodeData={element}
+                        key={index}
+                    />
+                ))}
+            </StyledBlockquote>
+        </BlockquoteContainer>
+    </BlockquoteStackingContext>
 );
 
 Blockquote.displayName = 'Blockquote';

--- a/tests/unit/__snapshots__/BlockQuote.test.js.snap
+++ b/tests/unit/__snapshots__/BlockQuote.test.js.snap
@@ -1,32 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<BlockquoteContainer>
-  <StyledBlockquote>
-    <ComponentFactory
-      key="0"
-      nodeData={
-        Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 27,
+<BlockquoteStackingContext>
+  <BlockquoteContainer>
+    <StyledBlockquote>
+      <ComponentFactory
+        key="0"
+        nodeData={
+          Object {
+            "children": Array [
+              Object {
+                "position": Object {
+                  "start": Object {
+                    "line": 27,
+                  },
                 },
+                "type": "text",
+                "value": "There are several ways to connect to your MongoDB instance.",
               },
-              "type": "text",
-              "value": "There are several ways to connect to your MongoDB instance.",
+            ],
+            "position": Object {
+              "start": Object {
+                "line": 27,
+              },
             },
-          ],
-          "position": Object {
-            "start": Object {
-              "line": 27,
-            },
-          },
-          "type": "paragraph",
+            "type": "paragraph",
+          }
         }
-      }
-    />
-  </StyledBlockquote>
-</BlockquoteContainer>
+      />
+    </StyledBlockquote>
+  </BlockquoteContainer>
+</BlockquoteStackingContext>
 `;


### PR DESCRIPTION
I have found a potential solution to some of our z-index woes and have implemented it on the Blockquote.

After #347 the `GlobalWrapper` had a background which caused some unintended side-effects. One of which was hiding a piece of the `Blockquote`:

![Screen Shot 2020-05-27 at 11 25 17 AM](https://user-images.githubusercontent.com/9064401/83040320-212f7a00-a00d-11ea-8741-ea446096f7da.png)

In fact, this piece of the Blockquote had a z-index of -1. Since we did not reset the stacking context for the Blockquote, this was hiding under every parent up to `<body />`. Adding this background exposed this problem.

![Screen Shot 2020-05-27 at 11 25 13 AM](https://user-images.githubusercontent.com/9064401/83040569-68b60600-a00d-11ea-9010-9ad4b0ff872a.png)

This PR adds a `div` to the Blockquote which resets the stacking context, so the blockquote sits in front of other elements and using z-indices here is with respect to the blockquote only.

![Screen Shot 2020-05-27 at 11 22 38 AM](https://user-images.githubusercontent.com/9064401/83040686-88e5c500-a00d-11ea-97f3-26c40b7dc803.png)

Funny enough, it seems this can also help with the `Button` hover state, should we want to bring that back in.