### PR TITLE
Cypress Tests for Tabs Component

### DIFF
--- a/cypress/integration/article.js
+++ b/cypress/integration/article.js
@@ -36,6 +36,8 @@ const TWITTER_SHARE_URL = `https://twitter.com/intent/tweet?url=${PROD_ARTICLE_U
 const UPDATED_ARTICLE_URL =
     '/article/coronavirus-map-live-data-tracker-charts/';
 
+const TAB_ARTICLE_URL = '/article/sample-tabs-article/';
+
 const SOCIAL_URLS = [LINKEDIN_SHARE_URL, TWITTER_SHARE_URL, FACEBOOK_SHARE_URL];
 
 describe('Sample Article Page', () => {
@@ -179,5 +181,68 @@ describe('Sample Article Page', () => {
     it('should include Updated dates where applicable', () => {
         cy.visit(UPDATED_ARTICLE_URL);
         cy.contains('Updated: Apr 21, 2020');
+    });
+    describe('Tabs Component', () => {
+        const getTabAtIndex = index => cy.get('[data-test="Tabs"]').eq(index);
+        const verifyIfTabIndexIsActive = (index, active = true) =>
+            cy
+                .get('button')
+                .eq(index)
+                .should(
+                    'have.attr',
+                    'aria-selected',
+                    active ? 'true' : 'false'
+                );
+        it('should render standard tabs', () => {
+            cy.visit(TAB_ARTICLE_URL);
+            cy.get('[data-test="Tabs"]').should('have.length', 3);
+            getTabAtIndex(0).within(() => {
+                // Check names of tabs
+                cy.contains('Bash');
+                cy.contains('C++11');
+                cy.contains('PHP');
+                // Check content (should only be mongoexport commands)
+                cy.contains('mongoexport');
+                cy.contains('Some C++ code').should('not.exist');
+            });
+        });
+        it('should render tabs with the hidden option', () => {
+            getTabAtIndex(1).within(() => {
+                // With the hidden directive, tab UI should not show
+                // In this component we use display: none to hide since this is provided by LeafyGreen, so we should use not.visible since it would still appear on the DOM (and not.exist would fail)
+                cy.contains('Mongo Shell').should('not.visible');
+                cy.contains('C++11').should('not.visible');
+                cy.contains('PHP').should('not.visible');
+                // Content is updated automatically
+                cy.contains('The reader selected bash');
+                cy.contains('The reader selected CPP').should('not.exist');
+            });
+        });
+        it('should change content when a tab is toggled', () => {
+            getTabAtIndex(0).within(() => {
+                // Make sure the first tab is selected and the second is not
+                verifyIfTabIndexIsActive(0);
+                verifyIfTabIndexIsActive(1, false);
+                // Clicking this tab should update other tabs on the page with this preference
+                cy.contains('C++11').should('exist').click();
+                verifyIfTabIndexIsActive(0, false);
+                verifyIfTabIndexIsActive(1);
+                // Check content (should only be C++ now)
+                cy.contains('mongoexport').should('not.exist');
+                cy.contains('Some C++ code');
+            });
+            // Check the hidden tab and make sure content was still updated
+            getTabAtIndex(1).within(() => {
+                cy.contains('The reader selected bash').should('not.exist');
+                cy.contains('The reader selected CPP');
+            });
+            // Check the bottom tab, it should be updated to match as well
+            getTabAtIndex(2).within(() => {
+                verifyIfTabIndexIsActive(0, false);
+                verifyIfTabIndexIsActive(1);
+                cy.contains('mongoexport').should('not.exist');
+                cy.contains('Some C++ code');
+            });
+        });
     });
 });

--- a/cypress/integration/article.js
+++ b/cypress/integration/article.js
@@ -183,7 +183,8 @@ describe('Sample Article Page', () => {
         cy.contains('Updated: Apr 21, 2020');
     });
     describe('Tabs Component', () => {
-        const getTabAtIndex = index => cy.get('[data-test="Tabs"]').eq(index);
+        const getTabsetAtIndex = index =>
+            cy.get('[data-test="Tabs"]').eq(index);
         const verifyIfTabIndexIsActive = (index, active = true) =>
             cy
                 .get('button')
@@ -196,7 +197,7 @@ describe('Sample Article Page', () => {
         it('should render standard tabs', () => {
             cy.visit(TAB_ARTICLE_URL);
             cy.get('[data-test="Tabs"]').should('have.length', 3);
-            getTabAtIndex(0).within(() => {
+            getTabsetAtIndex(0).within(() => {
                 // Check names of tabs
                 cy.contains('Bash');
                 cy.contains('C++11');
@@ -207,7 +208,7 @@ describe('Sample Article Page', () => {
             });
         });
         it('should render tabs with the hidden option', () => {
-            getTabAtIndex(1).within(() => {
+            getTabsetAtIndex(1).within(() => {
                 // With the hidden directive, tab UI should not show
                 // In this component we use display: none to hide since this is provided by LeafyGreen, so we should use not.visible since it would still appear on the DOM (and not.exist would fail)
                 cy.contains('Mongo Shell').should('not.visible');
@@ -219,7 +220,7 @@ describe('Sample Article Page', () => {
             });
         });
         it('should change content when a tab is toggled', () => {
-            getTabAtIndex(0).within(() => {
+            getTabsetAtIndex(0).within(() => {
                 // Make sure the first tab is selected and the second is not
                 verifyIfTabIndexIsActive(0);
                 verifyIfTabIndexIsActive(1, false);
@@ -232,12 +233,12 @@ describe('Sample Article Page', () => {
                 cy.contains('Some C++ code');
             });
             // Check the hidden tab and make sure content was still updated
-            getTabAtIndex(1).within(() => {
+            getTabsetAtIndex(1).within(() => {
                 cy.contains('The reader selected bash').should('not.exist');
                 cy.contains('The reader selected CPP');
             });
             // Check the bottom tab, it should be updated to match as well
-            getTabAtIndex(2).within(() => {
+            getTabsetAtIndex(2).within(() => {
                 verifyIfTabIndexIsActive(0, false);
                 verifyIfTabIndexIsActive(1);
                 cy.contains('mongoexport').should('not.exist');

--- a/src/components/dev-hub/tabs.js
+++ b/src/components/dev-hub/tabs.js
@@ -108,11 +108,12 @@ const Tabs = ({ nodeData: { children, options = {} } }) => {
     return (
         <>
             <StyledTabs
+                as={TabButton}
+                darkMode
+                data-test="Tabs"
+                ishidden={hidden}
                 selected={activeTab}
                 setSelected={onClick}
-                darkMode
-                ishidden={hidden}
-                as={TabButton}
             >
                 {tabs.map((tab, index) => {
                     const tabId = getNestedValue(['options', 'tabid'], tab);


### PR DESCRIPTION
[Staging Article (the one used in the cypress tests)](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/js/cypress-tabs/article/sample-tabs-article)

This PR continues with adding tests for the Tabs component by adding Cypress tests for it. Using a sample article, the UI tests check basic rendering and interactions, as well as some of the different options including the `hidden` option. I'd suggest checking out the staging link provided to help see some of these tests in action!