### PR TITLE
add useFetch debounce hook

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -36,5 +36,15 @@ module.exports = {
                 '^.+\\.jsx?$': `<rootDir>/jest-preprocess.js`,
             },
         },
+        {
+            displayName: 'hooks',
+            globals: {
+                __PATH_PREFIX__: '',
+            },
+            testMatch: ['<rootDir>/tests/hooks/*.test.js'],
+            transform: {
+                '^.+\\.jsx?$': `<rootDir>/jest-preprocess.js`,
+            },
+        },
     ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5770,6 +5770,15 @@
         "@testing-library/dom": "^5.6.1"
       }
     },
+    "@testing-library/react-hooks": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-3.4.1.tgz",
+      "integrity": "sha512-LbzvE7oKsVzuW1cxA/aOeNgeVvmHWG2p/WSzalIGyWuqZT3jVcNDT5KPEwy36sUYWde0Qsh32xqIUFXukeywXg==",
+      "requires": {
+        "@babel/runtime": "^7.5.4",
+        "@types/testing-library__react-hooks": "^3.3.0"
+      }
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -6033,6 +6042,14 @@
         "@types/react": "*"
       }
     },
+    "@types/react-test-renderer": {
+      "version": "16.9.3",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-16.9.3.tgz",
+      "integrity": "sha512-wJ7IlN5NI82XMLOyHSa+cNN4Z0I+8/YaLl04uDgcZ+W+ExWCmCiVTLT/7fRNqzy4OhStZcUwIqLNF7q+AdW43Q==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-textarea-autosize": {
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/@types/react-textarea-autosize/-/react-textarea-autosize-4.3.5.tgz",
@@ -6080,6 +6097,14 @@
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.5.tgz",
       "integrity": "sha512-/gG2M/Imw7cQFp8PGvz/SwocNrmKFjFsm5Pb8HdbHkZ1K8pmuPzOX4VeVoiEecFCVf4CsN1r3/BRvx+6sNqwtQ==",
       "dev": true
+    },
+    "@types/testing-library__react-hooks": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.4.0.tgz",
+      "integrity": "sha512-QYLZipqt1hpwYsBU63Ssa557v5wWbncqL36No59LI7W3nCMYKrLWTnYGn2griZ6v/3n5nKXNYkTeYpqPHY7Ukg==",
+      "requires": {
+        "@types/react-test-renderer": "*"
+      }
     },
     "@types/tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@emotion/styled": "^10.0.27",
     "@leafygreen-ui/checkbox": "^4.0.1",
     "@leafygreen-ui/code": "^3.4.4",
+    "@testing-library/react-hooks": "^3.4.1",
     "copy-to-clipboard": "^3.3.1",
     "css-loader": "^3.5.3",
     "dlv": "^1.1.3",

--- a/src/hooks/use-fetch.js
+++ b/src/hooks/use-fetch.js
@@ -7,6 +7,12 @@ const getErrorMessage = (response, method) =>
         ? `${method} Error: ${response.status} - ${response.statusText}`
         : `${method} Error: Did not receive a response from the server`;
 
