### PR TITLE
DEVHUB-169: Add Support for Optional SEO Fields

### DIFF
--- a/cypress/integration/article.js
+++ b/cypress/integration/article.js
@@ -2,11 +2,13 @@ const ARTICLE_WITH_SERIES_URL =
     '/article/3-things-to-know-switch-from-sql-mongodb';
 const PROD_ARTICLE_URL = `https://developer.mongodb.com${ARTICLE_WITH_SERIES_URL}`;
 
-// Article with no og description (test meta description fallback)
-const ARTICLE_WITHOUT_OG_DESCRIPTION_URL =
+// Article with no og description or og type (test meta description fallback)
+const ARTICLE_WITH_MINIMAL_OG_URL =
     '/article/active-active-application-architectures';
 const ARTICLE_WITHOUT_OG_META_DESCRIPTION =
     'This post will begin by describing the database capabilities required by modern multi-data center applications.';
+const DEFAULT_OG_TYPE = 'article';
+const DEFAULT_TWITTER_SITE = '@mongodb';
 
 const ARTICLE_TITLE = '3 Things to Know When You Switch from SQL to MongoDB';
 const ARTICLE_DESCRIPTION =
@@ -105,8 +107,7 @@ describe('Sample Article Page', () => {
         cy.checkMetaContentProperty('property="og:title"', ARTICLE_TITLE);
         cy.checkMetaContentProperty(
             'property="og:url"',
-            // This would match the PROD_ARTICLE_URL but it has http and not https
-            OG_URL
+            'http://developer-test.mongodb.com/article/3-things-to-know-switch-from-sql-mongodb'
         );
         // An og:description exists, so we should populate the tag with it
         cy.checkMetaContentProperty(
@@ -122,7 +123,10 @@ describe('Sample Article Page', () => {
             '@Lauren_Schaefer'
         );
         cy.checkMetaContentProperty('name="twitter:card"', 'summary');
-        cy.checkMetaContentProperty('name="twitter:site"', '@mongodb');
+        cy.checkMetaContentProperty(
+            'name="twitter:site"',
+            '@test-twitter-site'
+        );
         cy.checkMetaContentProperty('property="twitter:title"', ARTICLE_TITLE);
         cy.checkMetaContentProperty(
             'property="twitter:description"',
@@ -132,7 +136,7 @@ describe('Sample Article Page', () => {
     });
 
     it('should automatically populate the og description tag should it not be provided', () => {
-        cy.visit(ARTICLE_WITHOUT_OG_DESCRIPTION_URL).then(() => {
+        cy.visit(ARTICLE_WITH_MINIMAL_OG_URL).then(() => {
             cy.checkMetaContentProperty(
                 'name="description"',
                 ARTICLE_WITHOUT_OG_META_DESCRIPTION
@@ -141,6 +145,15 @@ describe('Sample Article Page', () => {
             cy.checkMetaContentProperty(
                 'property="og:description"',
                 ARTICLE_WITHOUT_OG_META_DESCRIPTION
+            );
+        });
+    });
+    it('should automatically populate the type tag should it not be provided', () => {
+        cy.visit(ARTICLE_WITH_MINIMAL_OG_URL).then(() => {
+            cy.checkMetaContentProperty('property="og:type"', DEFAULT_OG_TYPE);
+            cy.checkMetaContentProperty(
+                'name="twitter:site"',
+                DEFAULT_TWITTER_SITE
             );
         });
     });

--- a/cypress/integration/article.js
+++ b/cypress/integration/article.js
@@ -104,7 +104,7 @@ describe('Sample Article Page', () => {
         cy.title().should('eq', ARTICLE_TITLE).end();
 
         // Check og tags
-        cy.checkMetaContentProperty('property="og:type"', 'article');
+        cy.checkMetaContentProperty('property="og:type"', 'text');
         cy.checkMetaContentProperty('property="og:title"', ARTICLE_TITLE);
         cy.checkMetaContentProperty(
             'property="og:url"',

--- a/cypress/integration/article.js
+++ b/cypress/integration/article.js
@@ -5,6 +5,7 @@ const PROD_ARTICLE_URL = `https://developer.mongodb.com${ARTICLE_WITH_SERIES_URL
 // Article with no og description or og type (test meta description fallback)
 const ARTICLE_WITH_MINIMAL_OG_URL =
     '/article/active-active-application-architectures';
+const PROD_MINIMAL_ARTICLE_URL = `https://developer.mongodb.com${ARTICLE_WITH_MINIMAL_OG_URL}`;
 const ARTICLE_WITHOUT_OG_META_DESCRIPTION =
     'This post will begin by describing the database capabilities required by modern multi-data center applications.';
 const DEFAULT_OG_TYPE = 'article';
@@ -150,6 +151,10 @@ describe('Sample Article Page', () => {
     });
     it('should automatically populate the type tag should it not be provided', () => {
         cy.visit(ARTICLE_WITH_MINIMAL_OG_URL).then(() => {
+            cy.checkMetaContentProperty(
+                'property="og:url"',
+                PROD_MINIMAL_ARTICLE_URL
+            );
             cy.checkMetaContentProperty('property="og:type"', DEFAULT_OG_TYPE);
             cy.checkMetaContentProperty(
                 'name="twitter:site"',

--- a/src/components/dev-hub/SEO.js
+++ b/src/components/dev-hub/SEO.js
@@ -3,6 +3,7 @@ import { Helmet } from 'react-helmet';
 import { useSiteMetadata } from '../../hooks/use-site-metadata';
 import { getNestedText } from '../../utils/get-nested-text';
 
+const DEFAULT_OG_TYPE = 'article';
 const DEFAULT_TWITTER_SITE = '@mongodb';
 const isExternalUrl = /^http(s)?:\/\//;
 
@@ -23,7 +24,7 @@ const SEO = ({
     ogTitle,
     ogUrl,
     twitterNode,
-    type = 'article',
+    type,
 }) => {
     const twitter = twitterNode ? twitterNode.options : {};
     const twitterDescription = twitterNode
@@ -36,6 +37,7 @@ const SEO = ({
         : null;
     const effectiveMetaDescription = metaDescription || ogDescription;
     const effectiveOgDescription = ogDescription || metaDescription;
+    const effectiveOgType = type || DEFAULT_OG_TYPE;
     const effectiveTwitterSite = twitter.site || DEFAULT_TWITTER_SITE;
     return (
         <Helmet>
@@ -51,7 +53,7 @@ const SEO = ({
                 />
             )}
             {/* Type Tag */}
-            <meta property="og:type" content={type} />
+            <meta property="og:type" content={effectiveOgType} />
 
             {/* og:image Tag */}
             {ogImgSrc && <meta property="og:image" content={ogImgSrc} />}

--- a/src/components/dev-hub/SEO.js
+++ b/src/components/dev-hub/SEO.js
@@ -3,6 +3,7 @@ import { Helmet } from 'react-helmet';
 import { useSiteMetadata } from '../../hooks/use-site-metadata';
 import { getNestedText } from '../../utils/get-nested-text';
 
+const DEFAULT_TWITTER_SITE = '@mongodb';
 const isExternalUrl = /^http(s)?:\/\//;
 
 const getImageSrc = (src, siteUrl) => {
@@ -21,8 +22,8 @@ const SEO = ({
     ogDescription,
     ogTitle,
     ogUrl,
-    type,
     twitterNode,
+    type = 'article',
 }) => {
     const twitter = twitterNode ? twitterNode.options : {};
     const twitterDescription = twitterNode
@@ -35,6 +36,7 @@ const SEO = ({
         : null;
     const effectiveMetaDescription = metaDescription || ogDescription;
     const effectiveOgDescription = ogDescription || metaDescription;
+    const effectiveTwitterSite = twitter.site || DEFAULT_TWITTER_SITE;
     return (
         <Helmet>
             {/* meta description Tag */}
@@ -49,7 +51,7 @@ const SEO = ({
                 />
             )}
             {/* Type Tag */}
-            {type && <meta property="og:type" content={type} />}
+            <meta property="og:type" content={type} />
 
             {/* og:image Tag */}
             {ogImgSrc && <meta property="og:image" content={ogImgSrc} />}
@@ -72,9 +74,7 @@ const SEO = ({
             {twitterImgSrc && (
                 <meta name="twitter:image" content={twitterImgSrc} />
             )}
-            {twitter.site && (
-                <meta name="twitter:site" content={twitter.site} />
-            )}
+            <meta name="twitter:site" content={effectiveTwitterSite} />
             {twitter.title && (
                 <meta property="twitter:title" content={twitter.title} />
             )}

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -138,7 +138,7 @@ const Article = props => {
     }
     const tagList = getTagLinksFromMeta(meta);
     const articleTitle = dlv(meta.title, [0, 'value'], thisPage);
-    const articleUrl = `${siteUrl}/${thisPage}/`;
+    const articleUrl = `${siteUrl}/${thisPage}`;
     const headingNodes = findSectionHeadings(
         getNestedValue(['ast', 'children'], __refDocMapping),
         'type',
@@ -170,7 +170,7 @@ const Article = props => {
                 ogTitle={og.title || articleTitle}
                 ogUrl={og.url || articleUrl}
                 twitterNode={twitterNode}
-                type={og.type || 'article'}
+                type={og.type}
             />
             <BlogPostTitleArea
                 articleImage={withPrefix(meta['atf-image'])}


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DEVHUB-169)
[Staged Article With Relevant Tags](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-169/article/3-things-to-know-switch-from-sql-mongodb)
[Staged Article Without Relevant Tags Rendered](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-169/article/active-active-application-architectures)

This PR builds off of some previous SEO work to allow writers to omit several SEO fields, including:
- `twitter:site` (defaults to `@mongodb`)
- `og:url` (defaults to the expected url)
- `og:type` (defaults to `article`)

After this change, writers can omit these fields from their rSTs and have the expected value populate for them. I did the same in the devhub content integration repo (I can't link here because a fork of a private repo must be private) and added that into our testing library.

To verify, please check the meta tags of the 2nd article match these expected values. The meta tags for the first should be distinct, meaning we defined them all to be different in the source rST. If you want to see these rSTs slack me and I can send them over (I guess that is the easiest way?)