### PR TITLE
Convert ES5 require syntax to import/export for gatsby-node

### DIFF
--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -1,21 +1,19 @@
-const path = require('path');
-const { articles } = require('./src/queries/articles');
-const { constructDbFilter } = require('./src/utils/setup/construct-db-filter');
-const { initStitch } = require('./src/utils/setup/init-stich');
-const { saveAssetFiles } = require('./src/utils/setup/save-asset-files');
-const {
-    validateEnvVariables,
-} = require('./src/utils/setup/validate-env-variables');
-const { onCreatePage } = require('./src/utils/setup/on-create-page');
-const { createArticleNode } = require('./src/utils/setup/create-article-node');
-const { createAssetNodes } = require('./src/utils/setup/create-asset-nodes');
-const { createTagPageType } = require('./src/utils/setup/create-tag-page-type');
-const { getMetadata } = require('./src/utils/get-metadata');
-const {
+import path from 'path';
+import { articles } from './src/queries/articles';
+import { constructDbFilter } from './src/utils/setup/construct-db-filter';
+import { initStitch } from './src/utils/setup/init-stich';
+import { saveAssetFiles } from './src/utils/setup/save-asset-files';
+import { validateEnvVariables } from './src/utils/setup/validate-env-variables';
+import { handleCreatePage } from './src/utils/setup/handle-create-page';
+import { createArticleNode } from './src/utils/setup/create-article-node';
+import { createAssetNodes } from './src/utils/setup/create-asset-nodes';
+import { createTagPageType } from './src/utils/setup/create-tag-page-type';
+import { getMetadata } from './src/utils/get-metadata';
+import {
     DOCUMENTS_COLLECTION,
     METADATA_COLLECTION,
-} = require('./src/build-constants');
-const { createArticlePage } = require('./src/utils/setup/create-article-page');
+} from './src/build-constants';
+import { createArticlePage } from './src/utils/setup/create-article-page';
 
 // Consolidated metadata object used to identify build and env variables
 const metadata = getMetadata();
@@ -39,9 +37,9 @@ let learnFeaturedArticles;
 // Excluded articles from the learn page
 let excludedLearnPageArticles;
 
-exports.onPreBootstrap = validateEnvVariables;
+export const onPreBootstrap = validateEnvVariables;
 
