### PR TITLE
Clean up cypress concurrency issue

### DIFF
--- a/cypress/integration/learn.js
+++ b/cypress/integration/learn.js
@@ -60,32 +60,18 @@ describe('Learn Page', () => {
         // Check content
         cy.checkFirstCardInCardList('How to work with Johns Hopkins');
     });
-    it('should have a "Load More" button', () => {
+    it('should have a list of item cards', () => {
         cy.get('[data-test="card-list"]').within(() => {
             cy.get('[data-test="card"]').should('have.length', 12);
         });
-        cy.contains('Load more').click();
     });
-    /*
-    These actions can be a bit flaky because this requires the page
-    render after "Load More" has been clicked, so we can re-query once
-    should a failure occur
-    */
-    it(
-        'should have updated fields after "Load More" is activated',
-        {
-            retries: {
-                runMode: 1,
-                openMode: 1,
-            },
-        },
-        () => {
-            cy.url().should('include', 'page=2');
-            cy.get('[data-test="card-list"]').within(() => {
-                cy.get('[data-test="card"]').should('have.length', 24);
-            });
-        }
-    );
+    it('should have updated fields after "Load More" is activated', () => {
+        cy.contains('Load more').should('exist').click();
+        cy.url().should('include', 'page=2');
+        cy.get('[data-test="card-list"]').within(() => {
+            cy.get('[data-test="card"]').should('have.length', 24);
+        });
+    });
     it('should filter content using the text filter', () => {
         // Check empty state
         cy.mockTextFilterResponse();


### PR DESCRIPTION
This PR fixes an issue with cypress on the learn page where we were not effectively re-querying the DOM after a re-render ([similar issue to this mitx PR](https://github.com/10gen/mitx/pull/5123) with a similar resolution).

By cleaning this up, we don't need to optionally retry anymore for the following test, and I renamed some of the `describes` for clarity.