### PR TITLE
DEVHUB-220: Relative Link Fix

### DIFF
--- a/cypress/integration/article.js
+++ b/cypress/integration/article.js
@@ -95,7 +95,7 @@ describe('Sample Article Page', () => {
             cy.get('a')
                 .first()
                 .should('have.prop', 'href')
-                .and('include', '/article/map-terms-concepts-sql-mongodb');
+                .and('eq', '/article/map-terms-concepts-sql-mongodb');
         });
     });
 

--- a/cypress/integration/article.js
+++ b/cypress/integration/article.js
@@ -95,7 +95,12 @@ describe('Sample Article Page', () => {
             cy.get('a')
                 .first()
                 .should('have.prop', 'href')
-                .and('eq', '/article/map-terms-concepts-sql-mongodb');
+                .and('include', '/article/map-terms-concepts-sql-mongodb')
+                // Want to make sure the link is not relative
+                .and(
+                    'not.include',
+                    'article/3-things-to-know-switch-from-sql-mongodb'
+                );
         });
     });
 

--- a/src/components/dev-hub/link.js
+++ b/src/components/dev-hub/link.js
@@ -76,10 +76,11 @@ const StyledLink = styled('a')`
 const Link = ({ href, onClick, target, tertiary, to, ...rest }) => {
     if (to) {
         const AsInternalLink = StyledLink.withComponent(RouterLink);
+        const absoluteLink = to.startsWith('/') ? to : `/${to}`
         return (
             <AsInternalLink
                 onClick={onClick}
-                to={to}
+                to={absoluteLink}
                 tertiary={tertiary}
                 {...rest}
             />

--- a/src/components/dev-hub/series.js
+++ b/src/components/dev-hub/series.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { withPrefix } from 'gatsby';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import Link from './link';

--- a/src/components/dev-hub/series.js
+++ b/src/components/dev-hub/series.js
@@ -203,7 +203,7 @@ const Series = ({ children, name }) => (
                             <SeriesLink
                                 isActive={isActive}
                                 isPast={isPast}
-                                to={withPrefix(slug)}
+                                to={slug}
                             >
                                 {title}
                             </SeriesLink>

--- a/src/components/dev-hub/series.js
+++ b/src/components/dev-hub/series.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { withPrefix } from 'gatsby';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import Link from './link';
@@ -202,7 +203,7 @@ const Series = ({ children, name }) => (
                             <SeriesLink
                                 isActive={isActive}
                                 isPast={isPast}
-                                to={slug}
+                                to={withPrefix(slug)}
                             >
                                 {title}
                             </SeriesLink>

--- a/tests/unit/__snapshots__/Heading.test.js.snap
+++ b/tests/unit/__snapshots__/Heading.test.js.snap
@@ -6,7 +6,7 @@ exports[`renders correctly 1`] = `
   id="create-an-administrative-username-and-password"
 >
   <a
-    class="e1hiqreu0 css-tk4bib-StyledLink-PermaLink eygprlc0"
+    class="e1hiqreu0 css-b5zgq1-StyledLink-PermaLink eygprlc0"
     href="#create-an-administrative-username-and-password"
     title="Permalink to this headline"
   >

--- a/tests/unit/__snapshots__/Link.test.js.snap
+++ b/tests/unit/__snapshots__/Link.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Link component renders a variety of strings correctly empty string 1`] = `
 <a
-  class="css-1jd38gu-StyledLink eygprlc0"
+  class="css-1ladr30-StyledLink eygprlc0"
   href=""
 >
   Empty string
@@ -11,7 +11,7 @@ exports[`Link component renders a variety of strings correctly empty string 1`] 
 
 exports[`Link component renders a variety of strings correctly external URL 1`] = `
 <a
-  class="css-1jd38gu-StyledLink eygprlc0"
+  class="css-1ladr30-StyledLink eygprlc0"
   href="http://mongodb.com"
 >
   MongoDB Company
@@ -20,7 +20,7 @@ exports[`Link component renders a variety of strings correctly external URL 1`] 
 
 exports[`Link component renders a variety of strings correctly internal link 1`] = `
 <a
-  class="test-class css-1slig66-AsInternalLink-StyledLink eygprlc1"
+  class="test-class css-17yuigh-AsInternalLink-StyledLink eygprlc1"
   href="/drivers/c"
 >
   C Driver

--- a/tests/unit/__snapshots__/Reference.test.js.snap
+++ b/tests/unit/__snapshots__/Reference.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders correctly 1`] = `
 <a
-  class="reference css-1jd38gu-StyledLink eygprlc0"
+  class="reference css-1ladr30-StyledLink eygprlc0"
   href="https://docs.mlab.com/subscriptions/#change-plans-using-rnr"
   rel="noreferrer noopener"
   target="_blank"


### PR DESCRIPTION
[Linked Issue](https://github.com/gatsbyjs/gatsby/pull/25180)
[Broken Series in Prod](https://developer.mongodb.com/article/schema-design-anti-pattern-summary)
[Staging Link to Series Article](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/js/relative-link-fix/article/map-terms-concepts-sql-mongodb)
[Staging Link to Article with Related Articles (just to confirm it still works)](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/js/relative-link-fix/quickstart/bson-data-types-decimal128)

Recently we updated Gatsby to v2.22.11 to v2.24. In 2.22.17 [they changed the Link behavior so any paths without a leading slash are now interpreted as relative](https://github.com/gatsbyjs/gatsby/pull/24054) 🤦 

This PR adds a check to the `Link` to add a leading slash should it not exist.

To Verify:
- Check out the series at the bottom of the provided article in prod and see how the link is being interpreted as relative
- Check out the staging link and ensure it is not
- Also poke around to see if this is happening elsewhere!