### PR TITLE
DEVHUB-202: Add Four Missing Text Filter RSS Fields

### DIFF
--- a/src/queries/search-article-rss-data.js
+++ b/src/queries/search-article-rss-data.js
@@ -5,8 +5,11 @@ const searchArticleRSSData = `
               authors {
                 name
               }
+                atfimage
                 slug: id
                 description
+                languages
+                products
                 pubdate
                 tags
                 title

--- a/src/utils/setup/create-article-node.js
+++ b/src/utils/setup/create-article-node.js
@@ -18,8 +18,11 @@ export const createArticleNode = (
     slugContentMapping[slug] = doc;
     if (isArticlePage) {
         const content = {
+            atfimage: doc.query_fields['atf-image'],
             authors: doc.query_fields['author'],
             description: getNestedText(doc.query_fields['meta-description']),
+            languages: doc.query_fields['languages'],
+            products: doc.query_fields['products'],
             pubdate: doc.query_fields['pubdate'],
             tags: doc.query_fields['tags'],
             title: getNestedText(doc.query_fields['title']),

--- a/src/utils/setup/serialize-search-rss-data.js
+++ b/src/utils/setup/serialize-search-rss-data.js
@@ -1,29 +1,43 @@
+// We want to omit empty fields from the XML entirely
+const handlePossiblyEmptyField = (
+    article,
+    fieldName,
+    tagName,
+    getField = x => x
+) =>
+    article[fieldName]
+        ? [...article[fieldName].map(a => ({ [tagName]: getField(a) }))]
+        : null;
+
 const getCustomRSSElements = article => {
-    const authorNames = article.authors
-        ? [...article.authors.map(a => ({ author_name: a.name }))]
-        : [];
-    const languages = article.languages
-        ? [...article.languages.map(l => ({ language: l }))]
-        : [];
-    const products = article.products
-        ? [...article.products.map(l => ({ product: l }))]
-        : [];
-    const tags = article.tags ? [...article.tags.map(t => ({ tag: t }))] : [];
+    const authorNames = handlePossiblyEmptyField(
+        article,
+        'authors',
+        'author_name',
+        a => a.name
+    );
+    const languages = handlePossiblyEmptyField(
+        article,
+        'languages',
+        'language'
+    );
+    const products = handlePossiblyEmptyField(article, 'products', 'product');
+    const tags = handlePossiblyEmptyField(article, 'tags', 'tag');
     const customElements = [
         { atf_image: article.atfimage },
         { slug: article.slug },
         { type: article.type },
     ];
-    if (authorNames.length) {
+    if (authorNames) {
         customElements.push({ author_names: authorNames });
     }
-    if (languages.length) {
+    if (languages) {
         customElements.push({ languages: languages });
     }
-    if (products.length) {
+    if (products) {
         customElements.push({ products: products });
     }
-    if (tags.length) {
+    if (tags) {
         customElements.push({ tags: tags });
     }
     return customElements;

--- a/src/utils/setup/serialize-search-rss-data.js
+++ b/src/utils/setup/serialize-search-rss-data.js
@@ -2,10 +2,26 @@ const getCustomRSSElements = article => {
     const authorNames = article.authors
         ? [...article.authors.map(a => ({ author_name: a.name }))]
         : [];
+    const languages = article.languages
+        ? [...article.languages.map(l => ({ language: l }))]
+        : [];
+    const products = article.products
+        ? [...article.products.map(l => ({ product: l }))]
+        : [];
     const tags = article.tags ? [...article.tags.map(t => ({ tag: t }))] : [];
-    const customElements = [{ type: article.type }];
+    const customElements = [
+        { atf_image: article.atfimage },
+        { slug: article.slug },
+        { type: article.type },
+    ];
     if (authorNames.length) {
         customElements.push({ author_names: authorNames });
+    }
+    if (languages.length) {
+        customElements.push({ languages: languages });
+    }
+    if (products.length) {
+        customElements.push({ products: products });
     }
     if (tags.length) {
         customElements.push({ tags: tags });

--- a/tests/utils/create-article-node.test.js
+++ b/tests/utils/create-article-node.test.js
@@ -4,18 +4,24 @@ describe('Should properly postprocess an article node after it is fetched', () =
     const pageIdPrefix = 'test-pages/test';
     const articleAuthors = [{ name: 'Author One' }, { name: 'Author Two' }];
     const articleDescription = 'Article Description';
+    const articleLanguages = ['Python'];
+    const articleProducts = ['MongoDB'];
     const articlePubdate = '2030-01-01';
     const articleSlug = 'article/test-article';
     const articleTags = ['first-tag', 'second-tag'];
     const articleTitle = 'Test Article';
     const articleType = 'quickstart';
+    const atfimage = '/path/toimage';
     const articleNode = {
         ast: {
             children: [],
         },
         query_fields: {
+            'atf-image': atfimage,
             author: articleAuthors,
+            languages: articleLanguages,
             'meta-description': [{ type: 'text', value: articleDescription }],
+            products: articleProducts,
             pubdate: articlePubdate,
             tags: articleTags,
             title: [{ type: 'text', value: articleTitle }],
@@ -85,8 +91,11 @@ describe('Should properly postprocess an article node after it is fetched', () =
         expect(createdArticleNode.internal.contentDigest).not.toBeUndefined();
         expect(createContentDigest.mock.calls.length).toBe(1);
         const contentToDigest = {
+            atfimage,
             authors: articleAuthors,
             description: articleDescription,
+            languages: articleLanguages,
+            products: articleProducts,
             pubdate: articlePubdate,
             tags: articleTags,
             title: articleTitle,


### PR DESCRIPTION
For [DEVHUB-202](https://jira.mongodb.org/browse/DEVHUB-202)
[Staging RSS Feed link](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/js/rss-updates/search-rss.xml)
[Master RSS link](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/staging/search-rss.xml)

This PR adds four fields we also need for the text filter work into the RSS feed:
- `atf-image`: the location of the image shown with each article
- `slug`: the location of the article
- `products`: the list of products tags
- `languages`: the list of languages tags

To Verify:
- Check out the staging RSS feed link and compare with master RSS feed link (pick a specific article)
- The only changes should be the additions of these four fields. Nothing else should be different.

Here I looked at one for a COVID article to help verify. We can see the only changes were new field additions, as expected.
![Screen Shot 2020-09-01 at 3 29 32 PM](https://user-images.githubusercontent.com/9064401/91897220-f6863a80-ec67-11ea-855a-22a97cf68a4d.png)
