### PR TITLE
Fix CardList Flash on "Load More"

### DIFF
--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -105,11 +105,12 @@ export default React.memo(
     ({ videos, articles, podcasts, limit = CARD_LIST_LIMIT }) => {
         const { pathname, search } = useLocation();
         const localPage = pathname.replace(__PATH_PREFIX__, '');
-        // Get page if exists from search
         // Build next link, preserving other links
         const nextPageLink = useMemo(() => {
-            const { page, ...params } = parseQueryString(search);
-            const pageNumber = page ? parseInt(page) + 1 : 2;
+            // Get page if exists from search
+            const { page = 1, ...params } = parseQueryString(search);
+            // Have to parseInt because string + number gives a string
+            const pageNumber = parseInt(page) + 1;
             return (
                 localPage + buildQueryString({ page: pageNumber, ...params })
             );

--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -116,10 +116,8 @@ export default React.memo(
         }, [localPage, search]);
 
         useEffect(() => {
-            const { page } = parseQueryString(search);
-            if (page) {
-                setVisibleCards(page * limit);
-            }
+            const { page = 1 } = parseQueryString(search);
+            setVisibleCards(page * limit);
         }, [limit, search]);
         // Prevent jump to top
         videos = videos || [];
@@ -129,7 +127,8 @@ export default React.memo(
         const fullContentList = sortCardsByDate(
             videos.concat(articles, podcasts)
         );
-        const [visibleCards, setVisibleCards] = useState(limit);
+        const { page = 1 } = parseQueryString(search);
+        const [visibleCards, setVisibleCards] = useState(page * limit);
 
         const hasMore = fullContentList.length > visibleCards;
         const [activePodcast, setActivePodcast] = useState(false);


### PR DESCRIPTION
[Staging Link](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/js/rerender-cardlist/learn/?page=2)
[Broken Prod Link](https://developer.mongodb.com/learn/?page=2)
(See "How To Verify")

This PR fixes a re-render flash bug when using the "Load More" button on the `CardList`. What was happening before (and in the broken link) is for a split second when you click "Load More" the `CardList` rerenders with only having a total of the initial limit of cards (12) before a `useEffect` checks the query params for which "page" the user is on and then loads more. So some results would be hidden and then re-appear also losing track of scroll state.

The fix is to try to get the "page" before invoking `useState` so the first render always has the correct `page` and we do not have a delay before `useEffect` would kick in and fix this.

How To Verify:
- Check the broken link
- Click Load More at the bottom
- Notice how it condenses and then re-expands with a few flashes.
- Check the staging link
- Click Load More
- Notice how it simply adds those cards on to the bottom of the list instead of flickering on the rerender