### PR TITLE
DEVHUB-252: Support Object Representation for Assets

### DIFF
--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -22,7 +22,7 @@ const DB = metadata.database;
 const PAGE_ID_PREFIX = `${metadata.project}/${metadata.parserUser}/${metadata.parserBranch}`;
 
 // different types of references
-const assets = [];
+const assets = {};
 
 // in-memory object with key/value = filename/document
 const slugContentMapping = {};
@@ -88,7 +88,7 @@ export const createSchemaCustomization = ({ actions }) => {
 
 export const onCreateNode = async ({ node }) => {
     if (node.internal.type === 'Asset') {
-        assets.push(node.id);
+        assets[node.id] = node.paths;
     }
 };
 

--- a/src/utils/setup/create-asset-nodes.js
+++ b/src/utils/setup/create-asset-nodes.js
@@ -1,18 +1,30 @@
 import { getNestedValue } from '../get-nested-value';
 
 export const createAssetNodes = (doc, createNode, createContentDigest) => {
+    const assets = new Map();
     const pageNode = getNestedValue(['ast', 'children'], doc);
     if (pageNode) {
         // Cache static assets to save file i/o on repeated builds
         doc.static_assets.forEach(asset => {
+            const checksum = asset.checksum;
+            if (assets.has(checksum)) {
+                assets.set(
+                    checksum,
+                    new Set([...assets.get(checksum), asset.key])
+                );
+            } else {
+                assets.set(checksum, new Set([asset.key]));
+            }
+        });
+        Array.from(assets.keys()).forEach(checksum => {
             const assetNode = {
-                id: asset,
+                id: checksum,
                 parent: null,
                 children: [],
+                paths: Array.from(assets.get(checksum)),
                 internal: {
                     type: 'Asset',
-                    content: asset,
-                    contentDigest: createContentDigest(asset),
+                    contentDigest: createContentDigest(checksum),
                 },
             };
             createNode(assetNode);

--- a/src/utils/setup/save-asset-files.js
+++ b/src/utils/setup/save-asset-files.js
@@ -20,7 +20,7 @@ const saveFile = async (buffer, filepath) => {
 export const saveAssetFiles = async (assets, stitchClient) => {
     const numAssets = Object.keys(assets).length;
     if (numAssets) {
-        const assetQuery = { _id: { $in: Array.from(Object.keys(assets)) } };
+        const assetQuery = { _id: { $in: Object.keys(assets) } };
         const assetCollection = stitchClient
             .getServiceClient(RemoteMongoClient.factory, 'mongodb-atlas')
             .db(DB)

--- a/src/utils/setup/save-asset-files.js
+++ b/src/utils/setup/save-asset-files.js
@@ -9,28 +9,28 @@ const DB = metadata.database;
 
 const CHUNK_SIZE = 500;
 
-const saveFile = async asset => {
-    await fs.mkdir(path.join('static', path.dirname(asset.filename)), {
+const saveFile = async (asset, filepath) => {
+    await fs.mkdir(path.join('static', path.dirname(filepath)), {
         recursive: true,
     });
     await fs.writeFile(
-        path.join('static', asset.filename),
+        path.join('static', filepath),
         asset.data.buffer,
         'binary'
     );
 };
 
-// Write all assets to static directory
+// Write all assets to static directory while including all filepaths
 export const saveAssetFiles = async (assets, stitchClient) => {
-    if (assets.length) {
-        const assetQuery = { _id: { $in: assets } };
+    if (Object.keys(assets).length) {
+        const assetQuery = { _id: { $in: Array.from(Object.keys(assets)) } };
         const assetCollection = stitchClient
             .getServiceClient(RemoteMongoClient.factory, 'mongodb-atlas')
             .db(DB)
             .collection(ASSETS_COLLECTION);
 
         // Given CHUNK_SIZE and the total number of assets to fetch, query the db `iterations` number of times to avoid hitting Realm's memory limit
-        const iterations = Math.ceil(assets.length / CHUNK_SIZE);
+        const iterations = Math.ceil(Object.keys(assets).length / CHUNK_SIZE);
         const assetDataDocuments = await Promise.all(
             [...Array(iterations).keys()].map(i =>
                 assetCollection
@@ -42,11 +42,12 @@ export const saveAssetFiles = async (assets, stitchClient) => {
                     .toArray()
             )
         );
-
         const promises = [];
         assetDataDocuments.forEach(chunk => {
             chunk.forEach(asset => {
-                promises.push(saveFile(asset));
+                assets[asset._id].forEach(filepath => {
+                    promises.push(saveFile(asset, filepath));
+                });
             });
         });
         await Promise.all(promises);

--- a/tests/utils/create-asset-nodes.test.js
+++ b/tests/utils/create-asset-nodes.test.js
@@ -5,7 +5,11 @@ it('should properly construct nodes for static assets', () => {
         ast: {
             children: [],
         },
-        static_assets: ['asset_1', 'asset_2'],
+        // TODO: Update tests
+        static_assets: [
+            { checksum: 'asset_1', path: 'foo' },
+            { checksum: 'asset_2', path: 'bar' },
+        ],
     };
 
     const createNode = jest.fn();

--- a/tests/utils/create-asset-nodes.test.js
+++ b/tests/utils/create-asset-nodes.test.js
@@ -7,8 +7,9 @@ it('should properly construct nodes for static assets', () => {
         },
         // TODO: Update tests
         static_assets: [
-            { checksum: 'asset_1', path: 'foo' },
-            { checksum: 'asset_2', path: 'bar' },
+            { checksum: 'asset_1', key: 'foo.txt' },
+            { checksum: 'asset_2', key: 'bar.txt' },
+            { checksum: 'asset_2', key: 'baz.txt' },
         ],
     };
 
@@ -16,13 +17,28 @@ it('should properly construct nodes for static assets', () => {
     const createContentDigest = jest.fn(asset => asset[0]);
 
     createAssetNodes(testArticle, createNode, createContentDigest);
-    expect(createNode.mock.calls.length).toBe(testArticle.static_assets.length);
+    // Two assets share a checksum, so there should only be one call for the both of them
+    expect(createNode.mock.calls.length).toBe(
+        testArticle.static_assets.length - 1
+    );
 
     // check asset_1 call node
     const firstNode = createNode.mock.calls[0][0];
-    expect(firstNode.id).toBe(testArticle.static_assets[0]);
+    expect(firstNode.id).toBe(testArticle.static_assets[0].checksum);
+    expect(firstNode.paths).toStrictEqual([testArticle.static_assets[0].key]);
     expect(firstNode.internal.type).toBe('Asset');
     expect(firstNode.internal.contentDigest).toBe(
-        createContentDigest(testArticle.static_assets[0])
+        createContentDigest(testArticle.static_assets[0].checksum)
+    );
+
+    // check filepaths were consolidated properly
+    const shareChecksumNode = createNode.mock.calls[1][0];
+    expect(shareChecksumNode.id).toBe(testArticle.static_assets[1].checksum);
+    // At this point there should be two filepaths for this asset, but they may change order due to implementation as Set
+    expect(shareChecksumNode.paths).toContain(testArticle.static_assets[1].key);
+    expect(shareChecksumNode.paths).toContain(testArticle.static_assets[2].key);
+    expect(shareChecksumNode.internal.type).toBe('Asset');
+    expect(shareChecksumNode.internal.contentDigest).toBe(
+        createContentDigest(testArticle.static_assets[0].checksum)
     );
 });


### PR DESCRIPTION
[Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-252/)
[JIRA Ticket](https://jira.mongodb.org/browse/DEVHUB-252)

This PR follows the [related Snooty work](https://github.com/mongodb/snooty/pull/315/files) by changing the datatype of an asset from a string to an object containing the following fields:
- `checksum` (essentially a hash of the image)
- `key` (the filepath to store at)

Here is a summary of what I changed:
- Changed our GraphQL representation of an image to also have a `paths` array field (for all of the relevant filepaths to save as)
- Changed our local representation of assets from an Array to an Object mapping the checksum value to filepaths
- Updated testing