### PR TITLE
Tab Directive Support

### DIFF
--- a/cypress/integration/tag.js
+++ b/cypress/integration/tag.js
@@ -18,7 +18,7 @@ describe('Tag page', () => {
         });
     });
     it('should contain several articles with basic information', () => {
-        cy.get('[data-test="card"]').should('have.length', 4);
+        cy.get('[data-test="card"]').should('have.length', 5);
         cy.get('[data-test="card"]')
             .first()
             .then(card => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5269,6 +5269,15 @@
         }
       }
     },
+    "@leafygreen-ui/box": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/box/-/box-2.1.5.tgz",
+      "integrity": "sha512-taI8crQleiQJkTDaWjbSDe+apuyitNvjfplo6ggs+soXMl+nTPgNpgg5A2qBourvYhQ4427WChvQk/yT0JXrVQ==",
+      "requires": {
+        "@leafygreen-ui/lib": "^5.1.1",
+        "lodash": "^4.17.20"
+      }
+    },
     "@leafygreen-ui/checkbox": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@leafygreen-ui/checkbox/-/checkbox-4.1.1.tgz",
@@ -5313,6 +5322,14 @@
         "emotion": "^10.0.7"
       }
     },
+    "@leafygreen-ui/hooks": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-4.2.1.tgz",
+      "integrity": "sha512-+vvSw9YNjZByRMHD1TIh50CszWS+YxctCXmQZ7LUw/hLmT4eOK/cAFUh8RZp3QSu6/L6dhIcirtc3DST7htXhA==",
+      "requires": {
+        "lodash": "^4.17.20"
+      }
+    },
     "@leafygreen-ui/icon": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-6.5.0.tgz",
@@ -5329,6 +5346,15 @@
         "@leafygreen-ui/emotion": "2.0.2",
         "@leafygreen-ui/lib": "^5.1.1",
         "@leafygreen-ui/palette": "2.0.2"
+      }
+    },
+    "@leafygreen-ui/leafygreen-provider": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-1.1.4.tgz",
+      "integrity": "sha512-zn/ZXha3ogWqK1pMHShpbbcmVNUQkPxb8pGEsBMVXDLnLeurLkgYGgCWfvRd7XNCpCbZb/f9rqRYzQxu99JQ3A==",
+      "requires": {
+        "@leafygreen-ui/hooks": "^4.0.1",
+        "@leafygreen-ui/lib": "^5.1.1"
       }
     },
     "@leafygreen-ui/lib": {
@@ -5370,10 +5396,32 @@
         }
       }
     },
+    "@leafygreen-ui/tabs": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tabs/-/tabs-3.0.1.tgz",
+      "integrity": "sha512-seFy0wZZLkCg20ugYO0w+kh4NYp/wckB3Jyf3gu9V0Ljqasnp/BZAf0MZWQYi+TbygqUtI4ZARaJGdoeDfMHPw==",
+      "requires": {
+        "@leafygreen-ui/box": "^2.1.4",
+        "@leafygreen-ui/hooks": "^4.2.1",
+        "@leafygreen-ui/leafygreen-provider": "^1.1.4",
+        "@leafygreen-ui/lib": "^5.1.1",
+        "@leafygreen-ui/palette": "^2.0.2",
+        "@leafygreen-ui/tokens": "^0.3.0",
+        "lodash": "^4.17.20"
+      }
+    },
     "@leafygreen-ui/theme": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@leafygreen-ui/theme/-/theme-2.0.1.tgz",
       "integrity": "sha512-sAd20kG5F8jcko8zhzpaH9kncn14Wom/lTlAzLm8kpCBXesXDRYrQ/4ITFYvuQo//JRPL/GgeIFfxovl/cUrsQ=="
