### PR TITLE
Add Trailing Slash to LinkedIn Share URLs

### DIFF
--- a/cypress/integration/article.js
+++ b/cypress/integration/article.js
@@ -30,9 +30,7 @@ const OG_IMAGE =
 
 // Social Media Links
 const FACEBOOK_SHARE_URL = `https://www.facebook.com/sharer/sharer.php?u=${PROD_ARTICLE_URL}`;
-const LINKEDIN_SHARE_URL = `https://www.linkedin.com/shareArticle?url=${PROD_ARTICLE_URL}`;
-const OG_URL =
-    'http://developer.mongodb.com/article/3-things-to-know-switch-from-sql-mongodb';
+const LINKEDIN_SHARE_URL = `https://www.linkedin.com/shareArticle?url=${PROD_ARTICLE_URL}/`;
 const TWITTER_SHARE_URL = `https://twitter.com/intent/tweet?url=${PROD_ARTICLE_URL}&text=3%20Things%20to%20Know%20When%20You%20Switch%20from%20SQL%20to%20MongoDB`;
 
 const SOCIAL_URLS = [LINKEDIN_SHARE_URL, TWITTER_SHARE_URL, FACEBOOK_SHARE_URL];

--- a/src/utils/get-article-share-links.js
+++ b/src/utils/get-article-share-links.js
@@ -6,7 +6,8 @@ export const getArticleShareLinks = (title, url) => {
     const twitterUrl = `https://twitter.com/intent/tweet?url=${urlWithoutTrailingSlash}&text=${encodeURIComponent(
         title
     )}`;
-    const linkedInUrl = `https://www.linkedin.com/shareArticle?url=${urlWithoutTrailingSlash}`;
+    // LinkedIn throws redirects to the same exact URL without a trailing slash
+    const linkedInUrl = `https://www.linkedin.com/shareArticle?url=${urlWithoutTrailingSlash}/`;
     return {
         articleUrl: urlWithoutTrailingSlash,
         facebookUrl,


### PR DESCRIPTION
[Staging Link](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/js/linkedin-url-slash/article/johns-hopkins-university-covid-19-data-atlas)

We have some unsolved redirect issues on the DevHub for article links. Take a look at the [LinkedIn debugger specifically for this article](https://www.linkedin.com/post-inspector/inspect/https:%2F%2Fdeveloper.mongodb.com%2Fhow-to%2Fuse-atlas-on-heroku) and [this is what happens when someone tries to share the article without a trailing slash](https://www.linkedin.com/shareArticle/?url=https://developer.mongodb.com/how-to/use-atlas-on-heroku). If we add back in a trailing slash for this case, the preview functionality is restored.

Facebook and Twitter handle this well, but LinkedIn has always been a bit flaky. [Try to share this article from the staging link](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/js/linkedin-url-slash/article/johns-hopkins-university-covid-19-data-atlas) on LinkedIn and the preview shows as expected.

We are going to come back to fixing the redirect issues because we don't know what is up with that.