### PR TITLE
DEVHUB-251: Sort CardList by created-date

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,4 @@
 {
-    "baseUrl": "http://localhost:8000",
+    "baseUrl": "http://localhost:9000",
     "viewportWidth": 1280
 }

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,4 @@
 {
-    "baseUrl": "http://localhost:9000",
+    "baseUrl": "http://localhost:8000",
     "viewportWidth": 1280
 }

--- a/cypress/integration/learn.js
+++ b/cypress/integration/learn.js
@@ -40,23 +40,8 @@ describe('Learn Page', () => {
             cy.contains(`Published: ${FIRST_ARTICLE_PUBLISHED_DATE}`);
         });
         cy.visitWithoutFetch('/learn/');
-        cy.toggleLearnPageTab('Articles');
-        cy.get('[data-test="card-list"]').within(() => {
-            cy.get('[data-test="card"]')
-                .eq(1)
-                .should('contain', 'Build a Newsletter')
-                .click();
-        });
-        cy.url().should('include', SECOND_ARTICLE_IN_ORDERING);
-        cy.get('[data-test="hero-banner"]').within(() => {
-            // This article has no updated date, so it should fallback to the publish date for sorting, which should be before the above article
-            cy.contains('Updated: ').should('not.exist');
-            cy.contains(`Published: ${SECOND_ARTICLE_PUBLISHED_DATE}`);
-        });
     });
     it('should filter content based on the selected tab', () => {
-        cy.visitWithoutFetch('/learn/');
-        cy.get('header');
         // TODO: Check content in "All" (Stub videos and podcasts)
         // Check content in "Articles"
         cy.toggleLearnPageTab('Articles');

--- a/cypress/integration/learn.js
+++ b/cypress/integration/learn.js
@@ -1,3 +1,10 @@
+const SECOND_ARTICLE_IN_ORDERING =
+    '/article/build-newsletter-website-mongodb-data-platform';
+const FIRST_ARTICLE_IN_ORDERING = '/how-to/transactions-c-dotnet';
+const FIRST_ARTICLE_UPDATED_DATE = 'Oct 03, 2020';
+const FIRST_ARTICLE_PUBLISHED_DATE = 'Oct 17, 2018';
+const SECOND_ARTICLE_PUBLISHED_DATE = 'Apr 21, 2020';
+
 describe('Learn Page', () => {
     it('should properly render the learn page', () => {
         cy.visitWithoutFetch('/learn');
@@ -18,7 +25,31 @@ describe('Learn Page', () => {
                 cy.checkSecondaryFeaturedArticleCard
             );
     });
+    it('should sort using the updated date where appropriate', () => {
+        cy.toggleLearnPageTab('Articles');
+        cy.get('[data-test="card-list"]').within(() => {
+            cy.get('[data-test="card"]').first().click();
+        });
+        cy.url().should('include', FIRST_ARTICLE_IN_ORDERING);
+        // By targeting the hero banner we can be sure the navigation is done
+        cy.get('[data-test="hero-banner"]').within(() => {
+            cy.contains(`Updated: ${FIRST_ARTICLE_UPDATED_DATE}`);
+            cy.contains(`Published: ${FIRST_ARTICLE_PUBLISHED_DATE}`);
+        });
+        cy.visitWithoutFetch('/learn');
+        cy.toggleLearnPageTab('Articles');
+        cy.get('[data-test="card-list"]').within(() => {
+            cy.get('[data-test="card"]').eq(1).click();
+        });
+        cy.url().should('include', SECOND_ARTICLE_IN_ORDERING);
+        cy.get('[data-test="hero-banner"]').within(() => {
+            // This article has no updated date, so it should fallback to the publish date for sorting, which should be before the above article
+            cy.contains('Updated: ').should('not.exist');
+            cy.contains(`Published: ${SECOND_ARTICLE_PUBLISHED_DATE}`);
+        });
+    });
     it('should filter content based on the selected tab', () => {
+        cy.visitWithoutFetch('/learn');
         // TODO: Check content in "All" (Stub videos and podcasts)
         // Check content in "Articles"
         cy.toggleLearnPageTab('Articles');
@@ -27,7 +58,7 @@ describe('Learn Page', () => {
                 .first()
                 .within(card => {
                     cy.checkArticleCard(card);
-                    cy.contains('Build a Newsletter Website');
+                    cy.contains('Working with MongoDB Transactions');
                 });
         });
         // TODO Check content in "Videos" (Stub videos and podcasts)
@@ -35,6 +66,7 @@ describe('Learn Page', () => {
         // TODO Check content in "Podcasts" (Stub videos and podcasts)
         cy.toggleLearnPageTab('Podcasts');
     });
+
     it('should only show the filter bar for "All" or "Articles"', () => {
         cy.toggleLearnPageTab('All');
         cy.get('[data-test="filter-bar"]').should('exist');
@@ -47,7 +79,7 @@ describe('Learn Page', () => {
     });
     it('should filter content using the filter dropdowns', () => {
         cy.toggleLearnPageTab('Articles');
-        cy.checkFirstCardInCardList('Build a Newsletter Website');
+        cy.checkFirstCardInCardList('Working with MongoDB Transactions');
         cy.get('[data-test="filter-bar"]').within(() => {
             cy.get('[role="listbox"]').first().click();
         });
@@ -58,7 +90,7 @@ describe('Learn Page', () => {
         // The url should contain the filter value as a param
         cy.url().should('include', '?products=Atlas');
         // Check content
-        cy.checkFirstCardInCardList('How to work with Johns Hopkins');
+        cy.checkFirstCardInCardList('Coronavirus Map');
     });
     it('should have a list of item cards', () => {
         cy.get('[data-test="card-list"]').within(() => {

--- a/cypress/integration/learn.js
+++ b/cypress/integration/learn.js
@@ -7,7 +7,7 @@ const SECOND_ARTICLE_PUBLISHED_DATE = 'Apr 21, 2020';
 
 describe('Learn Page', () => {
     it('should properly render the learn page', () => {
-        cy.visitWithoutFetch('/learn');
+        cy.visitWithoutFetch('/learn/');
         // Make sure something renders on the page
         cy.contains('Make better, faster applications');
     });
@@ -39,7 +39,7 @@ describe('Learn Page', () => {
             cy.contains(`Updated: ${FIRST_ARTICLE_UPDATED_DATE}`);
             cy.contains(`Published: ${FIRST_ARTICLE_PUBLISHED_DATE}`);
         });
-        cy.visitWithoutFetch('/learn');
+        cy.visitWithoutFetch('/learn/');
         cy.toggleLearnPageTab('Articles');
         cy.get('[data-test="card-list"]').within(() => {
             cy.get('[data-test="card"]')
@@ -55,7 +55,7 @@ describe('Learn Page', () => {
         });
     });
     it('should filter content based on the selected tab', () => {
-        cy.visitWithoutFetch('/learn');
+        cy.visitWithoutFetch('/learn/');
         cy.get('header');
         // TODO: Check content in "All" (Stub videos and podcasts)
         // Check content in "Articles"

--- a/cypress/integration/learn.js
+++ b/cypress/integration/learn.js
@@ -28,7 +28,7 @@ describe('Learn Page', () => {
     it('should sort using the updated date where appropriate', () => {
         cy.toggleLearnPageTab('Articles');
         cy.get('[data-test="card-list"]').within(() => {
-            cy.get('[data-test="card"]').first().click();
+            cy.get('[data-test="card"]').first().should('exist').click();
         });
         cy.url().should('include', FIRST_ARTICLE_IN_ORDERING);
         // By targeting the hero banner we can be sure the navigation is done
@@ -39,7 +39,7 @@ describe('Learn Page', () => {
         cy.visitWithoutFetch('/learn');
         cy.toggleLearnPageTab('Articles');
         cy.get('[data-test="card-list"]').within(() => {
-            cy.get('[data-test="card"]').eq(1).click();
+            cy.get('[data-test="card"]').eq(1).should('exist').click();
         });
         cy.url().should('include', SECOND_ARTICLE_IN_ORDERING);
         cy.get('[data-test="hero-banner"]').within(() => {
@@ -50,6 +50,7 @@ describe('Learn Page', () => {
     });
     it('should filter content based on the selected tab', () => {
         cy.visitWithoutFetch('/learn');
+        cy.get('header');
         // TODO: Check content in "All" (Stub videos and podcasts)
         // Check content in "Articles"
         cy.toggleLearnPageTab('Articles');

--- a/cypress/integration/learn.js
+++ b/cypress/integration/learn.js
@@ -28,7 +28,10 @@ describe('Learn Page', () => {
     it('should sort using the updated date where appropriate', () => {
         cy.toggleLearnPageTab('Articles');
         cy.get('[data-test="card-list"]').within(() => {
-            cy.get('[data-test="card"]').first().should('exist').click();
+            cy.get('[data-test="card"]')
+                .first()
+                .should('contain', 'Working with MongoDB Transactions')
+                .click();
         });
         cy.url().should('include', FIRST_ARTICLE_IN_ORDERING);
         // By targeting the hero banner we can be sure the navigation is done
@@ -39,7 +42,10 @@ describe('Learn Page', () => {
         cy.visitWithoutFetch('/learn');
         cy.toggleLearnPageTab('Articles');
         cy.get('[data-test="card-list"]').within(() => {
-            cy.get('[data-test="card"]').eq(1).should('exist').click();
+            cy.get('[data-test="card"]')
+                .eq(1)
+                .should('contain', 'Build a Newsletter')
+                .click();
         });
         cy.url().should('include', SECOND_ARTICLE_IN_ORDERING);
         cy.get('[data-test="hero-banner"]').within(() => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -106,11 +106,11 @@ Cypress.Commands.add('toggleLearnPageTab', tabName => {
     cy.get('[data-test="tabs"]').within(() => {
         cy.contains(tabName).should('exist').click();
     });
-    // Check that this tab is now active before moving on to check content
-    cy.get(`[data-test="tab-${tabName}"]`).should(
-        'have.css',
-        'border-bottom-color'
-    );
+    if (tabName === 'All' || tabName === 'Articles') {
+        cy.get('[data-test="filter-bar"]').should('exist');
+    } else {
+        cy.get('[data-test="filter-bar"]').should('not.exist');
+    }
 });
 
 // To stub requests with Cypress, we must remove fetch from the browser so

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -106,6 +106,7 @@ Cypress.Commands.add('toggleLearnPageTab', tabName => {
     cy.get('[data-test="tabs"]').within(() => {
         cy.contains(tabName).should('exist').click();
     });
+    // Check that this tab is now active before moving on to check content
     cy.get(`[data-test="tab-${tabName}"]`).should(
         'have.css',
         'border-bottom-color'

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -106,11 +106,6 @@ Cypress.Commands.add('toggleLearnPageTab', tabName => {
     cy.get('[data-test="tabs"]').within(() => {
         cy.contains(tabName).should('exist').click();
     });
-    if (tabName === 'All' || tabName === 'Articles') {
-        cy.get('[data-test="filter-bar"]').should('exist');
-    } else {
-        cy.get('[data-test="filter-bar"]').should('not.exist');
-    }
 });
 
 // To stub requests with Cypress, we must remove fetch from the browser so

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -104,8 +104,12 @@ Cypress.Commands.add('mockTextFilterResponse', () => {
 
 Cypress.Commands.add('toggleLearnPageTab', tabName => {
     cy.get('[data-test="tabs"]').within(() => {
-        cy.contains(tabName).click();
+        cy.contains(tabName).should('exist').click();
     });
+    cy.get(`[data-test="tab-${tabName}"]`).should(
+        'have.css',
+        'border-bottom-color'
+    );
 });
 
 // To stub requests with Cypress, we must remove fetch from the browser so

--- a/src/components/dev-hub/blog-post-title-area.js
+++ b/src/components/dev-hub/blog-post-title-area.js
@@ -41,7 +41,11 @@ const BlogPostTitleArea = ({
 }) => {
     const BlogTitle = H2.withComponent('h1');
     return (
-        <HeroBanner background={articleImage} breadcrumb={breadcrumb}>
+        <HeroBanner
+            background={articleImage}
+            breadcrumb={breadcrumb}
+            data-test="hero-banner"
+        >
             <BlogTitle collapse>{title}</BlogTitle>
             <PostMetaLine>
                 <DateTextContainer>

--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -44,11 +44,15 @@ const getThumbnailUrl = media => {
         : media.thumbnailUrl;
 };
 
+/* Different content types currently have different APIs for accessing dates.
+ * Articles support `pubdate` and `updated-date` while Podcasts and Videos have publishDate
+ * a TODO is to reconsile these APIs
+ */
 const sortCardsByDate = contentList =>
     contentList.sort(
         (a, b) =>
-            new Date(b.publishDate || b.pubdate) -
-            new Date(a.publishDate || a.pubdate)
+            new Date(b['updated-date'] || b.publishDate || b.pubdate) -
+            new Date(a['updated-date'] || a.publishDate || a.pubdate)
     );
 
 const renderArticle = article => (

--- a/src/components/dev-hub/tab.js
+++ b/src/components/dev-hub/tab.js
@@ -47,6 +47,7 @@ const mapTabTextToButton = (textList, activeItem, handleClick) =>
         const isActive = item === activeItem;
         return (
             <TabButton
+                data-test={`tab-${item}`}
                 key={item}
                 isActive={isActive}
                 onClick={() => handleClick(item)}


### PR DESCRIPTION
[Staging Link (to learn page)](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-251/learn/)
[JIRA](https://jira.mongodb.org/browse/DEVHUB-234)

This PR makes a tweak to the general `CardList` component which will now account optionally for an article's `updated-date` when sorting. Most of the work here is improving the end-to-end tests to add a check for this behavior as well as clean up some tests impacted by the ordering change.