### PR TITLE
Remove extra 0 from card list

### DIFF
--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -138,9 +138,9 @@ export default React.memo(({ videos, articles, podcasts, limit = 9 }) => {
                     </Button>
                 </HasMoreButtonContainer>
             )}
-            {podcasts.length && (
+            {podcasts.length ? (
                 <Audio onClose={closeAudio} podcast={activePodcast} />
-            )}
+            ) : null}
         </>
     );
 });


### PR DESCRIPTION
There was a `0` floating at the bottom of the card list. This was because we are preparing for podcasts and didn't properly use our ternary operators on the length. This was not in prod.

This PR removes the 0.

![Screen Shot 2020-06-02 at 11 22 31 AM](https://user-images.githubusercontent.com/9064401/83538313-a9a59300-a4c3-11ea-8705-90f91898fa63.png)
