### PR TITLE
Fix fileid use for target

### DIFF
--- a/src/utils/setup/get-related-pages-with-images.js
+++ b/src/utils/setup/get-related-pages-with-images.js
@@ -7,7 +7,8 @@ export const getRelatedPagesWithImages = (
     const related = dlv(pageNodes, 'query_fields.related', []);
     const relatedPageInfo = related.map(r => {
         // Handle `reference` and `ref_role` types
-        const target = r.target || r.refuri || r.fileid;
+        const getTargetFromFileid = dlv(r, 'fileid.0', null);
+        const target = r.target || r.refuri || getTargetFromFileid;
         const slug = target && target.slice(1);
         return {
             ...r,

--- a/src/utils/setup/get-related-pages-with-images.js
+++ b/src/utils/setup/get-related-pages-with-images.js
@@ -8,7 +8,7 @@ export const getRelatedPagesWithImages = (
     const relatedPageInfo = related.map(r => {
         // Handle `reference` and `ref_role` types
         const getTargetFromFileid = dlv(r, 'fileid.0', null);
-        const target = r.target || r.refuri || getTargetFromFileid;
+        const target = r.refuri || getTargetFromFileid;
         const slug = target && target.slice(1);
         return {
             ...r,

--- a/tests/utils/create-article-page.test.js
+++ b/tests/utils/create-article-page.test.js
@@ -71,7 +71,7 @@ describe('creating an article page', () => {
             ast: {},
         };
         slugContentMapping[articleOneSlug].query_fields = {
-            related: [{ target: articleTwoSlug }],
+            related: [{ refuri: articleTwoSlug }],
         };
         createArticlePage(
             articleOneSlug,

--- a/tests/utils/get-related-pages-with-images.test.js
+++ b/tests/utils/get-related-pages-with-images.test.js
@@ -16,12 +16,12 @@ it('should get pages and images for posts related to an article', () => {
     };
     const articleWithRelatedImage = {
         query_fields: {
-            related: [{ target: '/foo' }],
+            related: [{ refuri: '/foo' }],
         },
     };
     const articleWithoutRelatedImage = {
         query_fields: {
-            related: [{ target: '/bar' }],
+            related: [{ refuri: '/bar' }],
         },
     };
 


### PR DESCRIPTION
[Staging link to article that failed CI build before](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/js/fileid-type-change/quickstart/bson-data-types-decimal128)

(Check out the related article at the bottom)

Related link data structure before:
```
[
  {
    type: 'ref_role',
    position: { start: [Object] },
    children: [],
    domain: 'std',
    name: 'doc',
    target: [ '/how-to/bucket-pattern', '' ]
    flag: '',
    fileid: [ '/how-to/bucket-pattern', '' ],
    image: '/images/atf-images/illustrations/schema-design-patterns.png'
  }
]
```

Related link data structure after:
```
[
  {
    type: 'ref_role',
    position: { start: [Object] },
    children: [],
    domain: 'std',
    name: 'doc',
    target: '/how-to/bucket-pattern',
    flag: '',
    fileid: [ '/how-to/bucket-pattern', '' ],
    image: '/images/atf-images/illustrations/schema-design-patterns.png'
  }
]
```

