### PR TITLE
Move /academia to /academia/educators

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -43,6 +43,7 @@ module.exports = {
                 feeds: [articleRssFeed],
             },
         },
+        'gatsby-plugin-meta-redirect', // this must be last
     ],
     siteMetadata: {
         ...metadata,

--- a/gatsby-config.prod.js
+++ b/gatsby-config.prod.js
@@ -40,6 +40,7 @@ module.exports = {
                 feeds: [articleRssFeed],
             },
         },
+        `gatsby-plugin-meta-redirect`, // this must be last
     ],
     siteMetadata: {
         ...metadata,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -89,7 +89,7 @@ const filteredPageGroups = allSeries => {
 };
 
 exports.createPages = async ({ actions, graphql }) => {
-    const { createPage } = actions;
+    const { createPage, createRedirect } = actions;
     const [, metadata, result] = await Promise.all([
         saveAssetFiles(assets, stitchClient),
         stitchClient.callFunction('fetchDocument', [
@@ -103,6 +103,12 @@ exports.createPages = async ({ actions, graphql }) => {
     if (result.error) {
         throw new Error(`Page build error: ${result.error}`);
     }
+
+    createRedirect({
+        fromPath: '/academia/',
+        toPath: '/academia/educators',
+        redirectInBrowser: true,
+    });
 
     const allSeries = filteredPageGroups(metadata.pageGroups);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14030,6 +14030,26 @@
         "@babel/runtime": "^7.9.6"
       }
     },
+    "gatsby-plugin-meta-redirect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-meta-redirect/-/gatsby-plugin-meta-redirect-1.1.1.tgz",
+      "integrity": "sha512-Oc4qgU3SlDUM9qoxIMKO+re2bdMs3/a2KXrfL65gb8XMLsHylBbveWtXZRhgjd2QDL/49RX4S9SEykuadRju2w==",
+      "requires": {
+        "fs-extra": "^7.0.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        }
+      }
+    },
     "gatsby-plugin-page-creator": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.3.7.tgz",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "gatsby-plugin-emotion": "^4.3.2",
     "gatsby-plugin-feed": "^2.5.3",
     "gatsby-plugin-google-tagmanager": "^2.3.3",
+    "gatsby-plugin-meta-redirect": "^1.1.1",
     "gatsby-plugin-react-helmet": "^3.3.2",
     "gatsby-plugin-sitemap": "^2.4.3",
     "memoizerific": "^1.11.3",

--- a/src/pages/academia/educators.js
+++ b/src/pages/academia/educators.js
@@ -1,24 +1,24 @@
 import React, { useRef } from 'react';
-import Layout from '../components/dev-hub/layout';
+import Layout from '../../components/dev-hub/layout';
 import { Helmet } from 'react-helmet';
-import { useSiteMetadata } from '../hooks/use-site-metadata';
+import { useSiteMetadata } from '../../hooks/use-site-metadata';
 import {
     colorMap,
     fontSize,
     screenSize,
     size,
     lineHeight,
-} from '../components/dev-hub/theme';
-import { H3, ArticleH2, P } from '../components/dev-hub/text';
+} from '../../components/dev-hub/theme';
+import { H3, ArticleH2, P } from '../../components/dev-hub/text';
 import styled from '@emotion/styled';
-import Button from '../components/dev-hub/button';
-import HeroBanner from '../components/dev-hub/hero-banner';
-import SectionHeader from '../components/dev-hub/section-header';
-import AcademiaSignUpForm from '../components/dev-hub/academia-sign-up-form';
-import HeroBannerImage from '../images/1x/Academia_Hero.svg';
-import TeachMongoDBImage from '../images/1x/TeachMongoDB.svg';
-import AcademiaLeafImage from '../images/1x/Academia_Leaf.svg';
-import useMedia from '../hooks/use-media';
+import Button from '../../components/dev-hub/button';
+import HeroBanner from '../../components/dev-hub/hero-banner';
+import SectionHeader from '../../components/dev-hub/section-header';
+import AcademiaSignUpForm from '../../components/dev-hub/academia-sign-up-form';
+import HeroBannerImage from '../../images/1x/Academia_Hero.svg';
+import TeachMongoDBImage from '../../images/1x/TeachMongoDB.svg';
+import AcademiaLeafImage from '../../images/1x/Academia_Leaf.svg';
+import useMedia from '../../hooks/use-media';
 
 const StyledHeroBanner = styled(HeroBanner)`
     margin: 0 ${size.medium};

--- a/src/utils/setup/on-create-page.js
+++ b/src/utils/setup/on-create-page.js
@@ -23,7 +23,7 @@ const DEFAULT_FEATURED_LEARN_SLUGS = [
     'how-to/polymorphic-pattern',
 ];
 
-const STAGING_PAGES = ['/academia/', '/media/'];
+const STAGING_PAGES = ['/academia/educators/', '/media/'];
 
 const requestStitch = async (functionName, ...args) =>
     stitchClient.callFunction(functionName, [metadata, ...args]);


### PR DESCRIPTION
This PR moves the academia page to `/academia/educators` and sets up a redirect for `/academia` to `/academia/educators`.

When running the `develop` server, there is a blip where it renders a 404 thten goes to the correct place. Fortunately, the [`gatsby-plugin-meta-redirect`](https://github.com/nsresulta/gatsby-plugin-meta-redirect) creates a small file to help handle this redirect on production builds so this will not happen after a production build.