-exports.sourceNodes = async ({
+export const sourceNodes = async ({
     actions: { createNode },
     createContentDigest,
 }) => {
@@ -70,7 +68,7 @@ exports.sourceNodes = async ({
     });
 };
 
-exports.onCreateNode = async ({ node }) => {
+export const onCreateNode = async ({ node }) => {
     if (node.internal.type === 'Asset') {
         assets.push(node.id);
     }
@@ -88,7 +86,7 @@ const filteredPageGroups = allSeries => {
     return allSeries;
 };
 
-exports.createPages = async ({ actions, graphql }) => {
+export const createPages = async ({ actions, graphql }) => {
     const { createPage, createRedirect } = actions;
     const [, metadata, result] = await Promise.all([
         saveAssetFiles(assets, stitchClient),
@@ -136,7 +134,7 @@ exports.createPages = async ({ actions, graphql }) => {
 };
 
 // Prevent errors when running gatsby build caused by browser packages run in a node environment.
-exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
+export const onCreateWebpackConfig = ({ stage, loaders, actions }) => {
     if (stage === 'build-html') {
         actions.setWebpackConfig({
             module: {
@@ -163,8 +161,8 @@ exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
     });
 };
 
-exports.onCreatePage = async ({ page, actions }) =>
-    onCreatePage(
+export const onCreatePage = async ({ page, actions }) =>
+    handleCreatePage(
         page,
         actions,
         stitchClient,

--- a/src/utils/setup/create-article-node.js
+++ b/src/utils/setup/create-article-node.js
@@ -1,7 +1,7 @@
-const { getNestedText } = require('../get-nested-text');
-const { getNestedValue } = require('../get-nested-value');
+import { getNestedText } from '../get-nested-text';
+import { getNestedValue } from '../get-nested-value';
 
-const createArticleNode = (
+export const createArticleNode = (
     doc,
     PAGE_ID_PREFIX,
     createNode,
@@ -34,5 +34,3 @@ const createArticleNode = (
         });
     }
 };
-
-module.exports = { createArticleNode };

--- a/src/utils/setup/create-article-page.js
+++ b/src/utils/setup/create-article-page.js
@@ -1,14 +1,12 @@
-const path = require('path');
-const {
-    getRelatedPagesWithImages,
-} = require('./get-related-pages-with-images');
-const { getNestedValue } = require('../get-nested-value');
-const { getPageSlug } = require('../get-page-slug');
-const { getSeriesArticles } = require('../get-series-articles');
-const { getTemplate } = require('../get-template');
-const { SNOOTY_STITCH_ID } = require('../../build-constants');
+import path from 'path';
+import { getRelatedPagesWithImages } from './get-related-pages-with-images';
+import { getNestedValue } from '../get-nested-value';
+import { getPageSlug } from '../get-page-slug';
+import { getSeriesArticles } from '../get-series-articles';
+import { getTemplate } from '../get-template';
+import { SNOOTY_STITCH_ID } from '../../build-constants';
 
-const createArticlePage = (
+export const createArticlePage = (
     page,
     slugContentMapping,
     allSeries,
@@ -42,5 +40,3 @@ const createArticlePage = (
         });
     }
 };
-
-module.exports = { createArticlePage };

--- a/src/utils/setup/create-asset-nodes.js
+++ b/src/utils/setup/create-asset-nodes.js
@@ -1,6 +1,6 @@
-const { getNestedValue } = require('../get-nested-value');
+import { getNestedValue } from '../get-nested-value';
 
-const createAssetNodes = (doc, createNode, createContentDigest) => {
+export const createAssetNodes = (doc, createNode, createContentDigest) => {
     const pageNode = getNestedValue(['ast', 'children'], doc);
     if (pageNode) {
         // Cache static assets to save file i/o on repeated builds
@@ -19,5 +19,3 @@ const createAssetNodes = (doc, createNode, createContentDigest) => {
         });
     }
 };
-
-module.exports = { createAssetNodes };

--- a/src/utils/setup/create-tag-page-type.js
+++ b/src/utils/setup/create-tag-page-type.js
@@ -1,8 +1,8 @@
-const dlv = require('dlv');
-const path = require('path');
-const { getTagPageUriComponent } = require('../get-tag-page-uri-component');
-const { SNOOTY_STITCH_ID } = require('../../build-constants');
-const { getMetadata } = require('../get-metadata');
+import dlv from 'dlv';
+import path from 'path';
+import { getTagPageUriComponent } from '../get-tag-page-uri-component';
+import { SNOOTY_STITCH_ID } from '../../build-constants';
+import { getMetadata } from '../get-metadata';
 
 const metadata = getMetadata();
 
@@ -28,7 +28,7 @@ const getAuthorIncludesPath = authorName => {
     }
 };
 
-const createTagPageType = async (
+export const createTagPageType = async (
     stitchType,
     createPage,
     pageMetadata,
@@ -99,5 +99,3 @@ const createTagPageType = async (
         }
     });
 };
-
-module.exports = { createTagPageType };

--- a/src/utils/setup/get-related-pages-with-images.js
+++ b/src/utils/setup/get-related-pages-with-images.js
@@ -1,6 +1,9 @@
-const dlv = require('dlv');
+import dlv from 'dlv';
 
-const getRelatedPagesWithImages = (pageNodes, RESOLVED_REF_DOC_MAPPING) => {
+export const getRelatedPagesWithImages = (
+    pageNodes,
+    RESOLVED_REF_DOC_MAPPING
+) => {
     const related = dlv(pageNodes, 'query_fields.related', []);
     const relatedPageInfo = related.map(r => {
         // Handle `reference` and `ref_role` types
@@ -18,5 +21,3 @@ const getRelatedPagesWithImages = (pageNodes, RESOLVED_REF_DOC_MAPPING) => {
     });
     return relatedPageInfo;
 };
-
-module.exports = { getRelatedPagesWithImages };

--- a/src/utils/setup/handle-create-page.js
+++ b/src/utils/setup/handle-create-page.js
@@ -1,8 +1,8 @@
-const memoizerific = require('memoizerific');
-const { removeExcludedArticles } = require('./remove-excluded-articles');
-const { removePageIfStaged } = require('./remove-page-if-staged');
-const { getNestedValue } = require('../get-nested-value');
-const { getMetadata } = require('../get-metadata');
+import memoizerific from 'memoizerific';
+import { removeExcludedArticles } from './remove-excluded-articles';
+import { removePageIfStaged } from './remove-page-if-staged';
+import { getNestedValue } from '../get-nested-value';
+import { getMetadata } from '../get-metadata';
 
 const metadata = getMetadata();
 let stitchClient;
@@ -41,7 +41,7 @@ const getAllArticles = memoizerific(1)(async () => {
     return filteredDocuments;
 });
 
-const findArticlesFromSlugs = (allArticles, articleSlugs, maxSize) => {
+export const findArticlesFromSlugs = (allArticles, articleSlugs, maxSize) => {
     const result = [];
     // If maxSize is undefined, this will return a shallow copy of articleSlugs
     articleSlugs.slice(0, maxSize).forEach((featuredSlug, i) => {
@@ -59,7 +59,7 @@ const findArticlesFromSlugs = (allArticles, articleSlugs, maxSize) => {
     return result;
 };
 
-const getLearnPageFilters = allArticles => {
+export const getLearnPageFilters = allArticles => {
     const languages = {};
     const products = {};
 
@@ -122,7 +122,7 @@ const getLearnPageFilters = allArticles => {
     return { languages, products };
 };
 
-const onCreatePage = async (
+export const handleCreatePage = async (
     page,
     actions,
     inheritedStitchClient,
@@ -176,5 +176,3 @@ const onCreatePage = async (
     }
     removePageIfStaged(page, deletePage, STAGING_PAGES);
 };
-
-module.exports = { findArticlesFromSlugs, getLearnPageFilters, onCreatePage };

--- a/src/utils/setup/init-stich.js
+++ b/src/utils/setup/init-stich.js
@@ -1,7 +1,7 @@
-const { Stitch, AnonymousCredential } = require('mongodb-stitch-server-sdk');
-const { SNOOTY_STITCH_ID } = require('../../build-constants');
+import { Stitch, AnonymousCredential } from 'mongodb-stitch-server-sdk';
+import { SNOOTY_STITCH_ID } from '../../build-constants';
 
-const initStitch = async () => {
+export const initStitch = async () => {
     const stitchClient = Stitch.hasAppClient(SNOOTY_STITCH_ID)
         ? Stitch.getAppClient(SNOOTY_STITCH_ID)
         : Stitch.initializeAppClient(SNOOTY_STITCH_ID);
@@ -10,5 +10,3 @@ const initStitch = async () => {
         .catch(console.error);
     return stitchClient;
 };
-
-module.exports = { initStitch };

--- a/src/utils/setup/remove-excluded-articles.js
+++ b/src/utils/setup/remove-excluded-articles.js
@@ -1,4 +1,7 @@
-const removeExcludedArticles = (allArticles, excludedLearnPageArticles) => {
+export const removeExcludedArticles = (
+    allArticles,
+    excludedLearnPageArticles
+) => {
     if (excludedLearnPageArticles && excludedLearnPageArticles.length) {
         const filteredArticles = allArticles.filter(
             article =>
@@ -21,5 +24,3 @@ const removeExcludedArticles = (allArticles, excludedLearnPageArticles) => {
     }
     return allArticles;
 };
-
-module.exports = { removeExcludedArticles };

--- a/src/utils/setup/remove-page-if-staged.js
+++ b/src/utils/setup/remove-page-if-staged.js
@@ -1,4 +1,4 @@
-const removePageIfStaged = (page, deletePage, stagingPages) => {
+export const removePageIfStaged = (page, deletePage, stagingPages) => {
     if (
         process.env.SNOOTY_ENV === 'production' &&
         stagingPages.includes(page.path)
@@ -6,5 +6,3 @@ const removePageIfStaged = (page, deletePage, stagingPages) => {
         deletePage(page);
     }
 };
-
-module.exports = { removePageIfStaged };

--- a/src/utils/setup/save-asset-files.js
+++ b/src/utils/setup/save-asset-files.js
@@ -1,7 +1,7 @@
-const fs = require('fs').promises;
-const path = require('path');
-const { ASSETS_COLLECTION } = require('../../build-constants');
-const { getMetadata } = require('../get-metadata');
+import { promises as fs } from 'fs';
+import path from 'path';
+import { ASSETS_COLLECTION } from '../../build-constants';
+import { getMetadata } from '../get-metadata';
 
 const metadata = getMetadata();
 const DB = metadata.database;
@@ -18,7 +18,7 @@ const saveFile = async asset => {
 };
 
 // Write all assets to static directory
-const saveAssetFiles = async (assets, stitchClient) => {
+export const saveAssetFiles = async (assets, stitchClient) => {
     if (assets.length) {
         const promises = [];
         const assetQuery = { _id: { $in: assets } };
@@ -32,5 +32,3 @@ const saveAssetFiles = async (assets, stitchClient) => {
         await Promise.all(promises);
     }
 };
-
-module.exports = { saveAssetFiles };

--- a/src/utils/setup/validate-env-variables.js
+++ b/src/utils/setup/validate-env-variables.js
@@ -1,6 +1,6 @@
 // env variables for building site along with use in front-end
 // https://www.gatsbyjs.org/docs/environment-variables/#defining-environment-variables
-const validateEnvVariables = () => {
+export const validateEnvVariables = () => {
     // make sure necessary env vars exist
     if (
         !process.env.GATSBY_SITE ||
@@ -12,5 +12,3 @@ const validateEnvVariables = () => {
         );
     }
 };
-
-module.exports.validateEnvVariables = validateEnvVariables;

--- a/tests/utils/find-articles-from-slugs.test.js
+++ b/tests/utils/find-articles-from-slugs.test.js
@@ -1,4 +1,4 @@
-import { findArticlesFromSlugs } from '../../src/utils/setup/on-create-page';
+import { findArticlesFromSlugs } from '../../src/utils/setup/handle-create-page';
 
 it('should correctly find featured articles given a set of requested articles', () => {
     let requestedFeaturedSlugs = [

--- a/tests/utils/get-learn-page-filters.test.js
+++ b/tests/utils/get-learn-page-filters.test.js
@@ -1,4 +1,4 @@
-import { getLearnPageFilters } from '../../src/utils/setup/on-create-page';
+import { getLearnPageFilters } from '../../src/utils/setup/handle-create-page';
 
 it('should correctly create filters for the learn page based on article tags', () => {
     const allArticles = [


### PR DESCRIPTION
This PR follows off the esm work to convert gatsby-node related modules to use `import/export` syntax. No functionality has been added or removed.

I renamed the helper module `onCreatePage` to `handleCreatePage` since this now conflicts with the gatsby node API function name. Before with `exports.onCreateNode` this was not an issue.