### PR TITLE
Add flexbox constraints for Academia Images

### DIFF
--- a/src/pages/academia/educators.js
+++ b/src/pages/academia/educators.js
@@ -20,6 +20,9 @@ import TeachMongoDBImage from '../../images/1x/TeachMongoDB.svg';
 import AcademiaLeafImage from '../../images/1x/Academia_Leaf.svg';
 import useMedia from '../../hooks/use-media';
 
+const LEAF_IMAGE_WIDTH = 125;
+const TEACH_IMAGE_WIDTH = 450;
+
 const StyledHeroBanner = styled(HeroBanner)`
     margin: 0 ${size.medium};
 `;
@@ -113,7 +116,14 @@ const StyledP = styled(P)`
 `;
 
 const StyledLeafImage = styled('img')`
-    margin-top: 350px;
+    margin-top: 200px;
+    flex: 0 0 ${LEAF_IMAGE_WIDTH}px;
+    width: ${LEAF_IMAGE_WIDTH}px;
+`;
+
+const StyledTeachImage = styled('img')`
+    flex: 0 0 ${TEACH_IMAGE_WIDTH}px;
+    width: ${TEACH_IMAGE_WIDTH}px;
 `;
 
 export default () => {
@@ -189,7 +199,7 @@ export default () => {
                     </OfferingsContent>
                 </div>
                 {!isMobile && (
-                    <img src={TeachMongoDBImage} alt="" width="450px" />
+                    <StyledTeachImage src={TeachMongoDBImage} alt="" />
                 )}
             </BodyContent>
 


### PR DESCRIPTION
This PR addresses images being different sizes on various browsers on the academia page.

The issue was Chrome was reading the `width` attribute off of images to provide flexbox positioning. Firefox did not work the same way. The solution here was to use flexbox css to specify an exact pixel width for these images.

Now the images look great on any browser. I also moved the leaf one up a bit to get it in line with the design.

Before (FF):
![Screen Shot 2020-06-03 at 3 23 18 PM](https://user-images.githubusercontent.com/9064401/83680092-77249480-a5ae-11ea-8a8e-fb81e8bc8c9a.png)
![Screen Shot 2020-06-03 at 3 23 22 PM](https://user-images.githubusercontent.com/9064401/83680094-77249480-a5ae-11ea-81f2-83c3e335ea11.png)


After (FF):
![Screen Shot 2020-06-03 at 3 17 47 PM](https://user-images.githubusercontent.com/9064401/83680108-7e4ba280-a5ae-11ea-9081-f0c6b2d4f14a.png)
![Screen Shot 2020-06-03 at 3 26 14 PM](https://user-images.githubusercontent.com/9064401/83680155-96bbbd00-a5ae-11ea-87d8-4f87850cfd54.png)

