### PR TITLE
Move logic for staged pages into Stitch

### DIFF
--- a/src/utils/setup/get-staging-pages.js
+++ b/src/utils/setup/get-staging-pages.js
@@ -1,0 +1,8 @@
+import { initStitch } from './init-stitch';
+import { STITCH_AUTH_APP_ID } from '../../constants';
+
+export const getStagingPages = async () => {
+    const client = await initStitch(STITCH_AUTH_APP_ID);
+    const stagingPages = await client.callFunction('fetchStagingPages', []);
+    return stagingPages;
+};

--- a/src/utils/setup/handle-create-page.js
+++ b/src/utils/setup/handle-create-page.js
@@ -4,6 +4,7 @@ import { removePageIfStaged } from './remove-page-if-staged';
 import { getNestedValue } from '../get-nested-value';
 import { getMetadata } from '../get-metadata';
 import { fetchBuildTimeMedia } from './fetch-build-time-media';
+import { getStagingPages } from './get-staging-pages';
 
 const metadata = getMetadata();
 let stitchClient;
@@ -24,7 +25,9 @@ const DEFAULT_FEATURED_LEARN_SLUGS = [
     'how-to/polymorphic-pattern',
 ];
 
-const STAGING_PAGES = ['/academia/educators/', '/media/'];
+const memoizedStagingPages = memoizerific(1)(
+    async () => await getStagingPages()
+);
 
 const requestStitch = async (functionName, ...args) =>
     stitchClient.callFunction(functionName, [metadata, ...args]);
@@ -133,6 +136,7 @@ export const handleCreatePage = async (
 ) => {
     const { createPage, deletePage } = actions;
     stitchClient = inheritedStitchClient;
+    const stagingPages = await memoizedStagingPages();
     switch (page.path) {
         case '/learn/':
             const allArticles = await getAllArticles();
@@ -178,5 +182,5 @@ export const handleCreatePage = async (
         default:
             break;
     }
-    removePageIfStaged(page, deletePage, STAGING_PAGES);
+    removePageIfStaged(page, deletePage, stagingPages);
 };


### PR DESCRIPTION
This PR moves the local variable `STAGING_PAGES` into Stitch and adds support to access it. This will allow us to control when pages are released without needing a code change on the repo (so long as the change is done before a new build).

In Stitch I set up a basic value called `STAGING_PAGES` which is just an array of pages we don't want out on Prod yet. I also set up a very simple function called `fetchStagingPages` which serves as a getter for this value.