### PR TITLE
Chunk asset queries

### DIFF
--- a/src/utils/setup/save-asset-files.js
+++ b/src/utils/setup/save-asset-files.js
@@ -1,10 +1,13 @@
 import { promises as fs } from 'fs';
 import path from 'path';
+import { RemoteMongoClient } from 'mongodb-stitch-server-sdk';
 import { ASSETS_COLLECTION } from '../../build-constants';
 import { getMetadata } from '../get-metadata';
 
 const metadata = getMetadata();
 const DB = metadata.database;
+
+const CHUNK_SIZE = 500;
 
 const saveFile = async asset => {
     await fs.mkdir(path.join('static', path.dirname(asset.filename)), {
@@ -20,14 +23,31 @@ const saveFile = async asset => {
 // Write all assets to static directory
 export const saveAssetFiles = async (assets, stitchClient) => {
     if (assets.length) {
-        const promises = [];
         const assetQuery = { _id: { $in: assets } };
-        const assetDataDocuments = await stitchClient.callFunction(
-            'fetchDocuments',
-            [DB, ASSETS_COLLECTION, assetQuery]
+        const assetCollection = stitchClient
+            .getServiceClient(RemoteMongoClient.factory, 'mongodb-atlas')
+            .db(DB)
+            .collection(ASSETS_COLLECTION);
+
+        // Given CHUNK_SIZE and the total number of assets to fetch, query the db `iterations` number of times to avoid hitting Realm's memory limit
+        const iterations = Math.ceil(assets.length / CHUNK_SIZE);
+        const assetDataDocuments = await Promise.all(
+            [...Array(iterations).keys()].map(i =>
+                assetCollection
+                    .aggregate([
+                        { $match: assetQuery },
+                        { $skip: i * CHUNK_SIZE },
+                        { $limit: CHUNK_SIZE },
+                    ])
+                    .toArray()
+            )
         );
-        assetDataDocuments.forEach(asset => {
-            promises.push(saveFile(asset));
+
+        const promises = [];
+        assetDataDocuments.forEach(chunk => {
+            chunk.forEach(asset => {
+                promises.push(saveFile(asset));
+            });
         });
         await Promise.all(promises);
     }


### PR DESCRIPTION
[[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/sophstad/ss/fix-assets/)] Use the aggregation pipeline to split our assets query into chunks of a given size. A subset of results is returned each time, which avoids hitting Realm's memory limit. This approach was significantly faster than running `.find()` multiple times, which proved prohibitively slow.