### PR TITLE
DEVHUB-234: (part 1) Refactor Featured Home Articles Logic

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -92,8 +92,7 @@ const DescriptiveText = styled(P)`
 
 // TODO: Generalize as new content types are supported
 const FeaturedHomePageItem = ({ item }) => {
-    const itemType = item.type;
-    if (itemType === 'article') {
+    if (item.type === 'article') {
         const { image, slug, title } = getFeaturedCardFields(item);
         return (
             <StyledTopCard

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -90,7 +90,24 @@ const DescriptiveText = styled(P)`
     margin-bottom: ${size.medium};
 `;
 
-const IndexPageContent = ({ stream, title, twitchVideo, featuredArticles }) => {
+// TODO: Generalize as new content types are supported
+const FeaturedHomePageItem = ({ item }) => {
+    const itemType = item.type;
+    if (itemType === 'article') {
+        const { image, slug, title } = getFeaturedCardFields(item);
+        return (
+            <StyledTopCard
+                maxTitleLines={3}
+                image={image}
+                to={slug}
+                title={title}
+                key={title}
+            />
+        );
+    }
+};
+
+const IndexPageContent = ({ stream, title, twitchVideo, featuredItems }) => {
     const theme = useTheme();
     return (
         <>
@@ -113,22 +130,9 @@ const IndexPageContent = ({ stream, title, twitchVideo, featuredArticles }) => {
                     </Heading>
                     <Sub>What will you create today?</Sub>
                     <CardGallery>
-                        {featuredArticles.map(article => {
-                            const {
-                                image,
-                                slug,
-                                title,
-                            } = getFeaturedCardFields(article);
-                            return (
-                                <StyledTopCard
-                                    maxTitleLines={3}
-                                    image={image}
-                                    to={slug}
-                                    title={title}
-                                    key={title}
-                                />
-                            );
-                        })}
+                        {featuredItems.map(item => (
+                            <FeaturedHomePageItem item={item} />
+                        ))}
                     </CardGallery>
                     <div>
                         <Button to="/learn" primary>
@@ -287,7 +291,7 @@ const IndexPageContent = ({ stream, title, twitchVideo, featuredArticles }) => {
     );
 };
 
-export default ({ pageContext: { featuredArticles } }) => {
+export default ({ pageContext: { featuredItems } }) => {
     const { stream, videos } = useTwitchApi();
     const { title } = useSiteMetadata();
     const twitchVideo = useMemo(() => {
@@ -301,7 +305,7 @@ export default ({ pageContext: { featuredArticles } }) => {
                 stream={stream}
                 title={title}
                 twitchVideo={twitchVideo}
-                featuredArticles={featuredArticles}
+                featuredItems={featuredItems}
             />
         </Layout>
     );

--- a/src/utils/setup/get-item-type-from-url.js
+++ b/src/utils/setup/get-item-type-from-url.js
@@ -1,0 +1,7 @@
+/**
+ * Identifies what type of content an item is based on some of its URL properties.
+ */
+export const getItemTypeFromUrl = () => {
+    // This will expand as new content types are supported
+    return 'article';
+};


### PR DESCRIPTION
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/js/home-featured-refactor/)
[JIRA](https://jira.mongodb.org/browse/DEVHUB-234)

This PR is related to a larger effort to un-hardcode logic for experiences on the DevHub which only support articles by refactoring Home page "Feature Article" section.

Previously, we had some logic and terminology which suggested this section only supports articles (which it still does right now), but this PR lays the foundation for supporting new content types here by doing the following:

- Adding a new `type` field to featured articles which can be used to distinguish between pieces of content. Ideally these should all share the same API (TS would be awesome for this someday) but until then this can help distinguish between cases
- Adding `switch` statements to better support forthcoming content types here

I also took this chance to remove an old piece of functionality relating to featured content. We used to have `DEFAULT` arrays for home/learn featured content but these haven't been used in a while and could be stale anyway.