### PR TITLE
DEVHUB-185 and DEVHUB-235: Learn Page Filter State

### DIFF
--- a/cypress/integration/learn.js
+++ b/cypress/integration/learn.js
@@ -31,7 +31,7 @@ describe('Learn Page', () => {
             cy.get('[data-test="card"]')
                 .first()
                 .should('contain', 'Working with MongoDB Transactions')
-                .click();
+                .click({ force: true });
         });
         cy.url().should('include', FIRST_ARTICLE_IN_ORDERING);
         // By targeting the hero banner we can be sure the navigation is done

--- a/cypress/integration/learn.js
+++ b/cypress/integration/learn.js
@@ -80,7 +80,7 @@ describe('Learn Page', () => {
         // Using trigger seems to work, but this should be looked into a bit more
         cy.contains('Atlas (26)').trigger('click');
         // The url should contain the filter value as a param
-        cy.url().should('include', '?products=Atlas');
+        cy.url().should('include', 'products=Atlas');
         // Check content
         cy.checkFirstCardInCardList('Coronavirus Map');
     });

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,5 +1,10 @@
-exports.shouldUpdateScroll = ({ prevRouterProps, routerProps }) => {
-    const prevLocation = prevRouterProps && prevRouterProps.location.pathname;
-    const newLocation = routerProps && routerProps.location.pathname;
+import { removeTrailingSlash } from './src/utils/remove-trailing-slash';
+
+export const shouldUpdateScroll = ({ prevRouterProps, routerProps }) => {
+    const prevLocation =
+        prevRouterProps &&
+        removeTrailingSlash(prevRouterProps.location.pathname);
+    const newLocation =
+        routerProps && removeTrailingSlash(routerProps.location.pathname);
     return prevLocation !== newLocation;
 };

--- a/src/components/dev-hub/input.js
+++ b/src/components/dev-hub/input.js
@@ -86,6 +86,8 @@ const InputContainer = styled('div')`
 
 const FormInput = ({ narrow, value, ...props }) => {
     const isEmpty = !value;
+    // Value can sometimes be null, this does not properly clear out the text field
+    const inputValue = isEmpty ? '' : value;
     return (
         <InputContainer isEmpty={isEmpty} narrow={narrow}>
             <Label
@@ -94,7 +96,7 @@ const FormInput = ({ narrow, value, ...props }) => {
             >
                 {props.placeholder}
             </Label>
-            <StyledInput value={value} narrow={narrow} {...props} />
+            <StyledInput value={inputValue} narrow={narrow} {...props} />
         </InputContainer>
     );
 };

--- a/src/components/dev-hub/select.js
+++ b/src/components/dev-hub/select.js
@@ -107,6 +107,12 @@ const FormSelect = ({
     useEffect(() => {
         setIsEnabled(enabled);
     }, [enabled]);
+    useEffect(() => {
+        if (!value) {
+            setSelectValue(value);
+            setSelectText(defaultText);
+        }
+    }, [defaultText, value]);
     /**
      * This useEffect should only be called once the component first renders with choices,
      * this should populate the select item with the default choice if there is one

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -189,6 +189,7 @@ const FeaturedArticles = ({ articles }) => {
 
 export default ({
     location,
+    navigate,
     pageContext: {
         allArticles,
         allPodcasts,
@@ -262,15 +263,13 @@ export default ({
         const searchParams = buildQueryString(filter);
         if (window.location.search !== searchParams) {
             // if the search params are empty, push the pathname state in order to remove params
-            window.history.replaceState(
-                {},
-                '',
-                searchParams === '' ? pathname : searchParams
-            );
+            navigate(searchParams === '' ? pathname : searchParams, {
+                replace: true,
+            });
             const filteredArticles = filterActiveArticles(filter);
             setArticles(filteredArticles);
         }
-    }, [metadata, filterValue, pathname, filterActiveArticles, location]);
+    }, [metadata, filterValue, pathname, filterActiveArticles, navigate]);
     // filterValue could be {} on a page load, or values can be "all" if toggled back
     const hasNoFilter = useMemo(
         () =>

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -239,13 +239,13 @@ export default ({
         filterValue => {
             const filter = stripAllParam(filterValue);
             const searchParams = buildQueryString(filter);
+            const filteredArticles = filterActiveArticles(filter);
+            setArticles(filteredArticles);
             if (window.location.search !== searchParams) {
                 // if the search params are empty, push the pathname state in order to remove params
                 navigate(searchParams === '' ? pathname : searchParams, {
                     replace: true,
                 });
-                const filteredArticles = filterActiveArticles(filter);
-                setArticles(filteredArticles);
             }
         },
         // Exclude "navigate" since it constantly changes

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -221,8 +221,8 @@ export default ({
         }
     }, []);
     useEffect(() => {
-        updateAllPageFilters(location.search);
-    }, [location.search, updateAllPageFilters]);
+        updateAllPageFilters(search);
+    }, [search, updateAllPageFilters]);
     const updateTextFilterQuery = useCallback(
         query => {
             setTextFilterQuery(query);

--- a/src/utils/get-article-share-links.js
+++ b/src/utils/get-article-share-links.js
@@ -1,7 +1,7 @@
+import { removeTrailingSlash } from './remove-trailing-slash';
+
 export const getArticleShareLinks = (title, url) => {
-    const urlWithoutTrailingSlash = url.match(/\/$/)
-        ? url.slice(0, url.length - 1)
-        : url;
+    const urlWithoutTrailingSlash = removeTrailingSlash(url);
     const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=${urlWithoutTrailingSlash}`;
     const twitterUrl = `https://twitter.com/intent/tweet?url=${urlWithoutTrailingSlash}&text=${encodeURIComponent(
         title

--- a/src/utils/learn-page-tabs.js
+++ b/src/utils/learn-page-tabs.js
@@ -1,0 +1,10 @@
+/**
+ * Enums are not supported in JS, only TS. Since we are not on TS, we can
+ * freeze an object to effectively create an enum.
+ */
+export const LearnPageTabs = Object.freeze({
+    all: 'All',
+    articles: 'Articles',
+    podcasts: 'Podcasts',
+    videos: 'Videos',
+});

--- a/src/utils/query-string.js
+++ b/src/utils/query-string.js
@@ -1,7 +1,10 @@
 export function buildQueryString(params) {
-    const entries = Object.keys(params).map(
-        key => encodeURIComponent(key) + '=' + encodeURIComponent(params[key])
-    );
+    const entries = Object.keys(params)
+        .sort()
+        .map(
+            key =>
+                encodeURIComponent(key) + '=' + encodeURIComponent(params[key])
+        );
     const string = entries.join('&');
     return string.length === 0 ? '' : '?' + string;
 }

--- a/src/utils/remove-trailing-slash.js
+++ b/src/utils/remove-trailing-slash.js
@@ -1,0 +1,3 @@
+// Returns a copy of the input string without a trailing slash, should it have one
+export const removeTrailingSlash = url =>
+    url && (url.match(/\/$/) ? url.slice(0, url.length - 1) : url);

--- a/tests/utils/remove-trailing-slash.test.js
+++ b/tests/utils/remove-trailing-slash.test.js
@@ -1,0 +1,14 @@
+import { removeTrailingSlash } from '../../src/utils/remove-trailing-slash';
+
+it('should remove trailing slashes from links where appropriate', () => {
+    const linkWithoutSlash = 'foo.bar';
+    const linkWithSlash = `${linkWithoutSlash}/`;
+    expect(removeTrailingSlash(linkWithSlash)).toBe(linkWithoutSlash);
+
+    // Should ignore anything without a slash
+    expect(removeTrailingSlash(linkWithoutSlash)).toBe(linkWithoutSlash);
+
+    // Should handle null/empty inputs
+    expect(removeTrailingSlash(null)).toBeNull();
+    expect(removeTrailingSlash('')).toBe('');
+});


### PR DESCRIPTION
[Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-185/learn)

This PR fixes some bugs with state on the learn page. Namely, the following points were addressed:
- Clears all state when the top `learn` link is clicked on the nav bar. (DEVHUB-185)
- Adds a query param to the URL based on which tab is clicked (articles, podcasts, etc.)
- Fixes a bug where the `select` component would not reset state while controlled by a parent if cleared
- Fixes a bug where pagination would change which filter settings were applied
- Adds an "enum" (actually an object since we are not on TS) for the different tabs on the learn page
- Fixes a bug where the URL would flicker with query params when certain filters were applied

Acceptance Criteria:
- Filters, Text filter, pagination, tabs should all still work as expected on the Learn page
- Clicking the `Learn` link on the top nav should reset state at any time
- Pagination should properly work with the same filters applied
- Clicking on an article from the learn page and then going back in the browser should keep filter settings