### PR TITLE
Disable Dropdown Selects when Text Filtering

### DIFF
--- a/src/components/dev-hub/filter-bar.js
+++ b/src/components/dev-hub/filter-bar.js
@@ -145,6 +145,7 @@ export default React.memo(
                     <FilterLabel>Filter By</FilterLabel>
                     <SelectWrapper>
                         <Select
+                            enabled={!textFilterQuery}
                             narrow
                             name="product"
                             choices={products}
@@ -156,6 +157,7 @@ export default React.memo(
                     </SelectWrapper>
                     <SelectWrapper>
                         <Select
+                            enabled={!textFilterQuery}
                             narrow
                             name="language"
                             choices={languages}

--- a/src/components/dev-hub/select.js
+++ b/src/components/dev-hub/select.js
@@ -4,12 +4,7 @@ import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import ArrowheadIcon from './icons/arrowhead-icon';
 import { P } from './text';
-import {
-    fontSize,
-    lineHeight,
-    layer,
-    size,
-} from './theme';
+import { fontSize, lineHeight, layer, size } from './theme';
 
 const BORDER_SIZE = 2;
 const OPTIONS_POSITION_OFFSET = 58;
@@ -32,7 +27,7 @@ const Option = styled('li')`
     white-space: nowrap;
     :focus,
     :hover {
-        background-color:${({ theme }) => theme.colorMap.greyDarkOne};
+        background-color: ${({ theme }) => theme.colorMap.greyDarkOne};
         color: ${({ theme }) => theme.colorMap.devWhite};
     }
 `;
@@ -59,8 +54,9 @@ const StyledCustomSelect = styled('div')`
     /* Adding border without color to prevent jarring visual on expand */
     border: ${BORDER_SIZE}px solid transparent;
     color: ${({ theme }) => theme.colorMap.devWhite};
-    cursor: pointer;
+    cursor: ${({ enabled }) => (enabled ? 'pointer' : 'not-allowed')};
     font-family: 'Fira Mono', monospace;
+    opacity: ${({ enabled }) => (enabled ? 1 : 0.3)};
     position: relative;
     ${({ showOptions, theme }) => showOptions && activeSelectStyles(theme)};
 `;
@@ -81,6 +77,7 @@ const FormSelect = ({
     name,
     choices = [],
     defaultText = '',
+    enabled = true,
     errors = [],
     narrow = false,
     onChange = null,
@@ -93,8 +90,8 @@ const FormSelect = ({
     const [selectText, setSelectText] = useState(defaultText);
     const [showOptions, setShowOptions] = useState(false);
     const selectOnClick = useCallback(() => {
-        setShowOptions(!showOptions);
-    }, [showOptions]);
+        if (enabled) setShowOptions(!showOptions);
+    }, [enabled, showOptions]);
     const selectOptions = typeof choices !== 'undefined' ? choices : children;
     const updateSelectedText = useCallback(
         text => {
@@ -170,12 +167,13 @@ const FormSelect = ({
     return (
         <StyledCustomSelect
             aria-expanded={showOptions}
+            enabled={enabled}
             onBlur={closeOptionsOnBlur}
             onClick={selectOnClick}
             onKeyDown={showOptionsOnEnter}
             role="listbox"
             showOptions={showOptions}
-            tabIndex="0"
+            tabIndex={enabled ? '0' : null}
         >
             <SelectedOption
                 errors={errors}


### PR DESCRIPTION
[Staging Link (Learn Page)](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/js/disabled-selects/)

This PR adds a small but nice piece of functionality in conjunction with the new text filter. When the user is using the text filter, the other filter types (product, language) are unavailable since we are filtering from an external service. This PR disables those filters when unavailable to provide a better experience for the user.

![Screen Shot 2020-09-02 at 3 50 17 PM](https://user-images.githubusercontent.com/9064401/92030103-901b1e00-ed34-11ea-9735-b9dcbf08ec8e.png)

To verify:
- When the text filter input is empty, the dropdowns next to it should be enabled
- When the text filter input is not empty, the dropdowns next to it should be disabled