### PR TITLE
DEVHUB-204 Part 1: UI Scaffolding

### DIFF
--- a/src/components/dev-hub/empty-text-filter-results.js
+++ b/src/components/dev-hub/empty-text-filter-results.js
@@ -1,0 +1,6 @@
+import React from 'react';
+
+// TODO: replace with real empty state
+const EmptyTextFilterResults = () => <p>No results</p>;
+
+export default EmptyTextFilterResults;

--- a/src/components/dev-hub/filter-bar.js
+++ b/src/components/dev-hub/filter-bar.js
@@ -57,7 +57,14 @@ const SelectWrapper = styled('div')`
 `;
 
 export default React.memo(
-    ({ filters, filterValue, setFilterValue, ...props }) => {
+    ({
+        filters,
+        filterValue,
+        setFilterValue,
+        // TODO: Use below to add text input results
+        setTextFilterResults,
+        ...props
+    }) => {
         const initialLanguages = useMemo(
             () => zipFilterObjects(filters.languages),
             [filters.languages]

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -6,6 +6,7 @@ import { H2 } from '../components/dev-hub/text';
 import MediaBlock from '../components/dev-hub/media-block';
 import Card from '../components/dev-hub/card';
 import CardList from '../components/dev-hub/card-list';
+import EmptyTextFilterResults from '../components/dev-hub/empty-text-filter-results';
 import FilterBar from '../components/dev-hub/filter-bar';
 import { screenSize, size } from '../components/dev-hub/theme';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
@@ -196,6 +197,7 @@ export default ({
         allArticles,
     ]);
     const [articles, setArticles] = useState(initialArticles);
+    const [textFilterResults, setTextFilterResults] = useState(null);
     const { search = '', pathname = '' } = location;
     const [filterValue, setFilterValue] = useState(parseQueryString(search));
     const filterActiveArticles = useCallback(
@@ -232,6 +234,25 @@ export default ({
     const leftTabs = ['All'];
     const rightTabs = ['Articles', 'Videos', 'Podcasts'];
 
+    const ActiveCardList = () => {
+        switch (activeItem) {
+            case 'Articles':
+                return <CardList articles={articles} />;
+            case 'Videos':
+                return <CardList videos={videos} />;
+            case 'Podcasts':
+                return <CardList podcasts={podcasts} />;
+            default:
+                return (
+                    <CardList
+                        articles={articles}
+                        videos={hasNoFilter ? videos : []}
+                        podcasts={hasNoFilter ? podcasts : []}
+                    />
+                );
+        }
+    };
+
     return (
         <Layout>
             <Helmet>
@@ -257,19 +278,19 @@ export default ({
                         filters={filters}
                         filterValue={filterValue}
                         setFilterValue={updateFilter}
+                        setTextFilterResults={setTextFilterResults}
                     />
                 )}
 
-                {activeItem === 'All' && (
-                    <CardList
-                        articles={articles}
-                        videos={hasNoFilter ? videos : []}
-                        podcasts={hasNoFilter ? podcasts : []}
-                    />
+                {textFilterResults ? (
+                    textFilterResults.length ? (
+                        <CardList articles={textFilterResults} />
+                    ) : (
+                        <EmptyTextFilterResults />
+                    )
+                ) : (
+                    <ActiveCardList />
                 )}
-                {activeItem === 'Articles' && <CardList articles={articles} />}
-                {activeItem === 'Videos' && <CardList videos={videos} />}
-                {activeItem === 'Podcasts' && <CardList podcasts={podcasts} />}
             </Article>
         </Layout>
     );


### PR DESCRIPTION
[InVision](https://mongodb.invisionapp.com/share/5GWV0HJSXZR#/screens/415163294)
[Staging Link (learn page)](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/js/text-filter-layout/learn)

This PR begins some work to implement the new learn page text filter (see InVision). The goal of this project is to add a new filter for the learn page which will hit a backend to fetch articles to show based on a text query (search, but we are not calling it search). More than happy to give additional context on the project! 

This does some small logic rearrangements on the learn page to be able to render content returned from a text filter query.

Before, we rendered content based on which learn page tab was selected. I moved that logic and replaced this with a `switch` statement, since that's effectively what we were doing before.

I also added a new state variable which we will use to get/set the results of a text filter called `textFilterResults`. Yes, we will be showing *only* the results of the text filter query, we will ignore the other filters altogether.

I also added a basic empty-state (to be filled in) so we can see how this will all tie together. The next step will be adding logic to fetch the results of a text filter query and display.

This PR was built to be able to be merged/deployed without any visible changes (text filter is not yet active), so:

### To Test
- Check that the staging link learn page behaves identically to the existing learn page