### PR TITLE
Add alt tags to images on academia page

### DIFF
--- a/src/pages/academia/educators.js
+++ b/src/pages/academia/educators.js
@@ -199,7 +199,10 @@ export default () => {
                     </OfferingsContent>
                 </div>
                 {!isMobile && (
-                    <StyledTeachImage src={TeachMongoDBImage} alt="" />
+                    <StyledTeachImage
+                        src={TeachMongoDBImage}
+                        alt="Cartoon teacher pointing at codeblock. Cartoon person sitting on bench reading laptop."
+                    />
                 )}
             </BodyContent>
 
@@ -251,7 +254,10 @@ export default () => {
                     </div>
 
                     {!isMobile && (
-                        <StyledLeafImage src={AcademiaLeafImage} alt="" />
+                        <StyledLeafImage
+                            src={AcademiaLeafImage}
+                            alt="Two green sprouting leaves"
+                        />
                     )}
                 </BodyContent>
             </EligibilitySection>


### PR DESCRIPTION
We also can add `alt` tags to academia page images to help with screen reading. This PR adds alt tags to the two body content images on the academia page.

Feedback on content welcome!