### PR TITLE
Remove padding from hero banner on mobile

### DIFF
--- a/src/pages/academia/educators.js
+++ b/src/pages/academia/educators.js
@@ -25,6 +25,9 @@ const TEACH_IMAGE_WIDTH = 450;
 
 const StyledHeroBanner = styled(HeroBanner)`
     margin: 0 ${size.medium};
+    @media ${screenSize.upToLarge} {
+        margin: 0;
+    }
 `;
 
 const Header = styled('header')`


### PR DESCRIPTION
This PR removes padding from the new `academia/educators.js` page header for mobile displays. This will allow help us get better alignment with the body content. 