### PR TITLE
Swap Nav link to Community Forums

### DIFF
--- a/src/components/dev-hub/global-nav.js
+++ b/src/components/dev-hub/global-nav.js
@@ -82,7 +82,9 @@ export default () => {
                     )}
                 </HomeLink>
                 <NavLink to="/learn">Learn</NavLink>
-                <NavLink to="/community">Community</NavLink>
+                <NavLink href="https://developer.mongodb.com/community/forums/">
+                    Community
+                </NavLink>
             </NavContent>
         </GlobalNav>
     );


### PR DESCRIPTION
[DEVHUB-150](https://jira.mongodb.org/browse/DEVHUB-150)

This PR switches the "community" link on the top nav to point to the community forums instead of the existing community page.

This PR does not touch the community page files, since it seems like DevRel will update these in the future. They still live and are accessible at `/community` and `/community/events`. We can stage these, but not sure what the best course of action here is.