### PR TITLE
DEVHUB-63: Change default number of tags shown to 3

### DIFF
--- a/cypress/integration/tag.js
+++ b/cypress/integration/tag.js
@@ -40,6 +40,13 @@ describe('Tag page', () => {
             .should('have.attr', 'href')
             .and('include', TAG_ARTICLE_URL);
     });
+    it('should expand the blog tag list when requested', () => {
+        cy.get('[data-test="card"]')
+            .first()
+            .within(() => {
+                cy.checkTagListProperties(true);
+            });
+    });
     it('should not be indexed for SEO', () => {
         cy.checkMetaContentProperty('name="robots"', 'noindex');
     });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,3 +1,5 @@
+const EXPAND_TAG_TEXT = '...';
+
 Cypress.Commands.add('closeModal', () => {
     cy.get('[data-test="modal-close"]').click();
 });
@@ -7,11 +9,35 @@ Cypress.Commands.add('useBodyReference', () => {
     cy.get('body').as('body');
 });
 
-Cypress.Commands.add('checkTagListProperties', () => {
+Cypress.Commands.add('checkTagListProperties', shouldExpand => {
     cy.get('ul li a')
         .first()
         .should('have.attr', 'href')
         .should('match', /\/(tag|product|language)/);
+    if (shouldExpand) {
+        const length = cy.get('ul li a').length;
+        cy.get('ul li a')
+            .last()
+            .within($el => {
+                expect($el.text()).to.equal(EXPAND_TAG_TEXT);
+            });
+        cy.get('ul li a').last().should('not.have.attr', 'href');
+        cy.get('ul li a').last().click();
+        // Now more tags may have been rendered but regardless the last one should
+        // not be the ...
+        const updatedLength = cy.get('ul li a').length;
+        const numTagsChanged = length !== updatedLength;
+        let lastElementDoesNotExpand;
+        cy.get('ul li a')
+            .last()
+            .within($el => {
+                lastElementDoesNotExpand = $el.text() !== EXPAND_TAG_TEXT;
+            });
+        expect(lastElementDoesNotExpand);
+        // This may not always be true, but it is for the testing purposes
+        // of a single chosen article
+        expect(numTagsChanged);
+    }
 });
 
 // Basic sanity checks for an article card (image, title, tags, etc)

--- a/src/components/dev-hub/blog-tag-list.js
+++ b/src/components/dev-hub/blog-tag-list.js
@@ -66,10 +66,14 @@ const BlogTagList = ({ tags = [] }) => {
                 ))}
             {!isExpanded && canExpand && (
                 <>
-                    {/* Since this can expand, we know value[0] and value[1] exist */}
-                    <BlogTag to={tags[0].to}>{tags[0].label}</BlogTag>
-                    <BlogTag to={tags[1].to}>{tags[1].label}</BlogTag>
-                    <BlogTag onClick={expandList}>...</BlogTag>
+                    {tags.slice(0, MINIMUM_EXPANDABLE_SIZE).map(t => (
+                        <BlogTag key={t.label} to={t.to}>
+                            {t.label}
+                        </BlogTag>
+                    ))}
+                    {tags.length !== MINIMUM_EXPANDABLE_SIZE ? (
+                        <BlogTag onClick={expandList}>...</BlogTag>
+                    ) : null}
                 </>
             )}
         </TagList>


### PR DESCRIPTION
[JIRA (Request in Thread)](https://jira.mongodb.org/browse/DEVHUB-63)
[Staging Link](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-63/learn)

This PR adds a request to bump the default number of tags that show from 2 to 3. I also added a cypress test to make sure expanding continues to work well.

To Verify:
- Check out the staging link
- Check out card tags
- Make sure any with `...` indeed expand to 4+