### PR TITLE
Bump GH Actions plugin versions

### DIFF
--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -13,7 +13,7 @@ jobs:
               with:
                   node-version: '12.x'
             - name: Cache node modules
-              uses: actions/cache@v1
+              uses: actions/cache@v2
               id: cache
               with:
                   path: node_modules
@@ -39,13 +39,13 @@ jobs:
             - name: Build Gatsby
               run: npm run buildTest
             - name: Cypress run
-              uses: cypress-io/github-action@v1
+              uses: cypress-io/github-action@v2
               with:
                   install: false
                   start: npm run serveTest
                   wait-on: 'http://localhost:9000'
             - name: Generate artifacts on failure
-              uses: actions/upload-artifact@v1
+              uses: actions/upload-artifact@v2
               if: failure()
               with:
                   name: cypress-screenshots

--- a/.github/workflows/devhub-npm-test.yaml
+++ b/.github/workflows/devhub-npm-test.yaml
@@ -19,7 +19,7 @@ jobs:
               with:
                   node-version: '12.x'
             - name: Cache node modules
-              uses: actions/cache@v1
+              uses: actions/cache@v2
               id: cache
               with:
                   path: node_modules


### PR DESCRIPTION
Bumps the following GH Action plugins:
- Cache
- Cypress
- Upload (for artifacts on failure)

The reason this came up was I noticed these deprecation warnings in the CI job generally. [Here is a job with the warnings](https://github.com/mongodb/devhub/actions/runs/345764491).

<img width="818" alt="Screen Shot 2020-11-05 at 1 51 07 PM" src="https://user-images.githubusercontent.com/9064401/98283844-40dcae00-1f6e-11eb-8703-a30f05353773.png">

We are not using `set-env` in our configs so I assumed this was one of the plugins we use and lo and behold, the CI job on this PR has no such warnings.