### PR TITLE
Fix local URLs coming from Events API

### DIFF
--- a/src/utils/fetch-event-data.js
+++ b/src/utils/fetch-event-data.js
@@ -1,5 +1,6 @@
-export const EVENTS_URL =
+const EVENTS_API_URL =
     'https://www.mongodb.com/api/event/all/1?sort=-node_type_attributes.event_start';
+const EVENTS_BASE_URL = 'http://www.mongodb.com/';
 
 export const removePastEvents = events => {
     const today = new Date();
@@ -10,10 +11,20 @@ export const removePastEvents = events => {
     );
 };
 
+// Some events coming from the .com API are relative links to events, so we must
+// convert these to absolute links
+const addUrlIfLocal = event => {
+    const url = event.url;
+    if (url.match(/^http/)) {
+        return event;
+    }
+    return { ...event, url: `${EVENTS_BASE_URL}${url}` };
+};
+
 // Fetches data from mongodb.com/events api
 const fetchEventData = async () => {
     try {
-        const data = await fetch(EVENTS_URL, {
+        const data = await fetch(EVENTS_API_URL, {
             credentials: 'same-origin',
             headers: {
                 'Content-Type': 'application/json',
@@ -22,7 +33,8 @@ const fetchEventData = async () => {
         if (data) {
             const parsedData = await data.json();
             const upcomingEvents = removePastEvents(parsedData);
-            return upcomingEvents;
+            const eventsWithUpdatedUrls = upcomingEvents.map(addUrlIfLocal);
+            return eventsWithUpdatedUrls;
         }
     } catch (e) {
         console.error(e);


### PR DESCRIPTION
[Staging Link](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/js/fix-event-local-urls/community/events/)
[Broken Production Link](https://developer.mongodb.com/community/events/)

This PR fixes addresses an issue where event data is coming in with relative links to an event on mongodb.com instead of absolute links. We don't try to format them as-is so this would try to link to developer.mongodb.com/community/events/events/eventname instead of mongodb.com/events/eventname

The solution here was to regex check for either `http` or `www` starting off this field. If this is the case then we don't add anything to the URL. If not, we add the mongodb.com/ prefix to make the link absolute.