### PR TITLE
Fix text sizing, background waves cover

### DIFF
--- a/src/pages/code-for-good.js
+++ b/src/pages/code-for-good.js
@@ -31,8 +31,8 @@ const Header = styled('header')`
     justify-content: space-between;
     padding-top: ${size.large};
     @media ${screenSize.upToLarge} {
-        flex-direction: column-reverse;
         margin-bottom: ${size.large};
+        flex-direction: column-reverse;
     }
 `;
 const HeaderText = styled('div')`
@@ -182,9 +182,9 @@ const StyledDashboardCaption = styled(P3)`
 const DashboardCaption = StyledDashboardCaption.withComponent('figcaption');
 
 const HeaderActionsContainer = styled('div')`
+    align-items: center;
     display: flex;
     flex-wrap: wrap;
-    align-items: center;
     padding-top: ${size.large};
 `;
 

--- a/src/pages/code-for-good.js
+++ b/src/pages/code-for-good.js
@@ -45,13 +45,14 @@ const HeaderText = styled('div')`
 
 const HeaderLink = styled(Link)`
     color: ${colorMap.darkGreen};
-    display: inline;
-    margin-top: ${size.large};
     margin-left: ${size.mediumLarge};
-    white-space: nowrap;
-    @media ${screenSize.upToLarge} {
-        display: block;
-        margin: 0;
+    margin-top: ${size.small};
+    :hover {
+        color: ${colorMap.darkGreen};
+    }
+    @media ${screenSize.upToMedium} {
+        margin-left: ${size.small};
+        font-size: ${fontSize.tiny};
     }
 `;
 
@@ -72,10 +73,7 @@ const BodyText = styled(P)`
 `;
 
 const StyledButton = styled(Button)`
-    margin-top: ${size.large};
-    @media ${screenSize.upToLarge} {
-        margin-bottom: ${size.medium};
-    }
+    margin-top: ${size.small};
 `;
 
 const BodyContent = styled('div')`
@@ -183,6 +181,13 @@ const StyledDashboardCaption = styled(P3)`
 
 const DashboardCaption = StyledDashboardCaption.withComponent('figcaption');
 
+const HeaderActionsContainer = styled('div')`
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    padding-top: ${size.large};
+`;
+
 export default () => {
     const metadata = useSiteMetadata();
     const codeForGoodBreadcrumbs = [
@@ -200,6 +205,7 @@ export default () => {
                 background={BackgroundWaves}
                 fullWidth={true}
                 showImageOnMobile={false}
+                shouldContainBackground={false}
             >
                 <Header>
                     <div>
@@ -214,17 +220,19 @@ export default () => {
                                 our oceans.
                             </StyledP>
                         </HeaderText>
-                        <StyledButton
-                            primary
-                            hasArrow={false}
-                            href="https://o-fish.github.io"
-                        >
-                            Build your own O-FISH app
-                        </StyledButton>
+                        <HeaderActionsContainer>
+                            <StyledButton
+                                primary
+                                hasArrow={false}
+                                href="https://o-fish.github.io"
+                            >
+                                Build your own O-FISH app
+                            </StyledButton>
 
-                        <HeaderLink href="#" tertiary>
-                            Learn why we created O-FISH
-                        </HeaderLink>
+                            <HeaderLink href="#" tertiary>
+                                Learn why we created O-FISH
+                            </HeaderLink>
+                        </HeaderActionsContainer>
                     </div>
                     <StyledLogoImage
                         src={WildAidLogo}


### PR DESCRIPTION
This PR addresses some design tweaks for the Code for Good page. Specifically, this PR:
- Disables the `shouldContainBackground` prop on the hero banner, allowing the image to break aspect ratio while shrinking (keeping the waves grounded to the bottom of the banner).
- Disables the pink hover state on the hero banner link
- Uses flexbox to manage when to wrap the hero banner link and gives spacing between the button and link when wrapped.


Here are some screenshots:

![Screen Shot 2020-06-05 at 11 47 20 AM](https://user-images.githubusercontent.com/9064401/83896986-f9ce6080-a722-11ea-8436-c9d63b1f767e.png)
![Screen Shot 2020-06-05 at 11 47 48 AM](https://user-images.githubusercontent.com/9064401/83896987-fa66f700-a722-11ea-9c2c-40facc781321.png)
