### PR TITLE
DEVHUB-222 & DEVHUB-184: "Load More" with Query Params

### DIFF
--- a/cypress/integration/learn.js
+++ b/cypress/integration/learn.js
@@ -60,6 +60,32 @@ describe('Learn Page', () => {
         // Check content
         cy.checkFirstCardInCardList('How to work with Johns Hopkins');
     });
+    it('should have a "Load More" button', () => {
+        cy.get('[data-test="card-list"]').within(() => {
+            cy.get('[data-test="card"]').should('have.length', 12);
+        });
+        cy.contains('Load more').click();
+    });
+    /*
+    These actions can be a bit flaky because this requires the page
+    render after "Load More" has been clicked, so we can re-query once
+    should a failure occur
+    */
+    it(
+        'should have updated fields after "Load More" is activated',
+        {
+            retries: {
+                runMode: 1,
+                openMode: 1,
+            },
+        },
+        () => {
+            cy.url().should('include', 'page=2');
+            cy.get('[data-test="card-list"]').within(() => {
+                cy.get('[data-test="card"]').should('have.length', 24);
+            });
+        }
+    );
     it('should filter content using the text filter', () => {
         // Check empty state
         cy.mockTextFilterResponse();

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,6 +1,5 @@
-exports.shouldUpdateScroll = ({
-    routerProps: { location },
-    getSavedScrollPosition,
-}) => {
-    return false;
+exports.shouldUpdateScroll = ({ prevRouterProps, routerProps }) => {
+    const prevLocation = prevRouterProps && prevRouterProps.location.pathname;
+    const newLocation = routerProps && routerProps.location.pathname;
+    return prevLocation !== newLocation;
 };

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,0 +1,6 @@
+exports.shouldUpdateScroll = ({
+    routerProps: { location },
+    getSavedScrollPosition,
+}) => {
+    return false;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -5868,7 +5868,6 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/@reach/router/-/router-1.3.4.tgz",
       "integrity": "sha512-+mtn9wjlB9NN2CNnnC/BRYtwdKBfSyyasPYraNAyvaV1occr/5NnB4CVzjEZipNHwYebQwcndGUmpFzxAUoqSA==",
-      "dev": true,
       "requires": {
         "create-react-context": "0.3.0",
         "invariant": "^2.2.3",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@leafygreen-ui/checkbox": "^4.1.1",
     "@leafygreen-ui/code": "^3.5.0",
     "@leafygreen-ui/icon": "^6.4.2",
+    "@reach/router": "^1.3.4",
     "@testing-library/react-hooks": "^3.4.1",
     "copy-to-clipboard": "^3.3.1",
     "css-loader": "^4.3.0",

--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -102,7 +102,6 @@ const renderContentTypeCard = (item, openAudio) => {
 export default React.memo(({ videos, articles, podcasts, limit = 9 }) => {
     const location = useLocation();
     const { pathname, search } = location;
-    console.log(location);
     // Get page if exists from search
     // Build next link, preserving other links
     const nextPageLink = useMemo(() => {

--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -11,6 +11,8 @@ import { getNestedText } from '../../utils/get-nested-text';
 import { getTagLinksFromMeta } from '../../utils/get-tag-links-from-meta';
 import getTwitchThumbnail from '../../utils/get-twitch-thumbnail';
 
+const CARD_LIST_LIMIT = 12;
+
 const CardContainer = styled('div')`
     display: grid;
     grid-template-columns: repeat(auto-fill, 350px);
@@ -99,68 +101,72 @@ const renderContentTypeCard = (item, openAudio) => {
     return renderArticle(item);
 };
 
-export default React.memo(({ videos, articles, podcasts, limit = 12 }) => {
-    const location = useLocation();
-    const { pathname, search } = location;
-    const localPage = pathname.replace(__PATH_PREFIX__, '');
-    // Get page if exists from search
-    // Build next link, preserving other links
-    const nextPageLink = useMemo(() => {
-        const { page, ...params } = parseQueryString(search);
-        if (page) {
-            return (
-                localPage +
-                buildQueryString({ page: parseInt(page) + 1, ...params })
-            );
-        }
-        return localPage + buildQueryString({ page: 2, ...params });
-    }, [localPage, search]);
+export default React.memo(
+    ({ videos, articles, podcasts, limit = CARD_LIST_LIMIT }) => {
+        const location = useLocation();
+        const { pathname, search } = location;
+        const localPage = pathname.replace(__PATH_PREFIX__, '');
+        // Get page if exists from search
+        // Build next link, preserving other links
+        const nextPageLink = useMemo(() => {
+            const { page, ...params } = parseQueryString(search);
+            if (page) {
+                return (
+                    localPage +
+                    buildQueryString({ page: parseInt(page) + 1, ...params })
+                );
+            }
+            return localPage + buildQueryString({ page: 2, ...params });
+        }, [localPage, search]);
 
-    useEffect(() => {
-        const { page } = parseQueryString(search);
-        if (page) {
-            setVisibleCards(page * limit);
-        }
-    }, [limit, search]);
-    // Prevent jump to top
-    videos = videos || [];
-    articles = articles || [];
-    podcasts = podcasts || [];
+        useEffect(() => {
+            const { page } = parseQueryString(search);
+            if (page) {
+                setVisibleCards(page * limit);
+            }
+        }, [limit, search]);
+        // Prevent jump to top
+        videos = videos || [];
+        articles = articles || [];
+        podcasts = podcasts || [];
 
-    const fullContentList = sortCardsByDate(videos.concat(articles, podcasts));
-    const [visibleCards, setVisibleCards] = useState(limit);
+        const fullContentList = sortCardsByDate(
+            videos.concat(articles, podcasts)
+        );
+        const [visibleCards, setVisibleCards] = useState(limit);
 
-    const hasMore = fullContentList.length > visibleCards;
-    const [activePodcast, setActivePodcast] = useState(false);
+        const hasMore = fullContentList.length > visibleCards;
+        const [activePodcast, setActivePodcast] = useState(false);
 
-    const openAudio = useCallback(podcast => {
-        setActivePodcast(podcast);
-    }, []);
-    const closeAudio = useCallback(e => {
-        e.stopPropagation();
-        setActivePodcast(null);
-    }, []);
+        const openAudio = useCallback(podcast => {
+            setActivePodcast(podcast);
+        }, []);
+        const closeAudio = useCallback(e => {
+            e.stopPropagation();
+            setActivePodcast(null);
+        }, []);
 
-    return (
-        <>
-            <CardContainer data-test="card-list">
-                {fullContentList
-                    .slice(0, visibleCards)
-                    .map(contentType =>
-                        renderContentTypeCard(contentType, openAudio)
-                    )}
-            </CardContainer>
+        return (
+            <>
+                <CardContainer data-test="card-list">
+                    {fullContentList
+                        .slice(0, visibleCards)
+                        .map(contentType =>
+                            renderContentTypeCard(contentType, openAudio)
+                        )}
+                </CardContainer>
 
-            {hasMore && (
-                <HasMoreButtonContainer>
-                    <Button secondary pagination to={nextPageLink}>
-                        Load more
-                    </Button>
-                </HasMoreButtonContainer>
-            )}
-            {podcasts.length ? (
-                <Audio onClose={closeAudio} podcast={activePodcast} />
-            ) : null}
-        </>
-    );
-});
+                {hasMore && (
+                    <HasMoreButtonContainer>
+                        <Button secondary pagination to={nextPageLink}>
+                            Load more
+                        </Button>
+                    </HasMoreButtonContainer>
+                )}
+                {podcasts.length ? (
+                    <Audio onClose={closeAudio} podcast={activePodcast} />
+                ) : null}
+            </>
+        );
+    }
+);

--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -103,20 +103,16 @@ const renderContentTypeCard = (item, openAudio) => {
 
 export default React.memo(
     ({ videos, articles, podcasts, limit = CARD_LIST_LIMIT }) => {
-        const location = useLocation();
-        const { pathname, search } = location;
+        const { pathname, search } = useLocation();
         const localPage = pathname.replace(__PATH_PREFIX__, '');
         // Get page if exists from search
         // Build next link, preserving other links
         const nextPageLink = useMemo(() => {
             const { page, ...params } = parseQueryString(search);
-            if (page) {
-                return (
-                    localPage +
-                    buildQueryString({ page: parseInt(page) + 1, ...params })
-                );
-            }
-            return localPage + buildQueryString({ page: 2, ...params });
+            const pageNumber = page ? parseInt(page) + 1 : 2;
+            return (
+                localPage + buildQueryString({ page: pageNumber, ...params })
+            );
         }, [localPage, search]);
 
         useEffect(() => {

--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -99,21 +99,22 @@ const renderContentTypeCard = (item, openAudio) => {
     return renderArticle(item);
 };
 
-export default React.memo(({ videos, articles, podcasts, limit = 9 }) => {
+export default React.memo(({ videos, articles, podcasts, limit = 12 }) => {
     const location = useLocation();
     const { pathname, search } = location;
+    const localPage = pathname.replace(__PATH_PREFIX__, '');
     // Get page if exists from search
     // Build next link, preserving other links
     const nextPageLink = useMemo(() => {
         const { page, ...params } = parseQueryString(search);
         if (page) {
             return (
-                pathname +
+                localPage +
                 buildQueryString({ page: parseInt(page) + 1, ...params })
             );
         }
-        return pathname + buildQueryString({ page: 2, ...params });
-    }, [pathname, search]);
+        return localPage + buildQueryString({ page: 2, ...params });
+    }, [localPage, search]);
 
     useEffect(() => {
         const { page } = parseQueryString(search);

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -100,10 +100,12 @@ const stripAllParam = filterValue => {
 };
 
 const filterArticles = (filter, initialArticles) => {
-    delete filter['page'];
     const filterValues = Object.keys(filter);
     return initialArticles.reduce((acc, article) => {
         for (let i = 0; i < filterValues.length; i++) {
+            if (filterValues[i] === 'page') {
+                continue;
+            }
             const fv = filterValues[i];
             const filterValuesForArticle = article[fv];
             const filterValueRequired = filter[fv];
@@ -208,6 +210,17 @@ export default ({
         filter => filterArticles(filter, initialArticles),
         [initialArticles]
     );
+    useEffect(() => {
+        const { page } = parseQueryString(search);
+        if (page) {
+            filterValue['page'] = page;
+            setFilterValue({ ...filterValue });
+        } else {
+            delete filterValue['page'];
+            setFilterValue({ ...filterValue });
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [search]);
     useEffect(() => {
         const filter = stripAllParam(filterValue);
         const searchParams = buildQueryString(filter);

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -92,7 +92,7 @@ const parseArticles = arr =>
 const stripAllParam = filterValue => {
     const newFilter = {};
     Object.keys(filterValue).forEach(key => {
-        if (filterValue[key] !== 'all') {
+        if (filterValue[key] !== 'all' && key !== 'page') {
             newFilter[key] = filterValue[key];
         }
     });

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -210,15 +210,23 @@ export default ({
         filter => filterArticles(filter, initialArticles),
         [initialArticles]
     );
+    // Update the filter value for page so it behaves nicely with query params
+    const updatePageFilter = useCallback(
+        search => {
+            const { page } = parseQueryString(search);
+            if (page) {
+                filterValue['page'] = page;
+                setFilterValue({ ...filterValue });
+            } else {
+                delete filterValue['page'];
+                setFilterValue({ ...filterValue });
+            }
+        },
+        [filterValue]
+    );
     useEffect(() => {
-        const { page } = parseQueryString(search);
-        if (page) {
-            filterValue['page'] = page;
-            setFilterValue({ ...filterValue });
-        } else {
-            delete filterValue['page'];
-            setFilterValue({ ...filterValue });
-        }
+        updatePageFilter(search);
+        // Don't want to also run for filterValues updatePageFilter
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [search]);
     useEffect(() => {
@@ -233,7 +241,6 @@ export default ({
         const filteredArticles = filterActiveArticles(filter);
         setArticles(filteredArticles);
     }, [metadata, filterValue, pathname, filterActiveArticles]);
-    const updateFilter = useCallback(filter => setFilterValue(filter), []);
     // filterValue could be {} on a page load, or values can be "all" if toggled back
     const hasNoFilter = useMemo(
         () =>
@@ -303,7 +310,7 @@ export default ({
                     <StyledFilterBar
                         filters={filters}
                         filterValue={filterValue}
-                        setFilterValue={updateFilter}
+                        setFilterValue={setFilterValue}
                         setTextFilterQuery={setTextFilterQuery}
                         textFilterQuery={textFilterQuery}
                     />

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -92,7 +92,7 @@ const parseArticles = arr =>
 const stripAllParam = filterValue => {
     const newFilter = {};
     Object.keys(filterValue).forEach(key => {
-        if (filterValue[key] !== 'all' && key !== 'page') {
+        if (filterValue[key] !== 'all') {
             newFilter[key] = filterValue[key];
         }
     });
@@ -100,6 +100,7 @@ const stripAllParam = filterValue => {
 };
 
 const filterArticles = (filter, initialArticles) => {
+    delete filter['page'];
     const filterValues = Object.keys(filter);
     return initialArticles.reduce((acc, article) => {
         for (let i = 0; i < filterValues.length; i++) {
@@ -201,15 +202,19 @@ export default ({
     const [textFilterQuery, setTextFilterQuery] = useState(null);
     const { results: textFilterResults } = useTextFilter(textFilterQuery);
     const { search = '', pathname = '' } = location;
+    console.log(search);
     const [filterValue, setFilterValue] = useState(parseQueryString(search));
+    console.log(filterValue);
     const filterActiveArticles = useCallback(
         filter => filterArticles(filter, initialArticles),
         [initialArticles]
     );
     useEffect(() => {
         const filter = stripAllParam(filterValue);
+        console.log(filter);
         const searchParams = buildQueryString(filter);
         // if the search params are empty, push the pathname state in order to remove params
+        console.log(searchParams);
         window.history.replaceState(
             {},
             '',

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -202,19 +202,15 @@ export default ({
     const [textFilterQuery, setTextFilterQuery] = useState(null);
     const { results: textFilterResults } = useTextFilter(textFilterQuery);
     const { search = '', pathname = '' } = location;
-    console.log(search);
     const [filterValue, setFilterValue] = useState(parseQueryString(search));
-    console.log(filterValue);
     const filterActiveArticles = useCallback(
         filter => filterArticles(filter, initialArticles),
         [initialArticles]
     );
     useEffect(() => {
         const filter = stripAllParam(filterValue);
-        console.log(filter);
         const searchParams = buildQueryString(filter);
         // if the search params are empty, push the pathname state in order to remove params
-        console.log(searchParams);
         window.history.replaceState(
             {},
             '',


### PR DESCRIPTION
[JIRA 222](https://jira.mongodb.org/browse/DEVHUB-222)
[JIRA 184](https://jira.mongodb.org/browse/DEVHUB-184)
[Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-222/learn)

This PR does a few things related to the load more button on card lists to make it more SEO friendly. Specifically:
1. The Load More button is now a link which appends a query param to the end of the current URL which will control how many items are shown
2. Implements the `shouldUpdateScroll` Gatsby Browser API method to keep the scroll position constant if a link goes to the same page (such as adds a query param)

A/C:
- A new `page` query param pops up when clicking "load more"
- Scroll position does not change
- The other query params still exist and work around `page` for filtering
- Also applies to "Tag" pages
