### PR TITLE
Construct basic snapshot test for tabs

### DIFF
--- a/tests/unit/Tabs.test.js
+++ b/tests/unit/Tabs.test.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Tabs from '../../src/components/dev-hub/tabs';
+
+// data for this component
+import mockData from './data/Tabs.test.json';
+
+it('renders correctly', () => {
+    const tree = shallow(<Tabs nodeData={mockData} />);
+    expect(tree).toMatchSnapshot();
+});

--- a/tests/unit/__snapshots__/Tabs.test.js.snap
+++ b/tests/unit/__snapshots__/Tabs.test.js.snap
@@ -1,0 +1,89 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<Fragment>
+  <StyledTabs
+    as={[Function]}
+    darkMode={true}
+    selected={0}
+    setSelected={[Function]}
+  >
+    <Tab
+      data-tabid="shell"
+      key="0"
+      name="Mongo Shell"
+      role="tab"
+    >
+      <ComponentFactory
+        key="0"
+        nodeData={
+          Object {
+            "copyable": true,
+            "emphasize_lines": Array [],
+            "lang": "bash",
+            "linenos": false,
+            "position": Object {
+              "start": Object {
+                "line": 132,
+              },
+            },
+            "type": "code",
+            "value": "mongoexport --collection='statistics' --out='statistics.jsonl' --uri=\\"mongodb+srv://readonly:readonly@covid-19.hip2i.mongodb.net/covid19\\"
+mongoexport --collection='metadata' --out='metadata.jsonl' --uri=\\"mongodb+srv://readonly:readonly@covid-19.hip2i.mongodb.net/covid19\\"",
+          }
+        }
+      />
+    </Tab>
+    <Tab
+      data-tabid="cpp"
+      key="1"
+      name="C++11"
+      role="tab"
+    >
+      <ComponentFactory
+        key="0"
+        nodeData={
+          Object {
+            "copyable": true,
+            "emphasize_lines": Array [],
+            "lang": "cpp",
+            "linenos": false,
+            "position": Object {
+              "start": Object {
+                "line": 140,
+              },
+            },
+            "type": "code",
+            "value": "Some C++ code",
+          }
+        }
+      />
+    </Tab>
+    <Tab
+      data-tabid="php"
+      key="2"
+      name="PHP"
+      role="tab"
+    >
+      <ComponentFactory
+        key="0"
+        nodeData={
+          Object {
+            "copyable": true,
+            "emphasize_lines": Array [],
+            "lang": "php",
+            "linenos": false,
+            "position": Object {
+              "start": Object {
+                "line": 147,
+              },
+            },
+            "type": "code",
+            "value": "Some PHP code",
+          }
+        }
+      />
+    </Tab>
+  </StyledTabs>
+</Fragment>
+`;

--- a/tests/unit/data/Tabs.test.json
+++ b/tests/unit/data/Tabs.test.json
@@ -1,0 +1,100 @@
+{
+  "type": "directive",
+  "position": {
+    "start": {
+      "line": 127
+    }
+  },
+  "children": [
+    {
+      "type": "directive",
+      "position": {
+        "start": {
+          "line": 129
+        }
+      },
+      "children": [
+        {
+          "type": "code",
+          "position": {
+            "start": {
+              "line": 132
+            }
+          },
+          "lang": "bash",
+          "copyable": true,
+          "emphasize_lines": [],
+          "value": "mongoexport --collection='statistics' --out='statistics.jsonl' --uri=\"mongodb+srv://readonly:readonly@covid-19.hip2i.mongodb.net/covid19\"\nmongoexport --collection='metadata' --out='metadata.jsonl' --uri=\"mongodb+srv://readonly:readonly@covid-19.hip2i.mongodb.net/covid19\"",
+          "linenos": false
+        }
+      ],
+      "domain": "",
+      "name": "tab",
+      "argument": [],
+      "options": {
+        "tabid": "shell"
+      }
+    },
+    {
+      "type": "directive",
+      "position": {
+        "start": {
+          "line": 137
+        }
+      },
+      "children": [
+        {
+          "type": "code",
+          "position": {
+            "start": {
+              "line": 140
+            }
+          },
+          "lang": "cpp",
+          "copyable": true,
+          "emphasize_lines": [],
+          "value": "Some C++ code",
+          "linenos": false
+        }
+      ],
+      "domain": "",
+      "name": "tab",
+      "argument": [],
+      "options": {
+        "tabid": "cpp"
+      }
+    },
+    {
+      "type": "directive",
+      "position": {
+        "start": {
+          "line": 144
+        }
+      },
+      "children": [
+        {
+          "type": "code",
+          "position": {
+            "start": {
+              "line": 147
+            }
+          },
+          "lang": "php",
+          "copyable": true,
+          "emphasize_lines": [],
+          "value": "Some PHP code",
+          "linenos": false
+        }
+      ],
+      "domain": "",
+      "name": "tab",
+      "argument": [],
+      "options": {
+        "tabid": "php"
+      }
+    }
+  ],
+  "domain": "",
+  "name": "tabs",
+  "argument": []
+}


### PR DESCRIPTION
The new Tabs component has gone through a dry run and functionally there are no changes to make. As a result, now is a time to fully add the component into our testing suite.

First up, this PR adds a basic snapshot test with data provided by the Snooty parser.