+    },
+    "@leafygreen-ui/tokens": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-0.3.0.tgz",
+      "integrity": "sha512-Bj9XW0CdPiC8vS4iAWKEq6I3QumgG/BXSg0ZKLbzrYOmAe6K9sHJU3yUygps0hhX794cAVeHO62N9/QOMN7heQ==",
+      "requires": {
+        "@leafygreen-ui/lib": "^5.1.1"
+      }
     },
     "@mdx-js/loader": {
       "version": "1.6.16",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@leafygreen-ui/checkbox": "^4.1.1",
     "@leafygreen-ui/code": "^3.5.0",
     "@leafygreen-ui/icon": "^6.4.2",
+    "@leafygreen-ui/tabs": "^3.0.1",
     "@reach/router": "^1.3.4",
     "@testing-library/react-hooks": "^3.4.1",
     "copy-to-clipboard": "^3.3.1",

--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -40,6 +40,7 @@ import Strong from './Strong';
 import Subscript from './Subscript';
 import Superscript from './Superscript';
 import SubstitutionReference from './SubstitutionReference';
+import Tabs from './dev-hub/tabs';
 import Target from './Target';
 import Text from './Text';
 import TitleReference from './TitleReference';
@@ -109,6 +110,7 @@ export default class ComponentFactory extends Component {
             subscript: Subscript,
             substitution_reference: SubstitutionReference,
             superscript: Superscript,
+            tabs: Tabs,
             target: Target,
             text: Text,
             title_reference: TitleReference,

--- a/src/components/dev-hub/button.js
+++ b/src/components/dev-hub/button.js
@@ -154,9 +154,20 @@ const StyledButton = styled('button')`
 
     ${({ primary, theme }) => primary && primaryStyles(theme)}
     ${({ secondary, theme }) => secondary && secondaryStyles(theme)}
-    ${({ play, theme }) => play && playStyles(theme)}
-    ${({ play, primary, secondary, theme }) =>
-        !primary && !secondary && !play && tertiaryStyles(theme)}
+    ${({
+        play,
+        theme,
+    }) => play && playStyles(theme)}
+    ${({
+        play,
+        primary,
+        secondary,
+        theme,
+    }) =>
+        !primary &&
+        !secondary &&
+        !play &&
+        tertiaryStyles(theme)}
     &[disabled],
     &[disabled]:hover {
         background: ${({ theme }) => theme.colorMap.greyLightThree};
@@ -187,7 +198,12 @@ const getArrow = ({ pagination, primary, secondary }) => {
  */
 
 const Button = ({ children, href, play, to, hasArrow = true, ...props }) => {
-    const isButton = !!(props.primary || props.secondary || play);
+    const isButton = !!(
+        props.primary ||
+        props.secondary ||
+        props.renderAsButton ||
+        play
+    );
     const arrow = hasArrow ? getArrow(props) : null;
     if (href || to || !isButton) {
         // If the Button has a `to` or a `href` prop, then it renders as a `Link` element,

--- a/src/components/dev-hub/layout.js
+++ b/src/components/dev-hub/layout.js
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { ThemeProvider } from 'emotion-theming';
 import { Global, css } from '@emotion/core';
 import styled from '@emotion/styled';
+import { TabProvider } from './tab-context';
 import { Helmet } from 'react-helmet';
 import GlobalNav from './global-nav';
 import GlobalFooter from './global-footer';
@@ -64,8 +65,10 @@ export const StorybookLayout = ({ children }) => {
     return (
         <ThemeProvider theme={darkTheme}>
             <GlobalWrapper>
-                <Global styles={style} />
-                <main>{children}</main>
+                <TabProvider>
+                    <Global styles={style} />
+                    <main>{children}</main>
+                </TabProvider>
             </GlobalWrapper>
         </ThemeProvider>
     );
@@ -85,7 +88,9 @@ export default ({ children }) => {
                 </Helmet>
                 <Global styles={style} />
                 <GlobalNav />
-                <Main>{children}</Main>
+                <TabProvider>
+                    <Main>{children}</Main>
+                </TabProvider>
                 <GlobalFooter />
             </GlobalWrapper>
         </ThemeProvider>

--- a/src/components/dev-hub/tab-context.js
+++ b/src/components/dev-hub/tab-context.js
@@ -1,0 +1,6 @@
+import React from 'react';
+
+export const TabContext = React.createContext({
+    activeTabs: undefined,
+    setActiveTab: () => {},
+});

--- a/src/components/dev-hub/tab-context.js
+++ b/src/components/dev-hub/tab-context.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useReducer } from 'react';
+import React, { useCallback, useEffect, useReducer, useState } from 'react';
 import { getLocalValue, setLocalValue } from '../../utils/browser-storage';
 
 const defaultContextValue = {
@@ -15,9 +15,25 @@ const reducer = (tabSelectionPreferences, { tabset, value }) => ({
 });
 
 const TabProvider = ({ children }) => {
+    const [debouncedTabUpdate, setDebouncedTabUpdate] = useState(null);
     const [activeTabs, setActiveTab] = useReducer(
         reducer,
         getLocalValue('activeTabs') || defaultContextValue.activeTabs
+    );
+
+    /*
+      The LeafyGreen Tabs Implementation keeps adding key event handlers
+      to the DOM. By using a setTimeout we can avoid duplicate events being
+      run and so key events work as expected
+    */
+    const debouncedSetActiveTab = useCallback(
+        v => {
+            if (debouncedTabUpdate) {
+                clearTimeout(debouncedTabUpdate);
+            }
+            setDebouncedTabUpdate(setTimeout(() => setActiveTab(v)));
+        },
+        [debouncedTabUpdate]
     );
 
     useEffect(() => {
@@ -25,7 +41,9 @@ const TabProvider = ({ children }) => {
     }, [activeTabs]);
 
     return (
-        <TabContext.Provider value={{ activeTabs, setActiveTab }}>
+        <TabContext.Provider
+            value={{ activeTabs, setActiveTab: debouncedSetActiveTab }}
+        >
             {children}
         </TabContext.Provider>
     );

--- a/src/components/dev-hub/tab-context.js
+++ b/src/components/dev-hub/tab-context.js
@@ -8,9 +8,10 @@ const defaultContextValue = {
 
 const TabContext = React.createContext(defaultContextValue);
 
-const reducer = (prevState, { name, value }) => ({
-    ...prevState,
-    [name]: value,
+// Keeps track of the preferences for all tab sets
+const reducer = (tabSelectionPreferences, { tabset, value }) => ({
+    ...tabSelectionPreferences,
+    [tabset]: value,
 });
 
 const TabProvider = ({ children }) => {

--- a/src/components/dev-hub/tab-context.js
+++ b/src/components/dev-hub/tab-context.js
@@ -1,6 +1,35 @@
-import React from 'react';
+import React, { useEffect, useReducer } from 'react';
+import { getLocalValue, setLocalValue } from '../../utils/browser-storage';
 
-export const TabContext = React.createContext({
-    activeTabs: undefined,
+const defaultContextValue = {
+    activeTabs: {},
     setActiveTab: () => {},
-});
+};
+
+const TabContext = React.createContext(defaultContextValue);
+
+const reducer = (prevState, { name, value }) => {
+    return {
+        ...prevState,
+        [name]: value,
+    };
+};
+
+const TabProvider = ({ children }) => {
+    const [activeTabs, setActiveTab] = useReducer(
+        reducer,
+        getLocalValue('activeTabs') || defaultContextValue.activeTabs
+    );
+
+    useEffect(() => {
+        setLocalValue('activeTabs', activeTabs);
+    }, [activeTabs]);
+
+    return (
+        <TabContext.Provider value={{ activeTabs, setActiveTab }}>
+            {children}
+        </TabContext.Provider>
+    );
+};
+
+export { TabContext, TabProvider };

--- a/src/components/dev-hub/tab-context.js
+++ b/src/components/dev-hub/tab-context.js
@@ -8,12 +8,10 @@ const defaultContextValue = {
 
 const TabContext = React.createContext(defaultContextValue);
 
-const reducer = (prevState, { name, value }) => {
-    return {
-        ...prevState,
-        [name]: value,
-    };
-};
+const reducer = (prevState, { name, value }) => ({
+    ...prevState,
+    [name]: value,
+});
 
 const TabProvider = ({ children }) => {
     const [activeTabs, setActiveTab] = useReducer(

--- a/src/components/dev-hub/tabs.js
+++ b/src/components/dev-hub/tabs.js
@@ -3,8 +3,21 @@ import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { Tabs as LeafyTabs, Tab } from '@leafygreen-ui/tabs';
 import ComponentFactory from '../ComponentFactory';
+import Button from './button';
 import { getNestedValue } from '../../utils/get-nested-value';
 import { TabContext } from './tab-context';
+
+const StyledTabButton = styled(Button)`
+    border-radius: 0;
+    :active,
+    :hover,
+    :focus {
+        color: ${({ theme }) => theme.colorMap.darkGreen};
+        :after {
+            background-color: ${({ theme }) => theme.colorMap.darkGreen};
+        }
+    }
+`;
 
 const SLUG_TO_STRING = {
     shell: 'Mongo Shell',
@@ -39,13 +52,13 @@ const hiddenTabStyling = css`
 `;
 
 const StyledTabs = styled(LeafyTabs)`
-    button:focus {
+    ${({ ishidden }) => ishidden && hiddenTabStyling};
+    a[aria-selected='true'] {
         color: ${({ theme }) => theme.colorMap.darkGreen};
         :after {
             background-color: ${({ theme }) => theme.colorMap.darkGreen};
         }
     }
-    ${({ ishidden }) => ishidden && hiddenTabStyling};
 `;
 
 const stringifyTab = tabName => SLUG_TO_STRING[tabName] || tabName;
@@ -54,6 +67,8 @@ const getTabId = node => getNestedValue(['options', 'tabid'], node);
 
 // Name anonymous tabsets by alphabetizing their tabids and concatenating with a forward slash
 const generateAnonymousTabsetName = tabIds => [...tabIds].sort().join('/');
+
+const TabButton = ({ ...props }) => <StyledTabButton tertiary {...props} />;
 
 const Tabs = ({ nodeData: { children, options = {} } }) => {
     const hidden = options.hidden;
@@ -95,6 +110,7 @@ const Tabs = ({ nodeData: { children, options = {} } }) => {
                 setSelected={onClick}
                 darkMode
                 ishidden={hidden}
+                as={TabButton}
             >
                 {tabs.map((tab, index) => {
                     const tabId = getNestedValue(['options', 'tabid'], tab);

--- a/src/components/dev-hub/tabs.js
+++ b/src/components/dev-hub/tabs.js
@@ -55,27 +55,46 @@ const stringifyTab = tabName => {
 
 const getTabId = node => getNestedValue(['options', 'tabid'], node);
 
+// Name anonymous tabsets by alphabetizing their tabids and concatenating with a forward slash
+const generateAnonymousTabsetName = tabIds => [...tabIds].sort().join('/');
+
 const Tabs = ({ nodeData: { children, options = {} } }) => {
     const hidden = options.hidden;
     const { activeTabs, setActiveTab } = useContext(TabContext);
     const tabIds = children.map(child => getTabId(child));
+    const tabsetName = options.tabset || generateAnonymousTabsetName(tabIds);
     const [activeTab, setActiveTabIndex] = useState(0);
     const tabs = children;
 
     useEffect(() => {
         if (!activeTab || !tabIds.includes(activeTab)) {
             // Set first tab as active if no tab was previously selected
-            // setActiveTab({ name: tabsetName, value: getTabId(children[0]) });
+            setActiveTab({ name: tabsetName, value: getTabId(children[0]) });
         }
     }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-    const onClick = useCallback(index => {}, []);
+    useEffect(() => {
+        const index = tabIds.indexOf(activeTabs[tabsetName]);
+        if (index !== -1) {
+            setActiveTabIndex(index);
+        }
+    }, [activeTabs, tabIds, tabsetName]);
+
+    const onClick = useCallback(
+        index => {
+            setActiveTab({
+                name: tabsetName,
+                value: getTabId(children[index]),
+            });
+        },
+        [children, setActiveTab, tabsetName]
+    );
 
     return (
         <>
             <StyledTabs
                 selected={activeTab}
-                setSelected={setActiveTabIndex}
+                setSelected={onClick}
                 darkMode
                 ishidden={hidden}
             >

--- a/src/components/dev-hub/tabs.js
+++ b/src/components/dev-hub/tabs.js
@@ -2,28 +2,11 @@ import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { Tabs as LeafyTabs, Tab } from '@leafygreen-ui/tabs';
-import PropTypes from 'prop-types';
 import ComponentFactory from '../ComponentFactory';
 import { getNestedValue } from '../../utils/get-nested-value';
 import { TabContext } from './tab-context';
 
-const hiddenTabStyling = css`
-    & > div:first-child {
-        display: none;
-    }
-`;
-
-const StyledTabs = styled(LeafyTabs)`
-    button:focus {
-        color: ${({ theme }) => theme.colorMap.darkGreen};
-        :after {
-            background-color: ${({ theme }) => theme.colorMap.darkGreen};
-        }
-    }
-    ${({ ishidden }) => ishidden && hiddenTabStyling};
-`;
-
-export const SLUG_TO_STRING = {
+const SLUG_TO_STRING = {
     shell: 'Mongo Shell',
     compass: 'Compass',
     python: 'Python',
@@ -49,9 +32,23 @@ export const SLUG_TO_STRING = {
     rhel: 'RHEL',
 };
 
-const stringifyTab = tabName => {
-    return SLUG_TO_STRING[tabName] || tabName;
-};
+const hiddenTabStyling = css`
+    & > div:first-child {
+        display: none;
+    }
+`;
+
+const StyledTabs = styled(LeafyTabs)`
+    button:focus {
+        color: ${({ theme }) => theme.colorMap.darkGreen};
+        :after {
+            background-color: ${({ theme }) => theme.colorMap.darkGreen};
+        }
+    }
+    ${({ ishidden }) => ishidden && hiddenTabStyling};
+`;
+
+const stringifyTab = tabName => SLUG_TO_STRING[tabName] || tabName;
 
 const getTabId = node => getNestedValue(['options', 'tabid'], node);
 
@@ -128,25 +125,3 @@ const Tabs = ({ nodeData: { children, options = {} } }) => {
 };
 
 export default Tabs;
-
-Tabs.propTypes = {
-    nodeData: PropTypes.shape({
-        children: PropTypes.arrayOf(
-            PropTypes.shape({
-                argument: PropTypes.arrayOf(
-                    PropTypes.shape({
-                        value: PropTypes.string,
-                    })
-                ).isRequired,
-                children: PropTypes.array,
-                name: PropTypes.oneOf(['tab']),
-                options: PropTypes.shape({
-                    tabid: PropTypes.string.isRequired,
-                }).isRequired,
-            })
-        ),
-        options: PropTypes.shape({
-            hidden: PropTypes.bool,
-        }),
-    }).isRequired,
-};

--- a/src/components/dev-hub/tabs.js
+++ b/src/components/dev-hub/tabs.js
@@ -61,10 +61,11 @@ const Tabs = ({ nodeData: { children, options = {} } }) => {
     const tabIds = children.map(child => getTabId(child));
     const tabsetName = options.tabset || generateAnonymousTabsetName(tabIds);
     const [activeTab, setActiveTabIndex] = useState(0);
+    const previousTabsetChoice = activeTabs[tabsetName];
     const tabs = children;
 
     useEffect(() => {
-        if (!activeTab || !tabIds.includes(activeTab)) {
+        if (!previousTabsetChoice || !tabIds.includes(previousTabsetChoice)) {
             // Set first tab as active if no tab was previously selected
             setActiveTab({ name: tabsetName, value: getTabId(children[0]) });
         }

--- a/src/components/dev-hub/tabs.js
+++ b/src/components/dev-hub/tabs.js
@@ -1,0 +1,112 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import ComponentFactory from '../ComponentFactory';
+import { TabContext } from './tab-context';
+import { getNestedValue } from '../../utils/get-nested-value';
+import { Tabs as LeafyTabs, Tab } from '@leafygreen-ui/tabs';
+
+export const SLUG_TO_STRING = {
+    shell: 'Mongo Shell',
+    compass: 'Compass',
+    python: 'Python',
+    javasync: 'Java (Sync)',
+    'java-sync': 'Java (Sync)',
+    nodejs: 'Node.js',
+    php: 'PHP',
+    motor: 'Motor',
+    'java-async': 'Java (Async)',
+    c: 'C',
+    cpp: 'C++11',
+    csharp: 'C#',
+    perl: 'Perl',
+    ruby: 'Ruby',
+    scala: 'Scala',
+    go: 'Go',
+    cloud: 'Cloud',
+    local: 'Local',
+    macos: 'macOS',
+    linux: 'Linux',
+    windows: 'Windows',
+    debian: 'Debian',
+    rhel: 'RHEL',
+};
+
+const stringifyTab = tabName => {
+    return SLUG_TO_STRING[tabName] || tabName;
+};
+
+const createFragment = (tab, index) => {
+    return (
+        <React.Fragment key={index}>
+            {tab.children.map((tabChild, tabChildIndex) => (
+                <ComponentFactory nodeData={tabChild} key={tabChildIndex} />
+            ))}
+        </React.Fragment>
+    );
+};
+
+const Tabs = ({ nodeData }) => {
+    const [activeTab, setActiveTab] = useState(0);
+
+    const isHidden = nodeData.options && nodeData.options.hidden;
+    const tabs = nodeData.children;
+
+    return (
+        <React.Fragment>
+            {isHidden || (
+                <LeafyTabs
+                    selected={activeTab}
+                    setSelected={setActiveTab}
+                    darkMode
+                >
+                    {tabs.map((tab, index) => {
+                        const tabId = getNestedValue(['options', 'tabid'], tab);
+                        const tabTitle =
+                            getNestedValue(['argument', 0, 'value'], tab) ||
+                            stringifyTab(tabId);
+
+                        // If there are no activeTabs, js would typically be disabled
+                        const tabContent = createFragment(tab, index);
+
+                        return (
+                            <Tab
+                                data-tabid={tabId}
+                                role="tab"
+                                key={index}
+                                name={tabTitle}
+                            >
+                                {tabContent}
+                            </Tab>
+                        );
+                    })}
+                </LeafyTabs>
+            )}
+        </React.Fragment>
+    );
+};
+
+export default Tabs;
+
+Tabs.propTypes = {
+    nodeData: PropTypes.shape({
+        children: PropTypes.arrayOf(
+            PropTypes.shape({
+                argument: PropTypes.arrayOf(
+                    PropTypes.shape({
+                        value: PropTypes.string,
+                    })
+                ).isRequired,
+                children: PropTypes.array,
+                name: PropTypes.oneOf(['tab']),
+                options: PropTypes.shape({
+                    tabid: PropTypes.string.isRequired,
+                }).isRequired,
+            })
+        ),
+        options: PropTypes.shape({
+            hidden: PropTypes.bool,
+        }),
+    }).isRequired,
+};
+
+Tabs.contextType = TabContext;

--- a/src/components/dev-hub/tabs.js
+++ b/src/components/dev-hub/tabs.js
@@ -53,7 +53,7 @@ const hiddenTabStyling = css`
 
 const StyledTabs = styled(LeafyTabs)`
     ${({ ishidden }) => ishidden && hiddenTabStyling};
-    a[aria-selected='true'] {
+    button[aria-selected='true'] {
         color: ${({ theme }) => theme.colorMap.darkGreen};
         :after {
             background-color: ${({ theme }) => theme.colorMap.darkGreen};
@@ -68,7 +68,9 @@ const getTabId = node => getNestedValue(['options', 'tabid'], node);
 // Name anonymous tabsets by alphabetizing their tabids and concatenating with a forward slash
 const generateAnonymousTabsetName = tabIds => [...tabIds].sort().join('/');
 
-const TabButton = ({ ...props }) => <StyledTabButton tertiary {...props} />;
+const TabButton = ({ ...props }) => (
+    <StyledTabButton renderAsButton {...props} />
+);
 
 const Tabs = ({ nodeData: { children, options = {} } }) => {
     const hidden = options.hidden;

--- a/src/components/dev-hub/tabs.js
+++ b/src/components/dev-hub/tabs.js
@@ -67,7 +67,7 @@ const Tabs = ({ nodeData: { children, options = {} } }) => {
     useEffect(() => {
         if (!previousTabsetChoice || !tabIds.includes(previousTabsetChoice)) {
             // Set first tab as active if no tab was previously selected
-            setActiveTab({ name: tabsetName, value: getTabId(children[0]) });
+            setActiveTab({ tabset: tabsetName, value: getTabId(children[0]) });
         }
     }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -81,7 +81,7 @@ const Tabs = ({ nodeData: { children, options = {} } }) => {
     const onClick = useCallback(
         index => {
             setActiveTab({
-                name: tabsetName,
+                tabset: tabsetName,
                 value: getTabId(children[index]),
             });
         },

--- a/src/utils/browser-storage.js
+++ b/src/utils/browser-storage.js
@@ -1,0 +1,57 @@
+import { isBrowser } from './is-browser';
+
+const isValidStorage = isBrowser;
+
+export const setLocalValue = (key, value) => {
+    if (isValidStorage) {
+        const prevState = JSON.parse(
+            window.localStorage.getItem('mongodb-devhub')
+        );
+        localStorage.setItem(
+            'mongodb-devhub',
+            JSON.stringify({ ...prevState, [key]: value })
+        );
+    }
+};
+
+export const getLocalValue = key => {
+    if (
+        isValidStorage &&
+        JSON.parse(window.localStorage.getItem('mongodb-devhub'))
+    ) {
+        const docsObj = JSON.parse(
+            window.localStorage.getItem('mongodb-devhub')
+        );
+        if (docsObj) {
+            return docsObj[key];
+        }
+    }
+    return undefined;
+};
+
+export const setSessionValue = (key, value) => {
+    if (isValidStorage) {
+        const prevState = JSON.parse(
+            window.sessionStorage.getItem('mongodb-devhub')
+        );
+        sessionStorage.setItem(
+            'mongodb-devhub',
+            JSON.stringify({ ...prevState, [key]: value })
+        );
+    }
+};
+
+export const getSessionValue = key => {
+    if (
+        isValidStorage &&
+        JSON.parse(window.sessionStorage.getItem('mongodb-devhub'))
+    ) {
+        const docsObj = JSON.parse(
+            window.sessionStorage.getItem('mongodb-devhub')
+        );
+        if (docsObj) {
+            return docsObj[key];
+        }
+    }
+    return undefined;
+};

--- a/src/utils/browser-storage.js
+++ b/src/utils/browser-storage.js
@@ -1,6 +1,6 @@
 import { isBrowser } from './is-browser';
 
-const isValidStorage = isBrowser;
+const isValidStorage = isBrowser();
 
 export const setLocalValue = (key, value) => {
     if (isValidStorage) {

--- a/src/utils/browser-storage.js
+++ b/src/utils/browser-storage.js
@@ -28,30 +28,3 @@ export const getLocalValue = key => {
     }
     return undefined;
 };
-
-export const setSessionValue = (key, value) => {
-    if (isValidStorage) {
-        const prevState = JSON.parse(
-            window.sessionStorage.getItem('mongodb-devhub')
-        );
-        sessionStorage.setItem(
-            'mongodb-devhub',
-            JSON.stringify({ ...prevState, [key]: value })
-        );
-    }
-};
-
-export const getSessionValue = key => {
-    if (
-        isValidStorage &&
-        JSON.parse(window.sessionStorage.getItem('mongodb-devhub'))
-    ) {
-        const docsObj = JSON.parse(
-            window.sessionStorage.getItem('mongodb-devhub')
-        );
-        if (docsObj) {
-            return docsObj[key];
-        }
-    }
-    return undefined;
-};


### PR DESCRIPTION
[Staging Article Using New Directive](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/js/tabs/article/sample-tabs-article)
[JIRA](https://jira.mongodb.org/browse/DEVHUB-238)

This PR adds a component to support a new Article directive called `.. tabs::`. [Here is the documentation](https://docs.mongodb.com/meta/tutorials/tabbed-content/) on this directive, but in a nutshell the premise is this:

- An article can use `.. tabs::` and hide content within
- The typical use case is for toggling which programming language to display on code
- **When one tab on a page changes, the others change to match (so programming language stays constant, etc)** (try this one out!)
- Tabs support a `:hidden:` option which hides the tab bar from view (so content toggles)
- Each `tab` has a `tabid` which corresponds to its name. These are mapped in the component to something more pleasant.

Much of this is copied from the Docs Platform front-end and I will show where this is linked. Our implementation of the tabs uses the LeafyGreen component whereas theirs is custom.

I will add Cypress tests for this after we get it in because Deepak wants the writers to try it out in a "beta" fashion since this ask is high priority and we don't support `.. tabs::` at all right now.

Here is the raw rST for the tabs in this article:

```
   .. tabs::

      .. tab::
        :tabid: shell
        .. code-block:: bash
          mongoexport --collection='statistics' --out='statistics.jsonl' --uri="mongodb+srv://readonly:readonly@covid-19.hip2i.mongodb.net/covid19"
          mongoexport --collection='metadata' --out='metadata.jsonl' --uri="mongodb+srv://readonly:readonly@covid-19.hip2i.mongodb.net/covid19"

      .. tab::
        :tabid: cpp
        .. code-block:: cpp
          Some C++ code

      .. tab::
        :tabid: php
        .. code-block:: php
          Some PHP code

   Now for some additional tabs

   .. tabs::
      :hidden:

      .. tab::
        :tabid: shell
        The reader selected bash

      .. tab::
        :tabid: cpp
        The reader selected CPP

      .. tab::
        :tabid: php
        The reader selected PHP

```