### PR TITLE
DEVHUB-202: Add Second RSS Feed for Text Filter

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,6 +2,7 @@ const { siteUrl } = require('./src/queries/site-url');
 const { generatePathPrefix } = require('./src/utils/generate-path-prefix');
 const { getMetadata } = require('./src/utils/get-metadata');
 const { articleRssFeed } = require('./src/utils/setup/article-rss-feed');
+const { searchRssFeed } = require('./src/utils/setup/search-rss-feed');
 
 const runningEnv = process.env.NODE_ENV || 'production';
 
@@ -40,7 +41,7 @@ module.exports = {
             resolve: 'gatsby-plugin-feed',
             options: {
                 query: siteUrl,
-                feeds: [articleRssFeed],
+                feeds: [articleRssFeed, searchRssFeed],
             },
         },
         'gatsby-plugin-meta-redirect', // this must be last

--- a/gatsby-config.prod.js
+++ b/gatsby-config.prod.js
@@ -1,6 +1,7 @@
 const { siteUrl } = require('./src/queries/site-url');
 const { getMetadata } = require('./src/utils/get-metadata');
 const { articleRssFeed } = require('./src/utils/setup/article-rss-feed');
+const { searchRssFeed } = require('./src/utils/setup/search-rss-feed');
 
 require('dotenv').config({
     path: '.env.production',
@@ -37,7 +38,7 @@ module.exports = {
             resolve: 'gatsby-plugin-feed',
             options: {
                 query: siteUrl,
-                feeds: [articleRssFeed],
+                feeds: [articleRssFeed, searchRssFeed],
             },
         },
         `gatsby-plugin-meta-redirect`, // this must be last

--- a/src/queries/search-article-rss-data.js
+++ b/src/queries/search-article-rss-data.js
@@ -1,0 +1,19 @@
+const searchArticleRSSData = `
+    query searchArticleRSSData {
+        allArticle(sort: {fields: pubdate, order: DESC}) {
+            nodes {
+              authors {
+                name
+              }
+                slug: id
+                description
+                pubdate
+                tags
+                title
+                type
+            }
+        }
+    }
+`;
+
+module.exports = { searchArticleRSSData };

--- a/src/utils/setup/create-article-node.js
+++ b/src/utils/setup/create-article-node.js
@@ -18,9 +18,12 @@ export const createArticleNode = (
     slugContentMapping[slug] = doc;
     if (isArticlePage) {
         const content = {
-            title: getNestedText(doc.query_fields['title']),
+            authors: doc.query_fields['author'],
             description: getNestedText(doc.query_fields['meta-description']),
             pubdate: doc.query_fields['pubdate'],
+            tags: doc.query_fields['tags'],
+            title: getNestedText(doc.query_fields['title']),
+            type: doc.query_fields['type'],
         };
         createNode({
             id: slug,

--- a/src/utils/setup/search-rss-feed.js
+++ b/src/utils/setup/search-rss-feed.js
@@ -9,7 +9,7 @@ const searchRssFeed = {
     serialize: serializeSearchRssData,
     query: searchArticleRSSData,
     output: '/search-rss.xml',
-    title: 'MongoDB Developer Hub',
+    title: 'MongoDB Developer Hub (Expanded)',
     site_url: siteUrl,
     feed_url: siteUrl + '/search-rss.xml',
 };

--- a/src/utils/setup/search-rss-feed.js
+++ b/src/utils/setup/search-rss-feed.js
@@ -1,0 +1,17 @@
+const {
+    searchArticleRSSData,
+} = require('../../queries/search-article-rss-data');
+const { serializeSearchRssData } = require('./serialize-search-rss-data');
+
+const siteUrl = 'https://developer.mongodb.com';
+
+const searchRssFeed = {
+    serialize: serializeSearchRssData,
+    query: searchArticleRSSData,
+    output: '/search-rss.xml',
+    title: 'MongoDB Developer Hub',
+    site_url: siteUrl,
+    feed_url: siteUrl + '/search-rss.xml',
+};
+
+module.exports = { searchRssFeed };

--- a/src/utils/setup/serialize-search-rss-data.js
+++ b/src/utils/setup/serialize-search-rss-data.js
@@ -1,17 +1,25 @@
+const getCustomRSSElements = article => {
+    const authorNames = article.authors
+        ? [...article.authors.map(a => ({ author_name: a.name }))]
+        : [];
+    const tags = article.tags ? [...article.tags.map(t => ({ tag: t }))] : [];
+    const customElements = [{ type: article.type }];
+    if (authorNames.length) {
+        customElements.push({ author_names: authorNames });
+    }
+    if (tags.length) {
+        customElements.push({ tags: tags });
+    }
+    return customElements;
+};
+
 const serializeSearchRssData = ({ query: { site, allArticle } }) =>
-    allArticle.nodes.map(article => {
-        const authorNames = article.authors.map(a => a.name);
-        return {
-            custom_elements: [
-                { type: article.type },
-                ...authorNames.map(a => ({ author_name: a })),
-            ],
-            categories: article.tags,
-            date: article.pubdate,
-            description: article.description,
-            title: article.title,
-            url: `${site.siteMetadata.siteUrl}/${article.slug}`,
-        };
-    });
+    allArticle.nodes.map(article => ({
+        custom_elements: getCustomRSSElements(article),
+        date: article.pubdate,
+        description: article.description,
+        title: article.title,
+        url: `${site.siteMetadata.siteUrl}/${article.slug}`,
+    }));
 
 module.exports = { serializeSearchRssData };

--- a/src/utils/setup/serialize-search-rss-data.js
+++ b/src/utils/setup/serialize-search-rss-data.js
@@ -1,0 +1,17 @@
+const serializeSearchRssData = ({ query: { site, allArticle } }) =>
+    allArticle.nodes.map(article => {
+        const authorNames = article.authors.map(a => a.name);
+        return {
+            custom_elements: [
+                { type: article.type },
+                ...authorNames.map(a => ({ author_name: a })),
+            ],
+            categories: article.tags,
+            date: article.pubdate,
+            description: article.description,
+            title: article.title,
+            url: `${site.siteMetadata.siteUrl}/${article.slug}`,
+        };
+    });
+
+module.exports = { serializeSearchRssData };

--- a/tests/utils/create-article-node.test.js
+++ b/tests/utils/create-article-node.test.js
@@ -2,18 +2,24 @@ import { createArticleNode } from '../../src/utils/setup/create-article-node';
 
 describe('Should properly postprocess an article node after it is fetched', () => {
     const pageIdPrefix = 'test-pages/test';
+    const articleAuthors = [{ name: 'Author One' }, { name: 'Author Two' }];
     const articleDescription = 'Article Description';
     const articlePubdate = '2030-01-01';
     const articleSlug = 'article/test-article';
+    const articleTags = ['first-tag', 'second-tag'];
     const articleTitle = 'Test Article';
+    const articleType = 'quickstart';
     const articleNode = {
         ast: {
             children: [],
         },
         query_fields: {
+            author: articleAuthors,
             'meta-description': [{ type: 'text', value: articleDescription }],
             pubdate: articlePubdate,
+            tags: articleTags,
             title: [{ type: 'text', value: articleTitle }],
+            type: articleType,
         },
         filename: `${articleSlug}.txt`,
         page_id: `${pageIdPrefix}/${articleSlug}`,
@@ -79,9 +85,12 @@ describe('Should properly postprocess an article node after it is fetched', () =
         expect(createdArticleNode.internal.contentDigest).not.toBeUndefined();
         expect(createContentDigest.mock.calls.length).toBe(1);
         const contentToDigest = {
-            title: articleTitle,
-            pubdate: articlePubdate,
+            authors: articleAuthors,
             description: articleDescription,
+            pubdate: articlePubdate,
+            tags: articleTags,
+            title: articleTitle,
+            type: articleType,
         };
         expect(createContentDigest.mock.calls[0][0]).toStrictEqual(
             contentToDigest


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DEVHUB-202)
[Staging RSS Feed File](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-202/search-rss.xml)

Deepak has asked for a second DevHub RSS feed, this time adding some custom fields relating to search. Initially I was thinking of adding to the existing feed but we decided to just keep this separate should we want to change the Search logic (he will be pulling from the generated XML file).

I've verified this format works for Deepak so we should be good on when to include/exclude fields, but will leave some PR comments.

To do so, we did the following things:
- Add the new fields `type`, `authors` (with name), and `tags` for an article into its GraphQL node
- Create a new query to query GraphQL for these additional fields for the new RSS feed
- Add new serializer to take GraphQL query response and format into the XML we want
- Hook serializer and config to `gatsby-config` and `gatsby-config.prod`

Check out the above staging RSS file to see it in action!