### PR TITLE
DEVHUB-205: Add support for statcounter

### DIFF
--- a/cypress/integration/article.js
+++ b/cypress/integration/article.js
@@ -32,6 +32,7 @@ const OG_URL =
 const TWITTER_SHARE_URL = `https://twitter.com/intent/tweet?url=${PROD_ARTICLE_URL}&text=3%20Things%20to%20Know%20When%20You%20Switch%20from%20SQL%20to%20MongoDB`;
 
 const SOCIAL_URLS = [LINKEDIN_SHARE_URL, TWITTER_SHARE_URL, FACEBOOK_SHARE_URL];
+const STATCOUNTER_URL = 'https://www.statcounter.com/counter/counter.js';
 
 describe('Sample Article Page', () => {
     it('should have a descriptive header', () => {
@@ -134,6 +135,10 @@ describe('Sample Article Page', () => {
             ARTICLE_DESCRIPTION
         );
         cy.checkMetaContentProperty('name="twitter:image"', TWITTER_IMAGE);
+    });
+
+    it('should contain the statcounter script tag', () => {
+        cy.checkScriptExists(`src="${STATCOUNTER_URL}"`);
     });
 
     it('should automatically populate the og description tag should it not be provided', () => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -31,6 +31,10 @@ Cypress.Commands.add('checkMetaContentProperty', (query, value) => {
     cy.get(`head meta[${query}]`).should('have.prop', 'content', value);
 });
 
+Cypress.Commands.add('checkScriptExists', query => {
+    cy.get(`body script[${query}]`).should('exist');
+});
+
 // Mock data from events servers
 Cypress.Commands.add('mockEventsApi', () => {
     cy.fixture('liveEventData.json').as('liveEventData');

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export const onRenderBody = ({ setPostBodyComponents }) => {
+    setPostBodyComponents([
+        <script type="text/javascript" key="add-statcounter-vars">
+            var sc_project=12381202; var sc_invisible=1; var
+            sc_security=`0c785d57`; var sc_https=1; var sc_remove_link=1;
+        </script>,
+        <script
+            type="text/javascript"
+            src="https://www.statcounter.com/counter/counter.js"
+            async
+            key="add-statcounter-js-file"
+        ></script>,
+        <noscript key="statcounter-noscript">
+            <div className="statcounter">
+                <img
+                    className="statcounter"
+                    src="https://c.statcounter.com/12381202/0/0c785d57/1/"
+                    alt="Web Analytics Made Easy - StatCounter"
+                />
+            </div>
+        </noscript>,
+    ]);
+};


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DEVHUB-205)
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-205/)

This PR adds several requested statcounter tags to the bottom of each page (see JIRA). The approach I took was to use a Gatsby plugin option called `onRenderBody`, which gives an option to specify tags to put at the end of the `body` tag.

To verify, each page should have tags within `body` towards the bottom that look like this:
![Screen Shot 2020-08-25 at 4 06 17 PM](https://user-images.githubusercontent.com/9064401/91222877-cd0c6280-e6ed-11ea-8643-28915d010c12.png)

I added a cypress test just to verify one of the tags exists (felt that was strong enough)
