### PR TITLE
DEVHUB-225: Use a Query Param for Text Filter

### DIFF
--- a/cypress/integration/learn.js
+++ b/cypress/integration/learn.js
@@ -67,6 +67,12 @@ describe('Learn Page', () => {
             cy.get('input').type('java');
         });
         cy.wait('@filterJavaArticles');
+        // Verify query params update as expected
+        cy.url().should('include', 'text=java');
+        cy.get('[data-test="filter-bar"]').within(() => {
+            cy.get('input').clear();
+        });
+        cy.url().should('not.include', 'text=java');
     });
     // TODO: Stub podcasts and videos
     xit('should play a podcast', () => {

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -207,7 +207,16 @@ export default ({
         [initialArticles]
     );
     useEffect(() => {
+        if (filterValue['text']) {
+            setTextFilterQuery(filterValue['text']);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    useEffect(() => {
         const filter = stripAllParam(filterValue);
+        if (textFilterQuery) {
+            filter['text'] = textFilterQuery;
+        }
         const searchParams = buildQueryString(filter);
         // if the search params are empty, push the pathname state in order to remove params
         window.history.replaceState(
@@ -217,7 +226,13 @@ export default ({
         );
         const filteredArticles = filterActiveArticles(filter);
         setArticles(filteredArticles);
-    }, [metadata, filterValue, pathname, filterActiveArticles]);
+    }, [
+        metadata,
+        filterValue,
+        pathname,
+        filterActiveArticles,
+        textFilterQuery,
+    ]);
     const updateFilter = useCallback(filter => setFilterValue(filter), []);
     // filterValue could be {} on a page load, or values can be "all" if toggled back
     const hasNoFilter = useMemo(

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -229,13 +229,7 @@ export default ({
         );
         const filteredArticles = filterActiveArticles(filter);
         setArticles(filteredArticles);
-    }, [
-        metadata,
-        filterValue,
-        pathname,
-        filterActiveArticles,
-        textFilterQuery,
-    ]);
+    }, [metadata, filterValue, pathname, filterActiveArticles]);
     const updateFilter = useCallback(filter => setFilterValue(filter), []);
     // filterValue could be {} on a page load, or values can be "all" if toggled back
     const hasNoFilter = useMemo(

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -198,27 +198,28 @@ export default ({
         allArticles,
     ]);
     const [articles, setArticles] = useState(initialArticles);
-    const [textFilterQuery, setTextFilterQuery] = useState(null);
-    const { results: textFilterResults } = useTextFilter(textFilterQuery);
     const { search = '', pathname = '' } = location;
     const [filterValue, setFilterValue] = useState(parseQueryString(search));
+    const [textFilterQuery, setTextFilterQuery] = useState(filterValue['text']);
+    const { results: textFilterResults } = useTextFilter(textFilterQuery);
     const filterActiveArticles = useCallback(
         filter => filterArticles(filter, initialArticles),
         [initialArticles]
     );
-    useEffect(() => {
-        if (filterValue['text']) {
-            setTextFilterQuery(filterValue['text']);
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    const updateTextFilterQuery = useCallback(
+        query => {
+            setTextFilterQuery(query);
+            if (query) {
+                filterValue['text'] = query;
+            } else {
+                delete filterValue['text'];
+            }
+            setFilterValue({ ...filterValue });
+        },
+        [filterValue]
+    );
     useEffect(() => {
         const filter = stripAllParam(filterValue);
-        if (textFilterQuery) {
-            filter['text'] = textFilterQuery;
-        } else {
-            delete filter['text'];
-        }
         const searchParams = buildQueryString(filter);
         // if the search params are empty, push the pathname state in order to remove params
         window.history.replaceState(
@@ -306,7 +307,7 @@ export default ({
                         filters={filters}
                         filterValue={filterValue}
                         setFilterValue={updateFilter}
-                        setTextFilterQuery={setTextFilterQuery}
+                        setTextFilterQuery={updateTextFilterQuery}
                         textFilterQuery={textFilterQuery}
                     />
                 )}

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -216,6 +216,8 @@ export default ({
         const filter = stripAllParam(filterValue);
         if (textFilterQuery) {
             filter['text'] = textFilterQuery;
+        } else {
+            delete filter['text'];
         }
         const searchParams = buildQueryString(filter);
         // if the search params are empty, push the pathname state in order to remove params


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DEVHUB-225)
[Staging Link](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-225/learn/)

This PR adds a small change to use a query param to keep track of the TextFilter value. Previously we were not doing so, so by keeping track of it with the rest of the existing learn page filters we can add it to the query params basically for free.

I also added a cypress test to model this behavior

A/C:
- There should be a `text` queryParam for the learn page if and only if there is some value in the text filter.
- This query param should be the same as the value in the text filter
- On loading the page with this query param, the filter should be properly updated