### PR TITLE
DEVHUB-190: Correctly use og description where appropriate

### DIFF
--- a/cypress/integration/article.js
+++ b/cypress/integration/article.js
@@ -2,9 +2,16 @@ const ARTICLE_WITH_SERIES_URL =
     '/article/3-things-to-know-switch-from-sql-mongodb';
 const PROD_ARTICLE_URL = `https://developer.mongodb.com${ARTICLE_WITH_SERIES_URL}`;
 
+// Article with no og description (test meta description fallback)
+const ARTICLE_WITHOUT_OG_DESCRIPTION_URL =
+    '/article/active-active-application-architectures';
+const ARTICLE_WITHOUT_OG_META_DESCRIPTION =
+    'This post will begin by describing the database capabilities required by modern multi-data center applications.';
+
 const ARTICLE_TITLE = '3 Things to Know When You Switch from SQL to MongoDB';
 const ARTICLE_DESCRIPTION =
     'Discover the 3 things you need to know when you switch from SQL to MongoDB';
+const OG_DESCRIPTION = 'og-description text';
 const SERIES_TITLE = 'SQL to MongoDB';
 
 // Images
@@ -101,10 +108,12 @@ describe('Sample Article Page', () => {
             // This would match the PROD_ARTICLE_URL but it has http and not https
             OG_URL
         );
+        // An og:description exists, so we should populate the tag with it
         cy.checkMetaContentProperty(
             'property="og:description"',
-            ARTICLE_DESCRIPTION
+            OG_DESCRIPTION
         );
+        cy.checkMetaContentProperty('name="description"', ARTICLE_DESCRIPTION);
         cy.checkMetaContentProperty('property="og:image"', OG_IMAGE);
 
         // Check Twitter tags
@@ -120,5 +129,19 @@ describe('Sample Article Page', () => {
             ARTICLE_DESCRIPTION
         );
         cy.checkMetaContentProperty('name="twitter:image"', TWITTER_IMAGE);
+    });
+
+    it('should automatically populate the og description tag should it not be provided', () => {
+        cy.visit(ARTICLE_WITHOUT_OG_DESCRIPTION_URL).then(() => {
+            cy.checkMetaContentProperty(
+                'name="description"',
+                ARTICLE_WITHOUT_OG_META_DESCRIPTION
+            );
+            // An og:description exists, so we should populate the tag with it
+            cy.checkMetaContentProperty(
+                'property="og:description"',
+                ARTICLE_WITHOUT_OG_META_DESCRIPTION
+            );
+        });
     });
 });

--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -30,7 +30,6 @@ import Literal from './Literal';
 import LiteralBlock from './LiteralBlock';
 import LiteralInclude from './LiteralInclude';
 import Meta from './Meta';
-import MetaDescription from './meta-description';
 import Paragraph from './Paragraph';
 import Reference from './Reference';
 import RefRole from './RefRole';
@@ -98,7 +97,6 @@ export default class ComponentFactory extends Component {
             literal_block: LiteralBlock,
             literalinclude: LiteralInclude,
             meta: Meta,
-            'meta-description': MetaDescription,
             only: Cond,
             paragraph: Paragraph,
             ref_role: RefRole,

--- a/src/components/dev-hub/SEO.js
+++ b/src/components/dev-hub/SEO.js
@@ -17,6 +17,8 @@ const SEO = ({
     articleTitle,
     canonicalUrl,
     image,
+    metaDescription,
+    ogDescription,
     ogTitle,
     ogUrl,
     type,
@@ -31,8 +33,21 @@ const SEO = ({
     const twitterImgSrc = twitter.image
         ? getImageSrc(twitter.image, siteUrl)
         : null;
+    const effectiveMetaDescription = metaDescription || ogDescription;
+    const effectiveOgDescription = ogDescription || metaDescription;
     return (
         <Helmet>
+            {/* meta description Tag */}
+            {effectiveMetaDescription && (
+                <meta name="description" content={effectiveMetaDescription} />
+            )}
+            {/* og:description Tag */}
+            {effectiveOgDescription && (
+                <meta
+                    property="og:description"
+                    content={effectiveOgDescription}
+                />
+            )}
             {/* Type Tag */}
             {type && <meta property="og:type" content={type} />}
 

--- a/src/components/meta-description.js
+++ b/src/components/meta-description.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import { Helmet } from 'react-helmet';
-import { getNestedText } from '../utils/get-nested-text';
-
-export default ({ nodeData: { children } }) => (
-    <Helmet>
-        <meta property="og:description" content={getNestedText(children)} />
-    </Helmet>
-);

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -19,6 +19,7 @@ import ShareMenu from '../components/dev-hub/share-menu';
 import ContentsMenu from '../components/dev-hub/contents-menu';
 import { getNestedValue } from '../utils/get-nested-value';
 import { findSectionHeadings } from '../utils/find-section-headings';
+import { getNestedText } from '../utils/get-nested-text';
 /**
  * Name map of directives we want to display in an article
  */
@@ -26,7 +27,6 @@ const contentNodesMap = {
     introduction: true,
     prerequisites: true,
     content: true,
-    'meta-description': true,
     summary: true,
 };
 
@@ -118,7 +118,14 @@ const Article = props => {
     const contentNodes = getContent(childNodes);
     const meta = dlv(__refDocMapping, 'query_fields');
     const og = meta.og || {};
+    const ogDescription =
+        og.children && og.children.length ? getNestedText(og.children) : null;
     const twitterNode = childNodes.find(node => node.name === 'twitter');
+    const metaDescriptionNode = childNodes.find(
+        node => node.name === 'meta-description'
+    );
+    const metaDescription =
+        metaDescriptionNode && getNestedText(metaDescriptionNode.children);
     const articleBreadcrumbs = [
         { label: 'Home', target: '/' },
         { label: 'Learn', target: '/learn' },
@@ -158,6 +165,8 @@ const Article = props => {
                 articleTitle={articleTitle}
                 canonicalUrl={canonicalUrl}
                 image={og.image}
+                metaDescription={metaDescription}
+                ogDescription={ogDescription}
                 ogTitle={og.title || articleTitle}
                 ogUrl={og.url || articleUrl}
                 twitterNode={twitterNode}


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DEVHUB-190)
[Staging (Article with og description in addition to meta description)](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-190/article/3-things-to-know-switch-from-sql-mongodb)
[Staging (Article with just a meta description)](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-190/article/active-active-application-architectures)

This PR incorporates an `og:description` for SEO on an article where appropriate. The rules are as follows:
- For the `og:description` tag, we use the og description if the article provides it. If the article does not provide an og description, we fallback to the meta description.
- For the meta `description` tag, we use the meta description if the article provides it. If the article does not provide this field, we fallback with the og description
- If neither are provided (very unlikely to happen), neither tag will render

The top staging link is for an article I updated to have a distince `og:description`. You can check the page source and see the distinction as such (and in the cypress tests!):
![Screen Shot 2020-08-20 at 10 48 05 AM](https://user-images.githubusercontent.com/9064401/90787972-49104000-e2d3-11ea-992c-c8485401fbb8.png)

The bottom link is for an article without an og:description provided. The `og:description` and meta `description` tags have identical content here.