### PR TITLE
Switch CI test branch off master

### DIFF
--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -34,7 +34,7 @@ jobs:
                   echo "GATSBY_SITE=devhub" > .env.production; \
                   echo "GATSBY_PARSER_CI_USER=jordanstapinski" >> .env.production; \
                   echo "GATSBY_PARSER_USER=jordanstapinski" >> .env.production; \
-                  echo "GATSBY_PARSER_BRANCH=master" >> .env.production; \
+                  echo "GATSBY_PARSER_BRANCH=CI" >> .env.production; \
                   echo "GATSBY_SNOOTY_DEV=true" >> .env.production; \
             - name: Build Gatsby
               run: npm run buildTest


### PR DESCRIPTION
To help with QA workflow improvements, we set up a new branch for storing CI data and will be using `master` to strictly clone the `devhub-content` repo. This PR changes the GH Action test to use the new branch