### PR TITLE
Remove AST and source from learn page context

### DIFF
--- a/src/utils/setup/handle-create-page.js
+++ b/src/utils/setup/handle-create-page.js
@@ -35,6 +35,11 @@ const memoizedStitchRequest = memoizerific(10)(requestStitch);
 
 const getAllArticles = memoizerific(1)(async () => {
     const documents = await memoizedStitchRequest('fetchDevhubMetadata', {});
+    // We don't need all of the article contents for preview
+    documents.forEach(doc => {
+        delete doc.ast;
+        delete doc.source;
+    });
     // Ignore bad data, including links to the home page as an "article"
     const filteredDocuments = documents.filter(d => {
         const route = getNestedValue(['query_fields', 'slug'], d);


### PR DESCRIPTION
[Staging Link](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/remove-ast-source/)

Lighthouse before this change (60 performance):
[before.pdf](https://github.com/mongodb/devhub/files/5525694/before.pdf)

Lighthouse after this change (90 performance):
[after.pdf](https://github.com/mongodb/devhub/files/5525692/after.pdf)

This PR removes some unnecessary data from the learn and home page contexts to slim down async Gatsby preloading in the background. Before, we naively passed all aspects of an article to the learn page, which topped out at ~20MB. This was a clear issue. Upon further investigation we had two fields in here which contained the content for every article on the DevHub, `ast` and `source`. For these pages, we do not need the entire content of every article, so we can remove this content at build time which dramatically slimmed down the page context and improved page performance.

Let's just check that the learn page still works as expected, but this performance improvement is a welcome sight. Also feel free to run the Lighthouse test on this link to verify the 30pt increase!