+/**
+ * Hook with option to debounce to fetch data (GET) and provide any postprocessing
+ * @param {*} url The url to fetch from
+ * @param {*} postprocessData Manipulations to data to be done after a fetch
+ * @param {*} debounceTime (Optional) if provided, will debounce the fetch based on this number of ms
+ */
 function useFetch(url, postprocessData, debounceTime) {
     const [data, setData] = useState(null);
     const [error, setError] = useState(null);

--- a/src/hooks/use-fetch.js
+++ b/src/hooks/use-fetch.js
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const isBadResponse = response => !response || (response && !response.ok);
+
+const getErrorMessage = (response, method) =>
+    response
+        ? `${method} Error: ${response.status} - ${response.statusText}`
+        : `${method} Error: Did not receive a response from the server`;
+
+function useFetch(url, postprocessData, debounceTime) {
+    const [data, setData] = useState(null);
+    const [error, setError] = useState(null);
+    const [fetchEvent, setFetchEvent] = useState(null);
+    const fetchData = useCallback(async () => {
+        const resp = await fetch(url);
+        if (isBadResponse(resp)) {
+            console.log('ERROR FOUND');
+            throw new Error(getErrorMessage(resp, 'GET'));
+        }
+        const parsedData = await postprocessData(resp);
+        if (parsedData) {
+            setError(null);
+            setData(parsedData);
+        }
+    }, [postprocessData, url]);
+    useEffect(() => {
+        const getData = async () => {
+            if (debounceTime) {
+                if (fetchEvent) {
+                    clearTimeout(fetchEvent);
+                }
+                setFetchEvent(setTimeout(fetchData, debounceTime));
+            } else {
+                try {
+                    fetchData();
+                } catch (e) {
+                    console.log('caught error');
+                    console.warn(e);
+                    setError(e);
+                    setData(null);
+                }
+            }
+        };
+        getData();
+        // Disabling exhaustive dep check, since we don't want to run this effect
+        // every time fetchEvent is updated (which would cause an infinite loop)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [debounceTime, fetchData, url]);
+
+    return { data, error };
+}
+
+export default useFetch;

--- a/src/hooks/use-fetch.js
+++ b/src/hooks/use-fetch.js
@@ -9,11 +9,12 @@ const getErrorMessage = (response, method) =>
 
 /**
  * Hook with option to debounce to fetch JSON data (GET requests)
+ * Returns an erorr message if one, and a Response if successful
  * @param {*} url The url to fetch from
  * @param {*} debounceTime (Optional) if provided, will debounce the fetch based on this number of ms
  */
 function useFetch(url, debounceTime) {
-    const [data, setData] = useState(null);
+    const [response, setResponse] = useState(null);
     const [error, setError] = useState(null);
     const [fetchEvent, setFetchEvent] = useState(null);
     const fetchData = async () => {
@@ -22,13 +23,10 @@ function useFetch(url, debounceTime) {
             const errorMessage = getErrorMessage(resp, 'GET');
             console.warn(errorMessage);
             setError(errorMessage);
-            setData(null);
+            setResponse(null);
         } else {
-            const jsonData = await resp.json();
-            if (jsonData) {
-                setError(null);
-                setData(jsonData);
-            }
+            setError(null);
+            setResponse(resp);
         }
     };
     useEffect(() => {
@@ -48,7 +46,7 @@ function useFetch(url, debounceTime) {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [debounceTime, url]);
 
-    return { data, error };
+    return { error, response };
 }
 
 export default useFetch;

--- a/src/hooks/use-fetch.js
+++ b/src/hooks/use-fetch.js
@@ -8,12 +8,11 @@ const getErrorMessage = (response, method) =>
         : `${method} Error: Did not receive a response from the server`;
 
 /**
- * Hook with option to debounce to fetch data (GET) and provide any postprocessing
+ * Hook with option to debounce to fetch JSON data (GET requests)
  * @param {*} url The url to fetch from
- * @param {*} postprocessData Manipulations to data to be done after a fetch
  * @param {*} debounceTime (Optional) if provided, will debounce the fetch based on this number of ms
  */
-function useFetch(url, postprocessData, debounceTime) {
+function useFetch(url, debounceTime) {
     const [data, setData] = useState(null);
     const [error, setError] = useState(null);
     const [fetchEvent, setFetchEvent] = useState(null);
@@ -25,10 +24,10 @@ function useFetch(url, postprocessData, debounceTime) {
             setError(errorMessage);
             setData(null);
         } else {
-            const parsedData = await postprocessData(resp);
-            if (parsedData) {
+            const jsonData = await resp.json();
+            if (jsonData) {
                 setError(null);
-                setData(parsedData);
+                setData(jsonData);
             }
         }
     };

--- a/tests/hooks/use-fetch.test.js
+++ b/tests/hooks/use-fetch.test.js
@@ -35,20 +35,18 @@ describe('Use Fetch', () => {
     });
 
     test('should return an error if any are thrown', async () => {
-        // const { warn } = console;
-        // console.warn = jest.fn();
-        // window.fetch.mockReturnValue(mockFailApi);
-        // const { result, waitForNextUpdate } = renderHook(() =>
-        //     useFetch('/url', x => x.json())
-        // );
-        // await waitForNextUpdate();
-        // await waitForNextUpdate();
-        // console.log(result.current);
-        // const { data, error } = result.current;
-        // expect(data).toEqual(null);
-        // expect(console.warn).toHaveBeenCalledTimes(1);
-        // expect(error).not.toBeNull();
-        // console.warn = warn;
-        // cleanup();
+        const { warn } = console;
+        console.warn = jest.fn();
+        window.fetch.mockReturnValue(mockFailApi);
+        const { result, waitForNextUpdate } = renderHook(() =>
+            useFetch('/url', x => x.json())
+        );
+        await waitForNextUpdate();
+        const { data, error } = result.current;
+        expect(data).toEqual(null);
+        expect(console.warn).toHaveBeenCalledTimes(1);
+        expect(error).not.toBeNull();
+        console.warn = warn;
+        cleanup();
     });
 });

--- a/tests/hooks/use-fetch.test.js
+++ b/tests/hooks/use-fetch.test.js
@@ -1,0 +1,54 @@
+import useFetch from '../../src/hooks/use-fetch';
+import { cleanup, renderHook } from '@testing-library/react-hooks';
+
+const sampleSuccess = {
+    someResult:
+        "I'm an example of a success response. This hook is meant to provide #request() capabilities in hook format",
+};
+
+const mockSuccessApi = {
+    ok: true,
+    json() {
+        return sampleSuccess;
+    },
+};
+
+const mockFailApi = {
+    ok: false,
+    json() {
+        return new Error('An error occured');
+    },
+};
+window.fetch = jest.fn();
+
+describe('Use Fetch', () => {
+    test('should get data', async () => {
+        window.fetch.mockReturnValue(mockSuccessApi);
+        const { result, waitForNextUpdate } = renderHook(() =>
+            useFetch('/url', x => x.json())
+        );
+        await waitForNextUpdate();
+        const { data, error } = result.current;
+        expect(data).toEqual(sampleSuccess);
+        expect(error).toEqual(null);
+        cleanup();
+    });
+
+    test('should return an error if any are thrown', async () => {
+        // const { warn } = console;
+        // console.warn = jest.fn();
+        // window.fetch.mockReturnValue(mockFailApi);
+        // const { result, waitForNextUpdate } = renderHook(() =>
+        //     useFetch('/url', x => x.json())
+        // );
+        // await waitForNextUpdate();
+        // await waitForNextUpdate();
+        // console.log(result.current);
+        // const { data, error } = result.current;
+        // expect(data).toEqual(null);
+        // expect(console.warn).toHaveBeenCalledTimes(1);
+        // expect(error).not.toBeNull();
+        // console.warn = warn;
+        // cleanup();
+    });
+});

--- a/tests/hooks/use-fetch.test.js
+++ b/tests/hooks/use-fetch.test.js
@@ -28,7 +28,7 @@ describe('Use Fetch', () => {
     test('should get data', async () => {
         window.fetch.mockReturnValue(mockSuccessApi);
         const { result, waitForNextUpdate } = renderHook(() =>
-            useFetch('/url', x => x.json())
+            useFetch('/url')
         );
         await waitForNextUpdate();
         const { data, error } = result.current;
@@ -42,7 +42,7 @@ describe('Use Fetch', () => {
         console.warn = jest.fn();
         window.fetch.mockReturnValue(mockFailApi);
         const { result, waitForNextUpdate } = renderHook(() =>
-            useFetch('/url', x => x.json())
+            useFetch('/url')
         );
         await waitForNextUpdate();
         const { data, error } = result.current;
@@ -59,7 +59,7 @@ describe('Use Fetch', () => {
         window.fetch.mockReturnValue(mockSuccessApi);
         let url = '/url';
         const { result, rerender, waitForNextUpdate } = renderHook(() =>
-            useFetch(url, x => x.json(), 1000)
+            useFetch(url, 1000)
         );
         expect(window.fetch).toHaveBeenCalledTimes(0);
         let { data, error } = result.current;

--- a/tests/hooks/use-fetch.test.js
+++ b/tests/hooks/use-fetch.test.js
@@ -19,9 +19,12 @@ const mockFailApi = {
         return new Error('An error occured');
     },
 };
-window.fetch = jest.fn();
 
 describe('Use Fetch', () => {
+    beforeEach(() => {
+        window.fetch = jest.fn();
+    });
+
     test('should get data', async () => {
         window.fetch.mockReturnValue(mockSuccessApi);
         const { result, waitForNextUpdate } = renderHook(() =>
@@ -51,7 +54,6 @@ describe('Use Fetch', () => {
     });
 
     test('should debounce fetch if requested', async () => {
-        window.fetch = jest.fn();
         // Use fake timers for easier control over debounce
         jest.useFakeTimers();
         window.fetch.mockReturnValue(mockSuccessApi);


### PR DESCRIPTION
This PR adds a new hook into the library: `useFetch`

This hook is similar in purpose to the one we have for university but adds the ability to debounce the fetch if requested by passing an optional third param.

For tests, I added the `react-hooks-testing-library` and started with the tests we have on University. I then added a debounce test as well.

We are not using this hook anywhere yet.