### PR TITLE
DOP-1667: Render children of root nodes

### DIFF
--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -73,6 +73,19 @@ export const sourceNodes = async ({
     });
 };
 
+// Snooty Parser v0.7.0 introduced a fileid keyword that is passed as a string for the includes directive
+// Gatsby does not look at the directive name, it just checks the overall shape and so this causes Gatsby to think something is off when it is actually fine since we case on the directive
+// We can ignore the provided type warning on the context because the directives are distinct
+export const createSchemaCustomization = ({ actions }) => {
+    const { createTypes } = actions;
+    const typeDefs = `
+    type SitePage implements Node @dontInfer {
+        path: String
+    }
+    `;
+    createTypes(typeDefs);
+};
+
 export const onCreateNode = async ({ node }) => {
     if (node.internal.type === 'Asset') {
         assets.push(node.id);

--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -34,8 +34,10 @@ import MetaDescription from './meta-description';
 import Paragraph from './Paragraph';
 import Reference from './Reference';
 import RefRole from './RefRole';
+import Root from './Root';
 import Section from './Section';
 import Step from './Step';
+import Steps from './Steps';
 import Strong from './Strong';
 import Subscript from './Subscript';
 import Superscript from './Superscript';
@@ -104,8 +106,10 @@ export default class ComponentFactory extends Component {
             paragraph: Paragraph,
             ref_role: RefRole,
             reference: Reference,
+            root: Root,
             section: Section,
             step: Step,
+            steps: Steps,
             strong: Strong,
             subscript: Subscript,
             substitution_reference: SubstitutionReference,

--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -14,6 +14,7 @@ import DefinitionList from './DefinitionList';
 import DefinitionListItem from './DefinitionListItem';
 import Deprecated from './Deprecated';
 import Emphasis from './Emphasis';
+import Extract from './Extract';
 import Figure from './Figure';
 import Footnote from './Footnote';
 import FootnoteReference from './FootnoteReference';
@@ -85,6 +86,7 @@ export default class ComponentFactory extends Component {
             definitionListItem: DefinitionListItem,
             deprecated: Deprecated,
             emphasis: Emphasis,
+            extract: Extract,
             figure: Figure,
             footnote: Footnote,
             footnote_reference: FootnoteReference,

--- a/src/components/Extract.js
+++ b/src/components/Extract.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ComponentFactory from './ComponentFactory';
+
+const Extract = ({ nodeData: { children }, ...rest }) =>
+    children.map((child, i) => (
+        <ComponentFactory {...rest} key={i} nodeData={child} />
+    ));
+
+Extract.propTypes = {
+    nodeData: PropTypes.shape({
+        children: PropTypes.arrayOf(PropTypes.object).isRequired,
+    }).isRequired,
+};
+
+export default Extract;

--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -2,15 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 
-const Include = ({ nodeData: { children }, ...rest }) =>
+const Root = ({ nodeData: { children }, ...rest }) =>
     children.map((child, i) => (
         <ComponentFactory {...rest} key={i} nodeData={child} />
     ));
 
-Include.propTypes = {
+Root.propTypes = {
     nodeData: PropTypes.shape({
         children: PropTypes.arrayOf(PropTypes.object).isRequired,
     }).isRequired,
 };
 
-export default Include;
+export default Root;

--- a/src/components/Step.js
+++ b/src/components/Step.js
@@ -5,7 +5,7 @@ import ComponentFactory from './ComponentFactory';
 const Step = ({ nodeData: { children }, stepNum, ...rest }) => (
     <div className="sequence-block">
         <div className="bullet-block">
-            <div className="sequence-step">{stepNum + 1}</div>
+            <div className="sequence-step">{stepNum}</div>
         </div>
         <div className="section">
             {children.map((child, index) => (
@@ -23,7 +23,7 @@ Step.propTypes = {
 };
 
 Step.defaultProps = {
-    stepNum: 0,
+    stepNum: 1,
 };
 
 export default Step;

--- a/src/components/Steps.js
+++ b/src/components/Steps.js
@@ -2,15 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 
-const Include = ({ nodeData: { children }, ...rest }) =>
+const Steps = ({ nodeData: { children }, ...rest }) =>
     children.map((child, i) => (
-        <ComponentFactory {...rest} key={i} nodeData={child} />
+        <ComponentFactory {...rest} key={i} nodeData={child} stepNum={i + 1} />
     ));
 
-Include.propTypes = {
+Steps.propTypes = {
     nodeData: PropTypes.shape({
         children: PropTypes.arrayOf(PropTypes.object).isRequired,
     }).isRequired,
 };
 
-export default Include;
+export default Steps;


### PR DESCRIPTION
[[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/sophstad/ss/DOP-1667/)] Parser PR https://github.com/mongodb/snooty-parser/pull/230 introduced a new `root` node to improve the accuracy and traceability of diagnostics. The front end now needs to dive into these root nodes in order to render their contents.

Duplicates https://github.com/mongodb/snooty/pull/304.