### PR TITLE
Add emotional theming to components

### DIFF
--- a/src/components/dev-hub/article-share-footer.js
+++ b/src/components/dev-hub/article-share-footer.js
@@ -3,7 +3,7 @@ import copy from 'copy-to-clipboard';
 import styled from '@emotion/styled';
 import { getArticleShareLinks } from '../../utils/get-article-share-links';
 import BlogTagList from './blog-tag-list';
-import { colorMap, screenSize, size } from './theme';
+import { screenSize, size } from './theme';
 import Link from './link';
 import Tooltip from './tooltip';
 import LinkIcon from './icons/link-icon';
@@ -12,7 +12,7 @@ import FacebookIcon from './icons/facebook-icon';
 import TwitterIcon from './icons/twitter-icon';
 
 const ArticleShareArea = styled('div')`
-    border-top: 1px solid ${colorMap.greyDarkTwo};
+    border-top: 1px solid ${({ theme }) => theme.colorMap.greyDarkTwo};
     display: flex;
     justify-content: space-between;
     margin-bottom: ${size.large};

--- a/src/components/dev-hub/author-image.js
+++ b/src/components/dev-hub/author-image.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { withPrefix } from 'gatsby';
-import { gradientMap, screenSize, size } from './theme';
+import { screenSize, size } from './theme';
 import { createShadowElement } from './utils';
 import DEFAULT_AUTHOR_IMAGE from '../../images/2x/Default-Profile@2x.png';
 
@@ -28,9 +28,9 @@ const AuthorImageContainer = styled('div')`
     position: relative;
     width: ${({ width, gradientOffset }) => width + gradientOffset}px;
     &:before {
-        ${({ gradientOffset }) =>
+        ${({ gradientOffset, theme }) =>
             createShadowElement(
-                gradientMap.greenTealOffset,
+                theme.gradientMap.greenTealOffset,
                 size.large,
                 0,
                 -gradientOffset

--- a/src/components/dev-hub/badge.js
+++ b/src/components/dev-hub/badge.js
@@ -1,11 +1,12 @@
 import React from 'react';
-import { colorMap, size } from './theme';
+import { size } from './theme';
 import { P5 } from './text';
 import styled from '@emotion/styled';
+import { useTheme } from 'emotion-theming';
 
 const Badge = styled('div')`
     bottom: 0;
-    background-color: ${colorMap.greyDarkThree};
+    background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
     font-family: akzidenz;
     letter-spacing: 1px;
     margin: ${size.default};
@@ -15,15 +16,15 @@ const Badge = styled('div')`
     ${({ color }) => color && `border: 1px solid ${color}`};
 `;
 
-const determineColor = contentType => {
+const determineColor = (contentType, theme) => {
     switch (contentType) {
         case 'youtube':
         case 'twitch':
-            return colorMap.salmon;
+            return theme.colorMap.salmon;
         case 'podcast':
-            return colorMap.yellow;
+            return theme.colorMap.yellow;
         case 'article':
-            return colorMap.teal;
+            return theme.colorMap.teal;
         default:
             return null;
     }
@@ -34,10 +35,13 @@ const badgeContent = contentType =>
         ? contentType + ' video'
         : contentType;
 
-export default ({ contentType, color = '', ...props }) => (
-    <Badge color={color || determineColor(contentType)} {...props}>
-        <P5 bold collapse>
-            {badgeContent(contentType)}
-        </P5>
-    </Badge>
-);
+export default ({ contentType, color = '' }) => {
+    const theme = useTheme();
+    return (
+        <Badge color={color || determineColor(contentType, theme)}>
+            <P5 bold collapse>
+                {badgeContent(contentType)}
+            </P5>
+        </Badge>
+    );
+};

--- a/src/components/dev-hub/blockquote.js
+++ b/src/components/dev-hub/blockquote.js
@@ -1,16 +1,16 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import ComponentFactory from '../ComponentFactory';
-import { colorMap, gradientMap, layer, size } from './theme';
+import { layer, size } from './theme';
 import { createShadowElement } from './utils';
 
 const BLOCKQUOTE_OFFSET = 10;
 const BORDER_SIZE = 2;
 
 const StyledBlockquote = styled('blockquote')`
-    background: ${colorMap.greyDarkThree};
+    background: ${({ theme }) => theme.colorMap.greyDarkThree};
     border-radius: ${size.tiny};
-    color: ${colorMap.devWhite};
+    color: ${({ theme }) => theme.colorMap.devWhite};
     margin: 0;
     padding: ${size.medium};
     > :last-child {
@@ -20,26 +20,28 @@ const StyledBlockquote = styled('blockquote')`
 
 const BlockquoteContainer = styled('div')`
     border-radius: ${size.tiny};
-    background: ${gradientMap.magentaSalmonSherbet};
+    background: ${({ theme }) => theme.gradientMap.magentaSalmonSherbet};
     background-size: cover;
     margin-bottom: ${BLOCKQUOTE_OFFSET + size.stripUnit(size.default)}px;
     padding: ${BORDER_SIZE}px;
     position: relative;
     &:before {
-        ${createShadowElement(
-            gradientMap.magentaSalmonSherbet,
-            size.tiny,
-            BLOCKQUOTE_OFFSET,
-            0
-        )}
+        ${({ theme }) =>
+            createShadowElement(
+                theme.gradientMap.magentaSalmonSherbet,
+                size.tiny,
+                BLOCKQUOTE_OFFSET,
+                0
+            )}
     }
     &:after {
-        ${createShadowElement(
-            colorMap.greyDarkThree,
-            size.tiny,
-            BLOCKQUOTE_OFFSET,
-            4
-        )};
+        ${({ theme }) =>
+            createShadowElement(
+                theme.colorMap.greyDarkThree,
+                size.tiny,
+                BLOCKQUOTE_OFFSET,
+                4
+            )};
     }
 `;
 

--- a/src/components/dev-hub/blog-post-title-area.js
+++ b/src/components/dev-hub/blog-post-title-area.js
@@ -2,12 +2,12 @@ import React from 'react';
 import styled from '@emotion/styled';
 import BlogTagList from './blog-tag-list';
 import { H2, P } from './text';
-import { colorMap, screenSize, fontSize, size } from './theme';
+import { screenSize, fontSize, size } from './theme';
 import BylineBlock from './byline-block';
 import HeroBanner from './hero-banner';
 
 const PostMetaLine = styled('div')`
-    color: ${colorMap.greyLightThree};
+    color: ${({ theme }) => theme.colorMap.greyLightThree};
     display: flex;
     margin: ${size.medium} 0 40px;
     font-size: ${fontSize.tiny};

--- a/src/components/dev-hub/blog-tag-list.js
+++ b/src/components/dev-hub/blog-tag-list.js
@@ -1,16 +1,16 @@
 import React, { useCallback, useState } from 'react';
 import styled from '@emotion/styled';
 import Link from './link';
-import { colorMap, fontSize, lineHeight, screenSize, size } from './theme';
+import { fontSize, lineHeight, screenSize, size } from './theme';
 
 const MINIMUM_EXPANDABLE_SIZE = 3;
 const MAX_TAG_LIST_SIZE = 5;
 
 const TagLink = styled(Link)`
-    background-color: ${colorMap.greyDarkThree};
-    border: 1px solid ${colorMap.greyDarkThree};
+    background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
+    border: 1px solid ${({ theme }) => theme.colorMap.greyDarkThree};
     border-radius: ${size.medium};
-    color: ${colorMap.greyLightTwo};
+    color: ${({ theme }) => theme.colorMap.greyLightTwo};
     display: inline-block;
     font-size: ${fontSize.micro};
     line-height: ${lineHeight.micro};
@@ -24,12 +24,12 @@ const TagLink = styled(Link)`
     &:active,
     &:focus,
     &:hover {
-        border: 1px solid ${colorMap.lightGreen};
+        border: 1px solid ${({ theme }) => theme.colorMap.lightGreen};
         cursor: pointer;
         transition: border 0.15s;
     }
     &:visited {
-        color: ${colorMap.greyLightTwo};
+        color: ${({ theme }) => theme.colorMap.greyLightTwo};
     }
 `;
 

--- a/src/components/dev-hub/breadcrumb.js
+++ b/src/components/dev-hub/breadcrumb.js
@@ -1,36 +1,34 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import Link from './link';
-import { colorMap } from './theme';
-
 const StyledBreadcrumb = styled(Link)`
     display: inline-block;
     font-family: 'Fira Mono', monospace;
     text-decoration: none;
     :hover {
-        color: ${colorMap.devWhite};
+        color: ${({ theme }) => theme.colorMap.devWhite};
         transition: color 0.15s;
     }
     &:after {
-        color: ${colorMap.lightGreen};
+        color: ${({ theme }) => theme.colorMap.lightGreen};
         /* 2192 is "RIGHTWARDS ARROW" */
         content: ' \u2192 ';
         white-space: pre;
     }
-    :visited {
-        color: ${colorMap.greyLightThree};
+    :visited 
+        color: ${({ theme }) => theme.colorMap.greyLightThree};
     }
     :visited:hover {
-        color: ${colorMap.lightGreen};
+        color: ${({ theme }) => theme.colorMap.lightGreen};
     }
 `;
 
 const BreadcrumbList = styled('div')`
     /* This assumes the list link is the active one */
     a:last-of-type {
-        color: ${colorMap.devWhite};
+        color: ${({ theme }) => theme.colorMap.devWhite};
         :hover {
-            color: ${colorMap.lightGreen};
+            color: ${({ theme }) => theme.colorMap.lightGreen};
         }
         &:after {
             content: none;

--- a/src/components/dev-hub/button.js
+++ b/src/components/dev-hub/button.js
@@ -3,9 +3,7 @@ import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import {
     animationSpeed,
-    colorMap,
     fontSize,
-    gradientMap,
     lineHeight,
     screenSize,
     size,
@@ -13,7 +11,7 @@ import {
 import { createShadowElement } from './utils';
 import Link from './link';
 
-const buttonHoverStyles = css`
+const buttonHoverStyles = theme => css`
     &:before,
     &:after {
         content: '';
@@ -23,22 +21,27 @@ const buttonHoverStyles = css`
     &:active,
     &:hover,
     &:focus {
-        color: ${colorMap.devWhite};
+        color: ${theme.colorMap.devWhite};
         &:before {
-            ${createShadowElement(gradientMap.green, size.large, 10, 0)}
+            ${createShadowElement(theme.gradientMap.green, size.large, 10, 0)}
         }
         &:after {
-            ${createShadowElement(colorMap.greyDarkThree, size.large, 10, 4)}
+            ${createShadowElement(
+                theme.colorMap.greyDarkThree,
+                size.large,
+                10,
+                4
+            )}
         }
     }
 `;
 
-const secondaryHoverStyles = css`
+const secondaryHoverStyles = theme => css`
     &:active,
     &:hover,
     &:focus {
-        color: ${colorMap.devWhite};
-        border: 2px solid ${colorMap.lightGreen};
+        color: ${theme.colorMap.devWhite};
+        border: 2px solid ${theme.colorMap.lightGreen};
     }
 `;
 
@@ -50,42 +53,42 @@ const buttonPadding = css`
     }
 `;
 
-const primaryStyles = css`
-    background: ${gradientMap.green};
+const primaryStyles = theme => css`
+    background: ${theme.gradientMap.green};
     text-decoration: none;
-    ${buttonHoverStyles}
+    ${buttonHoverStyles(theme)}
     ${buttonPadding}
 `;
 
-const secondaryStyles = css`
-    background: ${colorMap.greyDarkThree};
-    border: 2px solid ${colorMap.greyDarkOne};
+const secondaryStyles = theme => css`
+    background: ${theme.colorMap.greyDarkThree};
+    border: 2px solid ${theme.colorMap.greyDarkOne};
     position: relative;
     text-decoration: none;
     ${buttonPadding}
-    ${secondaryHoverStyles}
+    ${secondaryHoverStyles(theme)}
 `;
 
-const tertiaryStyles = css`
+const tertiaryStyles = theme => css`
     &:active,
     &:hover,
     &:focus {
-        color: ${colorMap.lightGreen};
+        color: ${theme.colorMap.lightGreen};
         transition: color ${animationSpeed.fast} ease-in;
     }
 `;
-const playStyles = css`
-    background-color: ${colorMap.devBlack};
-    border: 1px solid ${colorMap.devWhite};
+const playStyles = theme => css`
+    background-color: ${theme.colorMap.devBlack};
+    border: 1px solid ${theme.colorMap.devWhite};
     border-radius: 50%;
-    color: ${colorMap.devWhite};
+    color: ${theme.colorMap.devWhite};
     font-size: ${size.large};
     height: 80px;
     padding: ${size.default} ${size.default} ${size.default} ${size.medium};
     position: relative;
     width: 80px;
     &:before {
-        background: ${colorMap.greyLightThree};
+        background: ${theme.colorMap.greyLightThree};
         border-radius: 50%;
         bottom: -${size.xsmall};
         content: '';
@@ -100,9 +103,9 @@ const playStyles = css`
         content: '\u25b6';
     }
     :hover {
-        background-color: ${colorMap.devWhite};
-        border-color: ${colorMap.devWhite};
-        color: ${colorMap.devBlack};
+        background-color: ${theme.colorMap.devWhite};
+        border-color: ${theme.colorMap.devWhite};
+        color: ${theme.colorMap.devBlack};
         transition: color 0.4s;
         ::before {
             opacity: 0.6;
@@ -119,7 +122,7 @@ const playStyles = css`
 `;
 
 const PlayButtonWrapper = styled('div')`
-    background: ${colorMap.greyDarkTwo};
+    background: ${({ theme }) => theme.colorMap.greyDarkTwo};
     border-radius: 50%;
     bottom: -${size.default};
     content: '';
@@ -135,7 +138,7 @@ const StyledButton = styled('button')`
     border: none;
     border-radius: ${size.large};
     box-shadow: none;
-    color: ${({ color }) => (color ? color : colorMap.devWhite)};
+    color: ${({ color, theme }) => (color ? color : theme.colorMap.devWhite)};
     cursor: pointer;
     display: inline-block;
     font-family: 'Fira Mono', monospace;
@@ -149,14 +152,14 @@ const StyledButton = styled('button')`
         font-size: ${fontSize.tiny};
     }
 
-    ${({ primary }) => primary && primaryStyles}
-    ${({ secondary }) => secondary && secondaryStyles}
-    ${({ play }) => play && playStyles}
-    ${({ play, primary, secondary }) =>
-        !primary && !secondary && !play && tertiaryStyles}
+    ${({ primary, theme }) => primary && primaryStyles(theme)}
+    ${({ secondary, theme }) => secondary && secondaryStyles(theme)}
+    ${({ play, theme }) => play && playStyles(theme)}
+    ${({ play, primary, secondary, theme }) =>
+        !primary && !secondary && !play && tertiaryStyles(theme)}
     &[disabled],
     &[disabled]:hover {
-        background: ${colorMap.greyLightThree};
+        background: ${({ theme }) => theme.colorMap.greyLightThree};
         cursor: not-allowed;
     }
 `;

--- a/src/components/dev-hub/byline-block.js
+++ b/src/components/dev-hub/byline-block.js
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import Link from './link';
 import { P } from './text';
-import { colorMap, fontSize, screenSize, size } from './theme';
+import { fontSize, screenSize, size } from './theme';
 import { getTagPageUriComponent } from '../../utils/get-tag-page-uri-component';
 import AuthorImage from './author-image';
 
@@ -13,7 +13,7 @@ const AuthorImageContainer = styled('div')`
 const AuthorLink = styled(Link)`
     font-size: ${fontSize.tiny};
     :visited {
-        color: ${colorMap.greyLightThree};
+        color: ${({ theme }) => theme.colorMap.greyLightThree};
     }
     @media ${screenSize.upToLarge} {
         font-size: ${fontSize.xsmall};
@@ -29,7 +29,7 @@ const AuthorText = styled(P)`
 
 const ByLine = styled('div')`
     align-items: center;
-    color: ${colorMap.greyLightThree};
+    color: ${({ theme }) => theme.colorMap.greyLightThree};
     display: flex;
     font-size: ${fontSize.tiny};
     @media ${screenSize.upToLarge} {

--- a/src/components/dev-hub/card.js
+++ b/src/components/dev-hub/card.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import Button from './button';
-import { animationSpeed, colorMap, lineHeight, size, fontSize } from './theme';
+import { animationSpeed, lineHeight, size, fontSize } from './theme';
 import { H5, P } from './text';
 import Link from './link';
 import TagList from './blog-tag-list';
@@ -38,10 +38,10 @@ const ImageWrapper = styled('div')`
     position: relative;
     width: 100%;
 `;
-const hoverStyles = css`
+const hoverStyles = theme => css`
     &:hover,
     &:active {
-        background-color: ${colorMap.greyDarkTwo};
+        background-color: ${theme.colorMap.greyDarkTwo};
         color: inherit;
         cursor: pointer;
         ${Image} {
@@ -62,7 +62,7 @@ const Wrapper = styled('div')`
     transition: background-color ${animationSpeed.medium};
     width: ${({ width = 'auto' }) => width};
     ${({ highlight }) => highlight && `background: rgba(255, 255, 255, 0.3);`};
-    ${({ isClickable }) => isClickable && hoverStyles}
+    ${({ isClickable, theme }) => isClickable && hoverStyles(theme)}
 `;
 const truncate = maxLines => css`
     display: -webkit-box;
@@ -71,7 +71,7 @@ const truncate = maxLines => css`
     overflow: hidden;
 `;
 const DescriptionText = styled(P)`
-    color: ${colorMap.greyLightTwo};
+    color: ${({ theme }) => theme.colorMap.greyLightTwo};
     font-size: ${fontSize.small};
     line-height: ${lineHeight.small};
 `;

--- a/src/components/dev-hub/chart.js
+++ b/src/components/dev-hub/chart.js
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react';
 import { css } from '@emotion/core';
 import { buildQueryString } from '../../utils/query-string';
 import styled from '@emotion/styled';
-import { colorMap } from './theme';
 
 const DEFAULT_CHART_AUTOREFRESH = 3600;
 const DEFAULT_CHART_HEIGHT = '570';
@@ -41,9 +40,9 @@ const buildChartUrl = options => {
 };
 
 const StyledChart = styled('iframe')`
-    background: ${({ theme }) =>
-        theme === 'light' ? colorMap.devWhite : 'transparent'};
-    border: 1px solid ${colorMap.devWhite};
+    background: ${({ pageTheme, theme }) =>
+        pageTheme === 'light' ? theme.colorMap.devWhite : 'transparent'};
+    border: 1px solid ${({ theme }) => theme.colorMap.devWhite};
     ${({ customAlign }) => getAlignment(customAlign)};
     max-width: 100%;
 `;
@@ -53,7 +52,7 @@ const Chart = ({ nodeData: { options } }) => {
     return (
         <StyledChart
             customAlign={options.align}
-            theme={options.theme}
+            pageTheme={options.theme}
             height={options.height || DEFAULT_CHART_HEIGHT}
             title={options.title}
             src={chartSrc}

--- a/src/components/dev-hub/codeblock.js
+++ b/src/components/dev-hub/codeblock.js
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import Code from '@leafygreen-ui/code';
-import { colorMap, lineHeight, size } from './theme';
+import { lineHeight, size } from './theme';
 import CopyButton, { COPY_BUTTON_WIDTH } from './copy-button';
 
 const LEAFY_CODEBLOCK_PADDING = 12;
@@ -21,16 +21,16 @@ const CodeContainer = styled('div')`
 `;
 
 const CopyContainer = styled('div')`
-    background-color: ${colorMap.greyDarkThree};
+    background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
     border-radius: 0 ${size.small} ${size.small} 0;
-    color: ${colorMap.greyLightTwo};
+    color: ${({ theme }) => theme.colorMap.greyLightTwo};
     left: calc(100% - ${COPY_BUTTON_WIDTH}px - ${size.tiny});
     position: absolute;
     top: ${size.tiny};
 `;
 
 const StyledCode = styled(Code)`
-    border: 1px solid ${colorMap.greyDarkThree};
+    border: 1px solid ${({ theme }) => theme.colorMap.greyDarkThree};
     border-radius: ${size.small};
     line-height: ${lineHeight.xsmall};
     padding-right: ${size.xlarge};
@@ -41,17 +41,16 @@ const StyledCode = styled(Code)`
         }px)`};
     /* Line Numbers */
     > div {
-        background-color: ${colorMap.greyDarkTwo};
+        background-color: ${({ theme }) => theme.colorMap.greyDarkTwo};
         border-image: linear-gradient(
                 0deg,
-                ${colorMap.sherbet} 0%,
-                ${colorMap.salmon} 49.99%,
-                ${colorMap.magenta} 100%
+                ${({ theme }) => theme.colorMap.sherbet} 0%,
+                ${({ theme }) => theme.colorMap.salmon} 49.99%,
+                ${({ theme }) => theme.colorMap.magenta} 100%
             )
             1;
         border-width: 0 2px 0 0;
         border-right-style: solid;
-        color: ${colorMap.greyLightTwo};
         left: 0;
         padding: ${LEAFY_CODEBLOCK_PADDING}px;
         padding-top: ${size.large};

--- a/src/components/dev-hub/contents-menu.js
+++ b/src/components/dev-hub/contents-menu.js
@@ -5,7 +5,7 @@ import ControlledTooltip from './controlled-tooltip';
 import ListIcon from './icons/list-icon';
 import { H5, P } from './text';
 import Link from './link';
-import { animationSpeed, colorMap, size } from './theme';
+import { animationSpeed, size } from './theme';
 import { formatText } from '../../utils/format-text';
 import HoverTooltip from './hover-tooltip';
 
@@ -14,32 +14,32 @@ const StyledListIcon = styled(ListIcon)`
         g {
             path,
             circle {
-                fill: ${colorMap.devWhite};
+                fill: ${({ theme }) => theme.colorMap.devWhite};
             }
         }
     }
 `;
 
 const activeStyles = css`
-    color: ${colorMap.devWhite};
+    color: ${({ theme }) => theme.colorMap.devWhite};
     font-weight: bold;
     &:hover,
     &:visited {
-        color: ${colorMap.devWhite};
+        color: ${({ theme }) => theme.colorMap.devWhite};
     }
 `;
 
 const defaultStyles = css`
     &:hover {
-        color: ${colorMap.devWhite};
+        color: ${({ theme }) => theme.colorMap.devWhite};
         transition: color ${animationSpeed.fast};
     }
 `;
 const StyledLink = styled(Link)`
     &:visited {
-        color: ${colorMap.greyLightTwo};
+        color: ${({ theme }) => theme.colorMap.greyLightTwo};
     }
-    color: ${colorMap.greyLightTwo};
+    color: ${({ theme }) => theme.colorMap.greyLightTwo};
     text-decoration: none;
     ${({ isactive }) => (isactive ? activeStyles : defaultStyles)}
     &:after {

--- a/src/components/dev-hub/controlled-tooltip.js
+++ b/src/components/dev-hub/controlled-tooltip.js
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import Popover from 'react-tiny-popover';
-import { animationSpeed, colorMap, layer, size } from './theme';
+import { animationSpeed, layer, size } from './theme';
 
 const CONTENT_MAX_WIDTH = 250;
 const TOOLTIP_DISTANCE = 15;
@@ -14,17 +14,17 @@ const TOOLTIP_ALIGNMENT_MAP = {
     top: 'center',
 };
 
-const gradient = css`
+const gradient = theme => css`
     border-image: linear-gradient(
             315deg,
-            ${colorMap.violet} 0%,
-            ${colorMap.magenta} 40%,
-            ${colorMap.orange} 100%
+            ${theme.colorMap.violet} 0%,
+            ${theme.colorMap.magenta} 40%,
+            ${theme.colorMap.orange} 100%
         )
         1;
 `;
-const defaultBorder = css`
-    border-color: ${colorMap.greyLightTwo};
+const defaultBorder = theme => css`
+    border-color: ${theme.colorMap.greyLightTwo};
 `;
 const arrowBase = css`
     &:before,
@@ -76,7 +76,7 @@ const horizontalArrowBase = css`
     }
 `;
 
-const rightDefaultArrow = css`
+const rightDefaultArrow = theme => css`
     ${arrowBase}
     ${horizontalArrowBase}
     &:before,
@@ -84,24 +84,24 @@ const rightDefaultArrow = css`
         left: 100%;
     }
     &:before {
-        border-left-color: ${colorMap.greyLightTwo};
+        border-left-color: ${theme.colorMap.greyLightTwo};
     }
     &:after {
-        border-left-color: ${colorMap.greyDarkOne};
+        border-left-color: ${theme.colorMap.greyDarkOne};
     }
 `;
 
-const rightGradientArrow = css`
-    ${rightDefaultArrow}
+const rightGradientArrow = theme => css`
+    ${rightDefaultArrow(theme)}
     &:before {
-        border-left-color: ${colorMap.magenta};
+        border-left-color: ${theme.colorMap.magenta};
     }
     &:after {
-        border-left-color: ${colorMap.greyDarkOne};
+        border-left-color: ${theme.colorMap.greyDarkOne};
     }
 `;
 
-const leftDefaultArrow = css`
+const leftDefaultArrow = theme => css`
     ${arrowBase}
     ${horizontalArrowBase}
     &:before,
@@ -109,47 +109,47 @@ const leftDefaultArrow = css`
         right: 100%;
     }
     &:before {
-        border-right-color: ${colorMap.greyLightTwo};
+        border-right-color: ${theme.colorMap.greyLightTwo};
     }
     &:after {
-        border-right-color: ${colorMap.greyDarkOne};
+        border-right-color: ${theme.colorMap.greyDarkOne};
     }
 `;
 
-const leftGradientArrow = css`
+const leftGradientArrow = theme => css`
     ${leftDefaultArrow}
     &:before {
-        border-right-color: ${colorMap.orange};
+        border-right-color: ${theme.colorMap.orange};
     }
     &:after {
-        border-right-color: ${colorMap.greyDarkOne};
+        border-right-color: ${theme.colorMap.greyDarkOne};
     }
 `;
 
-const bottomDefaultArrow = css`
+const bottomDefaultArrow = theme => css`
     ${arrowBase}
     ${verticalArrowBase}
     &:after {
-        border-top-color: ${colorMap.greyDarkOne};
+        border-top-color: ${theme.colorMap.greyDarkOne};
         top: calc(100% + 11px);
     }
     &:before {
-        border-top-color: ${colorMap.greyLightTwo};
+        border-top-color: ${theme.colorMap.greyLightTwo};
         top: calc(100% + 15px);
     }
 `;
 
-const bottomGradientArrow = css`
+const bottomGradientArrow = theme => css`
     ${bottomDefaultArrow}
     &:after {
-        border-top-color: ${colorMap.greyDarkOne};
+        border-top-color: ${theme.colorMap.greyDarkOne};
     }
     &:before {
-        border-top-color: ${colorMap.magenta};
+        border-top-color: ${theme.colorMap.magenta};
     }
 `;
 
-const topDefaultArrow = css`
+const topDefaultArrow = theme => css`
     ${arrowBase}
     ${verticalArrowBase}
     &:before,
@@ -157,42 +157,51 @@ const topDefaultArrow = css`
         bottom: 100%;
     }
     &:after {
-        border-bottom-color: ${colorMap.greyDarkOne};
+        border-bottom-color: ${theme.colorMap.greyDarkOne};
     }
     &:before {
-        border-bottom-color: ${colorMap.greyLightTwo};
+        border-bottom-color: ${theme.colorMap.greyLightTwo};
     }
 `;
 
-const topGradientArrow = css`
+const topGradientArrow = theme => css`
     ${topDefaultArrow}
     &:after {
-        border-bottom-color: ${colorMap.greyDarkOne};
+        border-bottom-color: ${theme.colorMap.greyDarkOne};
     }
     &:before {
-        border-bottom-color: ${colorMap.magenta};
+        border-bottom-color: ${theme.colorMap.magenta};
     }
 `;
 
-const getArrowStyles = (hasGradientBorder, position) => {
+const getArrowStyles = (hasGradientBorder, position, theme) => {
     const tooltipArrowMap = {
-        bottom: hasGradientBorder ? topGradientArrow : topDefaultArrow,
-        left: hasGradientBorder ? rightGradientArrow : rightDefaultArrow,
-        right: hasGradientBorder ? leftGradientArrow : leftDefaultArrow,
-        top: hasGradientBorder ? bottomGradientArrow : bottomDefaultArrow,
+        bottom: hasGradientBorder
+            ? topGradientArrow(theme)
+            : topDefaultArrow(theme),
+        left: hasGradientBorder
+            ? rightGradientArrow(theme)
+            : rightDefaultArrow(theme),
+        right: hasGradientBorder
+            ? leftGradientArrow(theme)
+            : leftDefaultArrow(theme),
+        top: hasGradientBorder
+            ? bottomGradientArrow(theme)
+            : bottomDefaultArrow(theme),
     };
     return tooltipArrowMap[position];
 };
 
 const Content = styled('div')`
-    background: ${colorMap.greyDarkOne};
+    background: ${({ theme }) => theme.colorMap.greyDarkOne};
     border: 2px solid;
-    color: ${colorMap.devWhite};
+    color: ${({ theme }) => theme.colorMap.devWhite};
     max-width: ${({ maxWidth }) =>
         maxWidth ? `${maxWidth}px` : `${CONTENT_MAX_WIDTH}px`};
     padding: ${size.medium} ${size.default};
     position: relative;
-    ${({ hasGradientBorder }) => (hasGradientBorder ? gradient : defaultBorder)}
+    ${({ hasGradientBorder, theme }) =>
+        hasGradientBorder ? gradient(theme) : defaultBorder(theme)}
     ${({ hasGradientBorder, position }) =>
         getArrowStyles(hasGradientBorder, position)}
 `;

--- a/src/components/dev-hub/controlled-tooltip.js
+++ b/src/components/dev-hub/controlled-tooltip.js
@@ -165,7 +165,7 @@ const topDefaultArrow = theme => css`
 `;
 
 const topGradientArrow = theme => css`
-    ${topDefaultArrow}
+    ${topDefaultArrow(theme)}
     &:after {
         border-bottom-color: ${theme.colorMap.greyDarkOne};
     }
@@ -202,8 +202,8 @@ const Content = styled('div')`
     position: relative;
     ${({ hasGradientBorder, theme }) =>
         hasGradientBorder ? gradient(theme) : defaultBorder(theme)}
-    ${({ hasGradientBorder, position }) =>
-        getArrowStyles(hasGradientBorder, position)}
+    ${({ hasGradientBorder, position, theme }) =>
+        getArrowStyles(hasGradientBorder, position, theme)}
 `;
 
 const Trigger = styled('span')`


### PR DESCRIPTION
This PR adds emotion-theming to the components below to prepare for a theme change in the near future. Closed [412](https://github.com/mongodb/devhub/pull/412) in order to reduce the number of components to be reviewed at once.

Components modified so far:
- article-share-footer.js
- author-image.js
- badge.js
- blockquote.js
- blog-post-title-area.js
- blog-tag-list.js
- breadcrumb.js
- button.js
- byline-block.js
- card.js
- chart.js
- codeblock.js
- contents-menu.js
- controlled-tooltip.js
