### PR TITLE
Fix updated date field

### DIFF
--- a/cypress/integration/article.js
+++ b/cypress/integration/article.js
@@ -35,6 +35,9 @@ const OG_URL =
     'http://developer.mongodb.com/article/3-things-to-know-switch-from-sql-mongodb';
 const TWITTER_SHARE_URL = `https://twitter.com/intent/tweet?url=${PROD_ARTICLE_URL}&text=3%20Things%20to%20Know%20When%20You%20Switch%20from%20SQL%20to%20MongoDB`;
 
+const UPDATED_ARTICLE_URL =
+    '/article/coronavirus-map-live-data-tracker-charts/';
+
 const SOCIAL_URLS = [LINKEDIN_SHARE_URL, TWITTER_SHARE_URL, FACEBOOK_SHARE_URL];
 
 describe('Sample Article Page', () => {
@@ -174,5 +177,9 @@ describe('Sample Article Page', () => {
     it('should verify Cloud attribution links add the tck param as expected', () => {
         cy.visit(ARTICLE_WITH_ATTRIBUTION_LINK_URL);
         cy.get(`a[href='${EXPECTED_ATTRIBUTION_LINK}']`).should('exist');
+    });
+    it('should include Updated dates where applicable', () => {
+        cy.visit(UPDATED_ARTICLE_URL);
+        cy.contains('Updated: Apr 21, 2020');
     });
 });

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -151,7 +151,7 @@ const Article = props => {
         dateFormatOptions
     );
     const formattedUpdatedDate = toDateString(
-        meta.updatedDate,
+        meta['updated-date'],
         dateFormatOptions
     );
     const canonicalUrl = dlv(


### PR DESCRIPTION
[Staging Link (Fixed Article)](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/js/fix-updated-date/article/coronavirus-map-live-data-tracker-charts)
[Prod Link (Broken Article)](https://developer.mongodb.com/article/coronavirus-map-live-data-tracker-charts)

Somewhere along the way we were expecting the name of this field to be `updatedDate` but it was coming in as `updated-date`. This PR swaps to the correct field name and adds a cypress test for it as well.

Note in the broken article there is no updated date in the heading but in the staging link there is.