### PR TITLE
Remove Share Links Trailing Slash

### DIFF
--- a/cypress/integration/article.js
+++ b/cypress/integration/article.js
@@ -1,5 +1,5 @@
 const ARTICLE_WITH_SERIES_URL =
-    '/article/3-things-to-know-switch-from-sql-mongodb/';
+    '/article/3-things-to-know-switch-from-sql-mongodb';
 const PROD_ARTICLE_URL = `https://developer.mongodb.com${ARTICLE_WITH_SERIES_URL}`;
 
 const ARTICLE_TITLE = '3 Things to Know When You Switch from SQL to MongoDB';

--- a/src/components/dev-hub/article-share-footer.js
+++ b/src/components/dev-hub/article-share-footer.js
@@ -31,16 +31,15 @@ const BlogShareLinks = styled('div')`
 `;
 
 const ArticleShareFooter = ({ tags, title, url }) => {
-    const urlWithoutTrailingSlash = url.match(/\/$/)
-        ? url.slice(0, url.length - 1)
-        : url;
+    const {
+        articleUrl,
+        facebookUrl,
+        linkedInUrl,
+        twitterUrl,
+    } = getArticleShareLinks(title, url);
     const onCopyLink = useCallback(() => {
-        copy(urlWithoutTrailingSlash);
-    }, [urlWithoutTrailingSlash]);
-    const { facebookUrl, linkedInUrl, twitterUrl } = getArticleShareLinks(
-        title,
-        urlWithoutTrailingSlash
-    );
+        copy(articleUrl);
+    }, [articleUrl]);
     return (
         <ArticleShareArea>
             <BlogTagList tags={tags} />

--- a/src/components/dev-hub/article-share-footer.js
+++ b/src/components/dev-hub/article-share-footer.js
@@ -31,12 +31,15 @@ const BlogShareLinks = styled('div')`
 `;
 
 const ArticleShareFooter = ({ tags, title, url }) => {
+    const urlWithoutTrailingSlash = url.match(/\/$/)
+        ? url.slice(0, url.length - 1)
+        : url;
     const onCopyLink = useCallback(() => {
-        copy(url);
-    }, [url]);
+        copy(urlWithoutTrailingSlash);
+    }, [urlWithoutTrailingSlash]);
     const { facebookUrl, linkedInUrl, twitterUrl } = getArticleShareLinks(
         title,
-        url
+        urlWithoutTrailingSlash
     );
     return (
         <ArticleShareArea>

--- a/src/components/dev-hub/share-menu.js
+++ b/src/components/dev-hub/share-menu.js
@@ -55,8 +55,12 @@ const SocialIcon = ({ type, href, ...props }) => {
     const isClickable = href || props.onClick;
     return (
         <SocialLink
-            onMouseEnter={() => isClickable && setColor(theme.colorMap.devWhite)}
-            onMouseLeave={() => isClickable && setColor(theme.colorMap.greyLightTwo)}
+            onMouseEnter={() =>
+                isClickable && setColor(theme.colorMap.devWhite)
+            }
+            onMouseLeave={() =>
+                isClickable && setColor(theme.colorMap.greyLightTwo)
+            }
             href={href}
             target="_blank"
             isClickable={isClickable}
@@ -71,19 +75,22 @@ const SocialIcon = ({ type, href, ...props }) => {
  * @property {string} props.url
  */
 const ShareMenu = ({ title, url, ...props }) => {
+    const urlWithoutTrailingSlash = url.match(/\/$/)
+        ? url.slice(0, url.length - 1)
+        : url;
     const [showCopyMessage, setShowCopyMessage] = useState(false);
     const onCopyLink = useCallback(
         e => {
             e.preventDefault();
-            copy(url);
+            copy(urlWithoutTrailingSlash);
             setShowCopyMessage(true);
             setTimeout(() => setShowCopyMessage(false), 2000);
         },
-        [url]
+        [urlWithoutTrailingSlash]
     );
     const { facebookUrl, linkedInUrl, twitterUrl } = getArticleShareLinks(
         title,
-        url
+        urlWithoutTrailingSlash
     );
 
     return (

--- a/src/components/dev-hub/share-menu.js
+++ b/src/components/dev-hub/share-menu.js
@@ -75,22 +75,21 @@ const SocialIcon = ({ type, href, ...props }) => {
  * @property {string} props.url
  */
 const ShareMenu = ({ title, url, ...props }) => {
-    const urlWithoutTrailingSlash = url.match(/\/$/)
-        ? url.slice(0, url.length - 1)
-        : url;
     const [showCopyMessage, setShowCopyMessage] = useState(false);
+    const {
+        articleUrl,
+        facebookUrl,
+        linkedInUrl,
+        twitterUrl,
+    } = getArticleShareLinks(title, url);
     const onCopyLink = useCallback(
         e => {
             e.preventDefault();
-            copy(urlWithoutTrailingSlash);
+            copy(articleUrl);
             setShowCopyMessage(true);
             setTimeout(() => setShowCopyMessage(false), 2000);
         },
-        [urlWithoutTrailingSlash]
-    );
-    const { facebookUrl, linkedInUrl, twitterUrl } = getArticleShareLinks(
-        title,
-        urlWithoutTrailingSlash
+        [articleUrl]
     );
 
     return (

--- a/src/utils/get-article-share-links.js
+++ b/src/utils/get-article-share-links.js
@@ -1,8 +1,16 @@
 export const getArticleShareLinks = (title, url) => {
-    const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=${url}`;
-    const twitterUrl = `https://twitter.com/intent/tweet?url=${url}&text=${encodeURIComponent(
+    const urlWithoutTrailingSlash = url.match(/\/$/)
+        ? url.slice(0, url.length - 1)
+        : url;
+    const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=${urlWithoutTrailingSlash}`;
+    const twitterUrl = `https://twitter.com/intent/tweet?url=${urlWithoutTrailingSlash}&text=${encodeURIComponent(
         title
     )}`;
-    const linkedInUrl = `https://www.linkedin.com/shareArticle?url=${url}`;
-    return { facebookUrl, linkedInUrl, twitterUrl };
+    const linkedInUrl = `https://www.linkedin.com/shareArticle?url=${urlWithoutTrailingSlash}`;
+    return {
+        articleUrl: urlWithoutTrailingSlash,
+        facebookUrl,
+        linkedInUrl,
+        twitterUrl,
+    };
 };


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DEVHUB-200)
[Staging Link (Sample Article)](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/js/share-trailing-slash/how-to/static-website-deployments-mongodb-stitch-hugo-git-travis-ci)

This PR removes trailing slashes from our social share links on articles, including the copy functionality, twitter, facebook, and linkedin* (see below). I also was going to refactor these two components a bit more but it seemed pretty large for just this small change so I decided to hold off.

To verify:
- Check out the sample article
- Share links should all have the article url without a trailing slash (LinkedIn is odd and keeps putting it there even though we don't pass it, will look into this separately)
- Share links on top and bottom should be identical

LinkedIn is still putting a trailing slash on because the server seems to redirect it to do so. This is something for the backend team to look into.