### PR TITLE
Clean up prop errors in console

### DIFF
--- a/src/components/dev-hub/card.js
+++ b/src/components/dev-hub/card.js
@@ -56,13 +56,13 @@ const Wrapper = styled('div')`
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    max-width: ${({ maxWidth }) => `${maxWidth}px`};
+    max-width: ${({ maxwidth }) => `${maxwidth}px`};
     padding: ${size.medium};
     text-decoration: none;
     transition: background-color ${animationSpeed.medium};
     width: ${({ width = 'auto' }) => width};
     ${({ highlight }) => highlight && `background: rgba(255, 255, 255, 0.3);`};
-    ${({ isClickable }) => isClickable && hoverStyles}
+    ${({ isclickable }) => isclickable && hoverStyles};
 `;
 const truncate = maxLines => css`
     display: -webkit-box;
@@ -122,10 +122,9 @@ const Card = ({
             data-test="card"
             onClick={onClick}
             {...linkAttrs}
-            maxWidth={maxWidth}
-            isClickable={isClickable}
+            maxwidth={maxWidth}
+            isclickable={isClickable}
             className={className}
-            collapseImage={collapseImage}
         >
             <div>
                 {!collapseImage && (

--- a/src/components/dev-hub/icons/mdb-dev-leaf-desktop.js
+++ b/src/components/dev-hub/icons/mdb-dev-leaf-desktop.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default props => (
     <svg width="185px" viewBox="0 0 185 24" {...props}>
-        <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
             <g transform="translate(0.700000, 0.000000)">
                 <g>
                     <g>


### PR DESCRIPTION
This PR cleans up some lingering console errors related to incorrect prop casing. Specifically:
- On the nav image, we needed to camelcase in a few spots
- On cards, we conditionally render a styled component or the gatsby `Link`. If we render the latter, we must lowercase attributes as they are passed through to the DOM.