### PR TITLE
Podcasts in Stitch, Build Time

### DIFF
--- a/src/utils/devhub-api-stitch.js
+++ b/src/utils/devhub-api-stitch.js
@@ -9,6 +9,11 @@ const callDevhubAPIStitchFunction = async (fnName, ...fnArgs) => {
     }
 };
 
+export const requestLybsinPodcasts = async () => {
+    const result = await callDevhubAPIStitchFunction('fetchLybsinPodcasts');
+    return result;
+};
+
 export const requestMDBTwitchStream = async () => {
     const result = await callDevhubAPIStitchFunction('fetchMDBTwitchStream');
     return result;

--- a/src/utils/fetch-lybsin-podcasts.js
+++ b/src/utils/fetch-lybsin-podcasts.js
@@ -1,45 +1,11 @@
-import parser from 'fast-xml-parser';
-import dlv from 'dlv';
+import { requestLybsinPodcasts } from './devhub-api-stitch';
+import { parsePodcasts } from './parse-podcasts';
 
 // Fetches and parses podcast info from https://mongodb.libsyn.com/rss
 
-const RSS_URL = `https://mongodb.libsyn.com/rss`;
-
-const simplifyPodcast = podcast => {
-    const podcastJSON = {
-        mediaType: 'podcast',
-        title: podcast['title'],
-        publishDate: podcast['pubDate'],
-        description: podcast['itunes:summary'],
-        url: podcast['enclosure'] && podcast['enclosure']['url'],
-        thumbnailUrl:
-            podcast['itunes:image'] && podcast['itunes:image']['href'],
-    };
-    return podcastJSON;
-};
-
-const parsePodcasts = podcastXML => {
-    const options = {
-        attributeNamePrefix: '',
-        ignoreAttributes: false,
-        parseAttributeValue: true,
-    };
-
-    try {
-        const jsonObj = parser.parse(podcastXML, options, true);
-        const podcasts = dlv(jsonObj, 'rss.channel.item', []);
-        const parsedPodcasts = podcasts.map(simplifyPodcast);
-        return parsedPodcasts;
-    } catch (error) {
-        console.log(error.message);
-    }
-
-    return [];
-};
-
 const fetchLybsinPodcasts = async () => {
     try {
-        const response = await fetch(RSS_URL);
+        const response = await requestLybsinPodcasts();
         if (response) {
             const podcastXML = await response.text();
             const podcastList = parsePodcasts(podcastXML);

--- a/src/utils/parse-podcasts.js
+++ b/src/utils/parse-podcasts.js
@@ -1,0 +1,34 @@
+import parser from 'fast-xml-parser';
+import dlv from 'dlv';
+
+const simplifyPodcast = podcast => {
+    const podcastJSON = {
+        mediaType: 'podcast',
+        title: podcast['title'],
+        publishDate: podcast['pubDate'],
+        description: podcast['itunes:summary'],
+        url: podcast['enclosure'] && podcast['enclosure']['url'],
+        thumbnailUrl:
+            podcast['itunes:image'] && podcast['itunes:image']['href'],
+    };
+    return podcastJSON;
+};
+
+export const parsePodcasts = podcastXML => {
+    const options = {
+        attributeNamePrefix: '',
+        ignoreAttributes: false,
+        parseAttributeValue: true,
+    };
+
+    try {
+        const jsonObj = parser.parse(podcastXML, options, true);
+        const podcasts = dlv(jsonObj, 'rss.channel.item', []);
+        const parsedPodcasts = podcasts.map(simplifyPodcast);
+        return parsedPodcasts;
+    } catch (error) {
+        console.log(error.message);
+    }
+
+    return [];
+};

--- a/src/utils/setup/fetch-build-time-media.js
+++ b/src/utils/setup/fetch-build-time-media.js
@@ -1,18 +1,23 @@
 import { initStitch } from './init-stitch';
 import { STITCH_AUTH_APP_ID } from '../../constants';
+import { parsePodcasts } from '../parse-podcasts';
 import { simplifyTwitchResponse } from '../simplify-twitch-response';
 import { simplifyYoutubeResponse } from '../simplify-youtube-response';
 
 const MAX_RESULTS = 5;
 
-export const fetchBuildTimeVideos = async () => {
+export const fetchBuildTimeMedia = async () => {
     const client = await initStitch(STITCH_AUTH_APP_ID);
-    const [youtubeVideos, twitchVideos] = await Promise.all([
+    const [youtubeVideos, twitchVideos, lybsinPodcasts] = await Promise.all([
         client.callFunction('fetchYoutubeData', [MAX_RESULTS]),
         client.callFunction('fetchMDBTwitchVideos', [MAX_RESULTS]),
+        client.callFunction('fetchLybsinPodcasts', []),
     ]);
-    return [
-        youtubeVideos.items.map(simplifyYoutubeResponse),
-        twitchVideos.data.map(simplifyTwitchResponse),
-    ].flat();
+    return {
+        videos: [
+            youtubeVideos.items.map(simplifyYoutubeResponse),
+            twitchVideos.data.map(simplifyTwitchResponse),
+        ].flat(),
+        podcasts: parsePodcasts(lybsinPodcasts),
+    };
 };

--- a/src/utils/setup/handle-create-page.js
+++ b/src/utils/setup/handle-create-page.js
@@ -3,7 +3,7 @@ import { removeExcludedArticles } from './remove-excluded-articles';
 import { removePageIfStaged } from './remove-page-if-staged';
 import { getNestedValue } from '../get-nested-value';
 import { getMetadata } from '../get-metadata';
-import { fetchBuildTimeVideos } from './fetch-build-time-videos';
+import { fetchBuildTimeMedia } from './fetch-build-time-media';
 
 const metadata = getMetadata();
 let stitchClient;
@@ -146,16 +146,17 @@ export const handleCreatePage = async (
                 learnFeaturedArticles || DEFAULT_FEATURED_LEARN_SLUGS,
                 MAX_LEARN_PAGE_FEATURED_ARTICLES
             );
-            const allVideos = await fetchBuildTimeVideos();
+            const { podcasts, videos } = await fetchBuildTimeMedia();
             deletePage(page);
             createPage({
                 ...page,
                 context: {
                     ...page.context,
                     allArticles: learnPageArticles,
-                    allVideos,
                     featuredArticles: featuredLearnArticles,
                     filters,
+                    podcasts,
+                    videos,
                 },
             });
             break;


### PR DESCRIPTION
This PR moves the `fetch` for Lybsin Podcasts also into Stitch. `fetch` is not supported at build-time since `window` is undefined 🤦  so this is a requirement to use podcasts at build-time. Part of this was moving the postprocessing `parsePodcasts` into its own module.

I also updated the function to get build time data to support both videos and podcasts, to save on overhead for instantiating a stitch client.

This is the last piece of work to get media elements pulled at build time.