### PR TITLE
Use build-time media on the learn page

### DIFF
--- a/src/hooks/use-all-videos.js
+++ b/src/hooks/use-all-videos.js
@@ -2,8 +2,8 @@ import { useEffect, useState } from 'react';
 import fetchTwitchVideos from '../utils/fetch-twitch-videos';
 import fetchYoutubeData from '../utils/fetch-youtube-data';
 
-const useAllVideos = () => {
-    const [videos, setVideos] = useState(null);
+const useAllVideos = allVideos => {
+    const [videos, setVideos] = useState(allVideos);
     const [error, setError] = useState(null);
     const [isLoading, setIsLoading] = useState(false);
 

--- a/src/hooks/use-podcasts.js
+++ b/src/hooks/use-podcasts.js
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
 import fetchLybsinPodcasts from '../utils/fetch-lybsin-podcasts';
 
-const usePodcasts = () => {
-    const [podcasts, setPodcasts] = useState(null);
+const usePodcasts = allPodcasts => {
+    const [podcasts, setPodcasts] = useState(allPodcasts);
     const [error, setError] = useState(null);
     const [isLoading, setIsLoading] = useState(false);
 

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -183,7 +183,13 @@ const FeaturedArticles = ({ articles }) => {
 
 export default ({
     location,
-    pageContext: { allArticles, featuredArticles, filters },
+    pageContext: {
+        allArticles,
+        allPodcasts,
+        allVideos,
+        featuredArticles,
+        filters,
+    },
 }) => {
     const metadata = useSiteMetadata();
     const initialArticles = useMemo(() => parseArticles(allArticles), [
@@ -216,9 +222,10 @@ export default ({
             (!filterValue.products || filterValue.products === 'all'),
         [filterValue]
     );
-    const { videos } = useAllVideos();
 
-    const { podcasts } = usePodcasts();
+    const { videos } = useAllVideos(allVideos);
+
+    const { podcasts } = usePodcasts(allPodcasts);
 
     const [activeItem, setActiveItem] = useState('All');
 

--- a/src/utils/fetch-lybsin-podcasts.js
+++ b/src/utils/fetch-lybsin-podcasts.js
@@ -7,8 +7,7 @@ const fetchLybsinPodcasts = async () => {
     try {
         const response = await requestLybsinPodcasts();
         if (response) {
-            const podcastXML = await response.text();
-            const podcastList = parsePodcasts(podcastXML);
+            const podcastList = parsePodcasts(response);
             return podcastList;
         }
     } catch (e) {

--- a/src/utils/setup/fetch-build-time-media.js
+++ b/src/utils/setup/fetch-build-time-media.js
@@ -14,10 +14,10 @@ export const fetchBuildTimeMedia = async () => {
         client.callFunction('fetchLybsinPodcasts', []),
     ]);
     return {
-        videos: [
+        allVideos: [
             youtubeVideos.items.map(simplifyYoutubeResponse),
             twitchVideos.data.map(simplifyTwitchResponse),
         ].flat(),
-        podcasts: parsePodcasts(lybsinPodcasts),
+        allPodcasts: parsePodcasts(lybsinPodcasts),
     };
 };

--- a/src/utils/setup/handle-create-page.js
+++ b/src/utils/setup/handle-create-page.js
@@ -146,17 +146,17 @@ export const handleCreatePage = async (
                 learnFeaturedArticles || DEFAULT_FEATURED_LEARN_SLUGS,
                 MAX_LEARN_PAGE_FEATURED_ARTICLES
             );
-            const { podcasts, videos } = await fetchBuildTimeMedia();
+            const { allPodcasts, allVideos } = await fetchBuildTimeMedia();
             deletePage(page);
             createPage({
                 ...page,
                 context: {
                     ...page.context,
                     allArticles: learnPageArticles,
+                    allPodcasts,
+                    allVideos,
                     featuredArticles: featuredLearnArticles,
                     filters,
-                    podcasts,
-                    videos,
                 },
             });
             break;


### PR DESCRIPTION
This PR builds off of the previous work to move media fetching into build-time to use this media data on the learn page. This removes the "jittering" effect so long as there is no new content between the latest build and when the page is rendered.

I updated the hooks to take a default value, so that way if the fetch returns identical data there should not be a rerender.

The target branch for this PR is not staging, it is the branch with media on the learn page.