### PR TITLE
DEVHUB-243: Make podcast playing smooth

### DIFF
--- a/src/components/dev-hub/audio.js
+++ b/src/components/dev-hub/audio.js
@@ -191,9 +191,10 @@ const Audio = ({ onClose, podcast, ...props }) => {
     );
     const onChange = useCallback(
         seconds => {
+            setProgress({ ...progress, playedSeconds: seconds });
             playerRef.current.seekTo(seconds);
         },
-        [playerRef]
+        [playerRef, progress]
     );
     const onReady = useCallback(player => {
         playerRef.current = player;


### PR DESCRIPTION
[Staging Learn Page](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-243/learn)

When listening to Podcasts on the DevHub, there was a lag between moving the slider component and having the feedback show up in the UI (as well as the podcast playing). What was happening was when we changed the slider we would only update the underlying react-player to seek and not immediately move the slider/update state. The slider would catch up on the next second the podcast was playing since state os also updated by react-player.

By updating the state here as well we get a much smoother UX when using the slider!

To Verify:
- Check out the staging learn link and try to play a podcast
- Seek to some points on the podcast via the slider, the experience should be good (in contrast with what is on Production)