### PR TITLE
[DEVHUB-84] Comma-split Three or More Authors

### DIFF
--- a/src/components/dev-hub/byline-block.js
+++ b/src/components/dev-hub/byline-block.js
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import Link from './link';
 import { P } from './text';
 import { fontSize, screenSize, size } from './theme';
+import { getAuthorPrefix } from '../../utils/get-author-prefix';
 import { getTagPageUriComponent } from '../../utils/get-tag-page-uri-component';
 import AuthorImage from './author-image';
 
@@ -56,7 +57,7 @@ const AuthorNames = ({ authors }) => (
     <div>
         {authors.map(({ name }, index) => {
             const authorLink = `/author/${getTagPageUriComponent(name)}`;
-            const prefix = index === 0 ? 'By ' : '\u00a0and ';
+            const prefix = getAuthorPrefix(index, authors.length);
             return (
                 <AuthorText collapse key={name}>
                     {prefix}

--- a/src/utils/get-author-prefix.js
+++ b/src/utils/get-author-prefix.js
@@ -1,0 +1,17 @@
+/**
+ * Generates a prefix for an author's name on Byline Block based on index and
+ * total number of authors
+ */
+export const getAuthorPrefix = (index, numberOfAuthors) => {
+    switch (index) {
+        case 0:
+            return 'By ';
+        case numberOfAuthors - 1:
+            // Handle case of two authors, so no comma needed
+            if (numberOfAuthors === 2) return '\u00a0and ';
+            return ', and ';
+        default:
+            // Otherwise, let's use commas to separate authors
+            return ', ';
+    }
+};

--- a/tests/utils/get-author-prefix.test.js
+++ b/tests/utils/get-author-prefix.test.js
@@ -1,0 +1,20 @@
+import { getAuthorPrefix } from '../../src/utils/get-author-prefix';
+
+const getFullBylineString = arr =>
+    arr.map((name, i) => `${getAuthorPrefix(i, arr.length)}${name}`).join('');
+
+it('should correctly parse a line of authors based on the number of authors', () => {
+    const singleAuthorArray = ['Single Author'];
+    const singleAuthorResult = getFullBylineString(singleAuthorArray);
+    expect(singleAuthorResult).toBe('By Single Author');
+
+    const twoAuthorArray = ['First Author', 'Second Author'];
+    const twoAuthorResult = getFullBylineString(twoAuthorArray);
+    expect(twoAuthorResult).toBe('By First Author\u00a0and Second Author');
+
+    const threeAuthorArray = ['First Author', 'Second Author', 'Third Author'];
+    const threeAuthorResult = getFullBylineString(threeAuthorArray);
+    expect(threeAuthorResult).toBe(
+        'By First Author, Second Author, and Third Author'
+    );
+});

--- a/tests/utils/get-author-prefix.test.js
+++ b/tests/utils/get-author-prefix.test.js
@@ -12,9 +12,20 @@ it('should correctly parse a line of authors based on the number of authors', ()
     const twoAuthorResult = getFullBylineString(twoAuthorArray);
     expect(twoAuthorResult).toBe('By First Author\u00a0and Second Author');
 
-    const threeAuthorArray = ['First Author', 'Second Author', 'Third Author'];
+    const threeAuthorArray = [...twoAuthorArray, 'Third Author'];
     const threeAuthorResult = getFullBylineString(threeAuthorArray);
     expect(threeAuthorResult).toBe(
         'By First Author, Second Author, and Third Author'
+    );
+
+    const sixAuthorArray = [
+        ...threeAuthorArray,
+        'Fourth Author',
+        'Fifth Author',
+        'Sixth Author',
+    ];
+    const sixAuthorResult = getFullBylineString(sixAuthorArray);
+    expect(sixAuthorResult).toBe(
+        'By First Author, Second Author, Third Author, Fourth Author, Fifth Author, and Sixth Author'
     );
 });


### PR DESCRIPTION
[Ticket](https://jira.mongodb.org/browse/DEVHUB-84)

This PR updates the BylineBlock logic to comma-split lists of authors when three or more are present. One example of this locally is in the article `/article/johns-hopkins-university-covid-19-data-atlas` which has four authors. I decided to abstract this logic out and test it since it got a little complicated.

- If there is one author, it should look like 'By Author Name' (same as before)
- If exactly two: 'By First Author and Second Author' (same as before)
- If 3+: 'By First Author, Second Author, and Third Author' (new!)

(The tests should help shed light on this)

Before:
<img width="448" alt="Screen Shot 2020-07-09 at 5 47 07 PM" src="https://user-images.githubusercontent.com/9064401/87094308-a8772c80-c20c-11ea-932b-54d2b6e3b64e.png">

After:
<img width="406" alt="Screen Shot 2020-07-09 at 5 44 26 PM" src="https://user-images.githubusercontent.com/9064401/87094322-af9e3a80-c20c-11ea-8acf-2169909e2c1c.png">
