### PR TITLE
Set CFG visited links to green using href

### DIFF
--- a/src/pages/code-for-good.js
+++ b/src/pages/code-for-good.js
@@ -91,6 +91,9 @@ const BodyContent = styled('div')`
 const StyledParagraphLink = styled(Link)`
     color: ${colorMap.darkGreen};
     text-decoration: none;
+    :visited {
+        color: ${colorMap.darkGreen};
+    }
 `;
 
 const StyledLink = styled(Link)`
@@ -98,6 +101,9 @@ const StyledLink = styled(Link)`
     font-weight: bold;
     margin-top: ${size.mediumLarge};
     text-decoration: none;
+    :visited {
+        color: ${colorMap.darkGreen};
+    }
 `;
 
 const UnderstandTextSection = styled('div')`


### PR DESCRIPTION
These would show as white when `visited`, but we would always like them as green.

![Screen Shot 2020-06-05 at 10 08 38 AM](https://user-images.githubusercontent.com/9064401/83885597-90dfec00-a714-11ea-8890-e12d9eba7d35.png)
