### PR TITLE
Use YouTube Video PublishDate for Sorting

### DIFF
--- a/src/utils/fetch-youtube-data.js
+++ b/src/utils/fetch-youtube-data.js
@@ -4,10 +4,17 @@ import { requestYoutubePlaylist } from './devhub-api-stitch';
 
 const simplifyResponse = responseData => {
     const video = responseData.snippet;
+    // Video publish date is stored in "contentDetails", publish date in "snippet"
+    // is for when this video was added to the playlist
+    const publishedDate = dlv(
+        responseData,
+        'contentDetails.videoPublishedAt',
+        null
+    );
     const youtubeJSON = {
         mediaType: 'youtube',
         title: video['title'],
-        publishDate: video['publishedAt'],
+        publishDate: publishedDate,
         description: video['description'],
         videoId: dlv(video, 'resourceId.videoId', []),
         playlistId: video['playlistId'],


### PR DESCRIPTION
While testing the media component I found a small bug. The `publishAt` on `snippet` from YouTube is for when this video was added to the playlist. We should be sorting by when the video is published to YouTube.

I made the API call change in Stitch as well to get `contentDetails` as well, and the sorting is as expected after this PR.

[Here are the docs for playlist items](https://developers.google.com/youtube/v3/docs/playlistItems), where we can see this distinction.