### PR TITLE
DEVHUB-204 Part 2: Empty State

### DIFF
--- a/src/components/dev-hub/empty-text-filter-results.js
+++ b/src/components/dev-hub/empty-text-filter-results.js
@@ -1,6 +1,41 @@
 import React from 'react';
+import styled from '@emotion/styled';
+import { lineHeight, screenSize, size } from './theme';
+import { H4, P } from './text';
 
-// TODO: replace with real empty state
-const EmptyTextFilterResults = () => <p>No results</p>;
+const BOTTOM_DESKTOP_MARGIN = '240px';
+const MAX_WIDTH = '360px';
+
+const EmptyStateContainer = styled('div')`
+    color: ${({ theme }) => theme.colorMap.greyLightTwo};
+    display: flex;
+    flex-direction: column;
+    margin: ${size.xxlarge} auto ${BOTTOM_DESKTOP_MARGIN};
+    max-width: ${MAX_WIDTH};
+    text-align: center;
+    @media ${screenSize.upToLarge} {
+        margin: ${size.mediumLarge} auto ${size.xlarge};
+    }
+`;
+
+const StyledH4 = styled(H4)`
+    font-family: akzidenz;
+    font-weight: normal;
+    margin-bottom: ${size.xsmall};
+`;
+
+const StyledP = styled(P)`
+    line-height: ${lineHeight.small};
+`;
+
+const EmptyTextFilterResults = () => (
+    <EmptyStateContainer>
+        <StyledH4>No matching results.</StyledH4>
+        <StyledP>
+            We did not find any articles matching your query, please try with
+            different search query.
+        </StyledP>
+    </EmptyStateContainer>
+);
 
 export default EmptyTextFilterResults;


### PR DESCRIPTION
[InVision](https://mongodb.invisionapp.com/d/main/#/console/19769567/429514727/preview) (Dan also checked and gave LGTM)
[Staging Link](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/js/text-filter-empty/learn/) (Learn Page, Hardcoded Empty State)

This PR continue with the text filter work and adds in the desired empty state. Note for the staging link I hardcoded it in for an easier time reviewing, this is not an actual change.

![Screen Shot 2020-08-26 at 3 08 57 PM](https://user-images.githubusercontent.com/9064401/91346311-a5c99a00-e7ae-11ea-8314-712d64c8183c.png)
