### PR TITLE
Re-hydrate enabled styles for Selects

### DIFF
--- a/src/components/dev-hub/select.js
+++ b/src/components/dev-hub/select.js
@@ -86,6 +86,7 @@ const FormSelect = ({
     value = '',
     ...extraProps
 }) => {
+    const [isEnabled, setIsEnabled] = useState(false);
     const [selectValue, setSelectValue] = useState(value);
     const [selectText, setSelectText] = useState(defaultText);
     const [showOptions, setShowOptions] = useState(false);
@@ -102,6 +103,10 @@ const FormSelect = ({
         },
         [styleSelectedText]
     );
+    // Styles for enabled were not properly being hydrated, so we assume false first and then re-render if true
+    useEffect(() => {
+        setIsEnabled(enabled);
+    }, [enabled]);
     /**
      * This useEffect should only be called once the component first renders with choices,
      * this should populate the select item with the default choice if there is one
@@ -167,14 +172,14 @@ const FormSelect = ({
     return (
         <StyledCustomSelect
             aria-expanded={showOptions}
-            enabled={enabled}
+            enabled={isEnabled}
             aria-label={name}
             onBlur={closeOptionsOnBlur}
             onClick={selectOnClick}
             onKeyDown={showOptionsOnEnter}
             role="listbox"
             showOptions={showOptions}
-            tabIndex={enabled ? '0' : null}
+            tabIndex={isEnabled ? '0' : null}
         >
             <SelectedOption
                 errors={errors}


### PR DESCRIPTION
[Staging Link (working example)](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/js/hydrate-select-enabled/learn/?text=foo)
[Staging Link (broken example)](http://docs-devhub-staging.s3-website-us-east-1.amazonaws.com/776b8b8/devhub/docsworker-xlarge/09-28-20/learn/?text=staging)

When checking the staging branch I noticed some odd behavior on the Select when it should be disabled. What happens is we have a query param so the text filter should be filled and the other dropdown filters should be disabled (see working staging link for this in action).

Gatsby, at build-time, would default to the `enabled=true` when generating static html. We would then render the page with a query param and the styling would not be updated as expected because at build-time we generated html for the `enabled=true` default state. The key here is we want to hydrate this component with correct data in the browser so the static html is updated properly. (Check the broken vs working links to really get a handle of this).

The solution here was to use a `useState` variable to track enabled (not just relying on the prop), and re-setting this `isEnabled` `useState` variable when the component is mounted to make sure the correct styles are applied for the component.
