### PR TITLE
Delete CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Globally requested for review when someone opens a pull request.
-* @melissarudofsky @jbouzi12 @jestapinski @greggb


### PR DESCRIPTION
This was helpful when we were developing more frequently, but I think we can manually assign reviewers now. Open to feedback though.