### PR TITLE
Upgrade LeafyGreen Code Block, Add Line Highlighting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5288,26 +5288,53 @@
       }
     },
     "@leafygreen-ui/code": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/code/-/code-3.5.0.tgz",
-      "integrity": "sha512-gtK7HKnred1jXQFCcgmVriwZpbBcu6minxF84D9T/2Pt87TkP5y5BeTsm2EHjywlXfegRQV5t9iDjeSRNu4qKQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/code/-/code-7.3.0.tgz",
+      "integrity": "sha512-Ka9M52EoDxCS24ST2kMYAA54Cew1EHwsdS36ajv9p0ya64W/ozDwgKWVXDyomNAvNoVLEGPcly7A7U/H27Odng==",
       "requires": {
-        "@leafygreen-ui/icon": "^6.1.0",
-        "@leafygreen-ui/icon-button": "^6.0.0",
-        "@leafygreen-ui/lib": "^4.4.1",
-        "@leafygreen-ui/syntax": "^2.6.0",
+        "@leafygreen-ui/hooks": "^6.0.0",
+        "@leafygreen-ui/icon": "^7.0.1",
+        "@leafygreen-ui/icon-button": "^9.0.1",
+        "@leafygreen-ui/lib": "^6.1.1",
+        "@leafygreen-ui/syntax": "^6.2.0",
         "clipboard": "^2.0.6"
       },
       "dependencies": {
-        "@leafygreen-ui/lib": {
-          "version": "4.5.1",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-4.5.1.tgz",
-          "integrity": "sha512-Dan2suXpQHDYPx8xJX6LrtZUzu6VuEocVZnc2bjVPCypFx5n3UB6cOBHDYLIbUA36gMsfOHZ6e7nj2sUKc5I+A==",
+        "@leafygreen-ui/emotion": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-3.0.1.tgz",
+          "integrity": "sha512-h0VaYrbwC7jNpGKXq81qu4QveT9lyPQFDRrcePIL+UoDA8nLRzs+5T2oxyJkHqulmgHrRTmLEXv2pIuJinbKHA==",
           "requires": {
-            "@leafygreen-ui/emotion": "^2.0.1",
-            "@testing-library/react": "^8.0.1",
+            "create-emotion": "^10.0.7",
+            "create-emotion-server": "10.0.27",
+            "emotion": "^10.0.7"
+          }
+        },
+        "@leafygreen-ui/hooks": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-6.0.0.tgz",
+          "integrity": "sha512-KkOOhiQ+kgiaJo0Uj5kxyYKHillJUzbofy6qFPwjvsf2jZ1LbEsd/1RB9Ck5UDbaiRMhmdSBkWux4u8fOy42BA==",
+          "requires": {
+            "lodash": "^4.17.20"
+          }
+        },
+        "@leafygreen-ui/icon": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-7.0.1.tgz",
+          "integrity": "sha512-Qo07jAw9GA9s8uKi5UGfj5ikegKuA5dMjhp0YY9s0HIdSMg7jjTkJXe/UPQ+XbVnXuZPY7vW0mosM7BQsu0aEA==",
+          "requires": {
+            "@leafygreen-ui/lib": "^6.0.1"
+          }
+        },
+        "@leafygreen-ui/lib": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-6.1.1.tgz",
+          "integrity": "sha512-lteg/OcZa2Z5X/TF8fmQt/fPSnaYrx3eVqRHM2eHn5DbvLo4ZWN7EXj+LFViGkRQ61XAg1q+4uVm6majbKRXRg==",
+          "requires": {
+            "@leafygreen-ui/emotion": "^3.0.1",
             "facepaint": "^1.2.1",
-            "polished": "^2.3.0"
+            "polished": "^2.3.0",
+            "prop-types": "^15.0.0"
           }
         }
       }
@@ -5339,13 +5366,51 @@
       }
     },
     "@leafygreen-ui/icon-button": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon-button/-/icon-button-6.1.4.tgz",
-      "integrity": "sha512-nXD4iUbd7qT/SNeWx2aEHIDxkpLsltDQnDSw8LCDhwVut07ZjtncqKk9WPXkNO54MXs+VHvO740yIz7rhmAZ3A==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon-button/-/icon-button-9.0.1.tgz",
+      "integrity": "sha512-4k8paYh0AbmNXwHEBBwLxo+8EU/hy307la0jSjKktGR/rAoxm0MX0gGFH7STwh0qiLvAakA97Jh8FcF8BwoS/g==",
       "requires": {
-        "@leafygreen-ui/emotion": "2.0.2",
-        "@leafygreen-ui/lib": "^5.1.1",
-        "@leafygreen-ui/palette": "2.0.2"
+        "@leafygreen-ui/box": "^3.0.1",
+        "@leafygreen-ui/emotion": "^3.0.1",
+        "@leafygreen-ui/lib": "^6.0.1",
+        "@leafygreen-ui/palette": "^3.0.1"
+      },
+      "dependencies": {
+        "@leafygreen-ui/box": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/box/-/box-3.0.2.tgz",
+          "integrity": "sha512-cyIw5POyivusUlHIVC3Enb5AVAAaLBF4DhdxPw9ymZL4lIJMZiRrFq7ayKykdyUXaB5jOnn+4qha2OXrgTYmJQ==",
+          "requires": {
+            "@leafygreen-ui/lib": "^6.0.1",
+            "lodash": "^4.17.20"
+          }
+        },
+        "@leafygreen-ui/emotion": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-3.0.1.tgz",
+          "integrity": "sha512-h0VaYrbwC7jNpGKXq81qu4QveT9lyPQFDRrcePIL+UoDA8nLRzs+5T2oxyJkHqulmgHrRTmLEXv2pIuJinbKHA==",
+          "requires": {
+            "create-emotion": "^10.0.7",
+            "create-emotion-server": "10.0.27",
+            "emotion": "^10.0.7"
+          }
+        },
+        "@leafygreen-ui/lib": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-6.1.1.tgz",
+          "integrity": "sha512-lteg/OcZa2Z5X/TF8fmQt/fPSnaYrx3eVqRHM2eHn5DbvLo4ZWN7EXj+LFViGkRQ61XAg1q+4uVm6majbKRXRg==",
+          "requires": {
+            "@leafygreen-ui/emotion": "^3.0.1",
+            "facepaint": "^1.2.1",
+            "polished": "^2.3.0",
+            "prop-types": "^15.0.0"
+          }
+        },
+        "@leafygreen-ui/palette": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-3.1.0.tgz",
+          "integrity": "sha512-+KuBtiSD72vwWb2VMoDX1AJ6eLjsbWcQcJgmkNxWNih4DtJieufNxTxsJwvPRWoe6ik1yfchBJnugehLEAvHIQ=="
+        }
       }
     },
     "@leafygreen-ui/leafygreen-provider": {
@@ -5373,25 +5438,50 @@
       "integrity": "sha512-QxjLcJu1WqKjJvlTw6nmq3gdjBEVy9rXdxBlkMR0hgvyzK3qW6w+iGaJExnjMRppzND7ijzsF0IJn1TYKNmevg=="
     },
     "@leafygreen-ui/syntax": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/syntax/-/syntax-2.8.0.tgz",
-      "integrity": "sha512-AJ1DP8kupmVkQa/OCh4CWA4xDquXTW1VX9pNOYI2IjNnwNwnKcqvf7M3QK5ndn4x1goFb9gKBxWmFDGdADCwNw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/syntax/-/syntax-6.2.0.tgz",
+      "integrity": "sha512-2Cel63WlD+kyZ+zaC1khr3szZOAzWL4OAJgBuvjugRDNEOnJv0cq79j6REQMZ8z7rzVuqMYbudOvR+G8AOaMSQ==",
       "requires": {
-        "@leafygreen-ui/lib": "^4.3.0",
-        "@leafygreen-ui/palette": "^2.0.1",
-        "highlight.js": "^9.15.6",
-        "highlightjs-graphql": "^1.0.1"
+        "@leafygreen-ui/lib": "^6.1.0",
+        "@leafygreen-ui/palette": "^3.0.1",
+        "@leafygreen-ui/tokens": "^0.5.0",
+        "highlight.js": "^10.0.3",
+        "highlightjs-graphql": "^1.0.1",
+        "highlightjs-line-numbers.js": "^2.7.0"
       },
       "dependencies": {
-        "@leafygreen-ui/lib": {
-          "version": "4.5.1",
-          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-4.5.1.tgz",
-          "integrity": "sha512-Dan2suXpQHDYPx8xJX6LrtZUzu6VuEocVZnc2bjVPCypFx5n3UB6cOBHDYLIbUA36gMsfOHZ6e7nj2sUKc5I+A==",
+        "@leafygreen-ui/emotion": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-3.0.1.tgz",
+          "integrity": "sha512-h0VaYrbwC7jNpGKXq81qu4QveT9lyPQFDRrcePIL+UoDA8nLRzs+5T2oxyJkHqulmgHrRTmLEXv2pIuJinbKHA==",
           "requires": {
-            "@leafygreen-ui/emotion": "^2.0.1",
-            "@testing-library/react": "^8.0.1",
+            "create-emotion": "^10.0.7",
+            "create-emotion-server": "10.0.27",
+            "emotion": "^10.0.7"
+          }
+        },
+        "@leafygreen-ui/lib": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-6.1.1.tgz",
+          "integrity": "sha512-lteg/OcZa2Z5X/TF8fmQt/fPSnaYrx3eVqRHM2eHn5DbvLo4ZWN7EXj+LFViGkRQ61XAg1q+4uVm6majbKRXRg==",
+          "requires": {
+            "@leafygreen-ui/emotion": "^3.0.1",
             "facepaint": "^1.2.1",
-            "polished": "^2.3.0"
+            "polished": "^2.3.0",
+            "prop-types": "^15.0.0"
+          }
+        },
+        "@leafygreen-ui/palette": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-3.1.0.tgz",
+          "integrity": "sha512-+KuBtiSD72vwWb2VMoDX1AJ6eLjsbWcQcJgmkNxWNih4DtJieufNxTxsJwvPRWoe6ik1yfchBJnugehLEAvHIQ=="
+        },
+        "@leafygreen-ui/tokens": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-0.5.0.tgz",
+          "integrity": "sha512-1rnFI1NSNtddMtRzwy4rS/4NF3rO7eK1dbw/+h+VAqY1OZHNJinV0R283QJajx2dMttm20mOpTN6v099kM0SxQ==",
+          "requires": {
+            "@leafygreen-ui/lib": "^6.0.1"
           }
         }
       }
@@ -5989,11 +6079,6 @@
       "requires": {
         "any-observable": "^0.3.0"
       }
-    },
-    "@sheerun/mutationobserver-shim": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
-      "integrity": "sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw=="
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -8970,58 +9055,6 @@
         "defer-to-connect": "^1.0.1"
       }
     },
-    "@testing-library/dom": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-5.6.1.tgz",
-      "integrity": "sha512-Y1T2bjtvQMewffn1CJ28kpgnuvPYKsBcZMagEH0ppfEMZPDc8AkkEnTk4smrGZKw0cblNB3lhM2FMnpfLExlHg==",
-      "requires": {
-        "@babel/runtime": "^7.5.5",
-        "@sheerun/mutationobserver-shim": "^0.3.2",
-        "aria-query": "3.0.0",
-        "pretty-format": "^24.8.0",
-        "wait-for-expect": "^1.2.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "24.9.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
-          "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^1.1.1",
-            "@types/yargs": "^13.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "13.0.10",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.10.tgz",
-          "integrity": "sha512-MU10TSgzNABgdzKvQVW1nuuT+sgBMWeXNc3XOs5YXV5SDAK+PPja2eUuBNB9iqElu03xyEDqlnGw0jgl4nbqGQ==",
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "pretty-format": {
-          "version": "24.9.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
-          "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
-          "requires": {
-            "@jest/types": "^24.9.0",
-            "ansi-regex": "^4.0.0",
-            "ansi-styles": "^3.2.0",
-            "react-is": "^16.8.4"
-          }
-        }
-      }
-    },
-    "@testing-library/react": {
-      "version": "8.0.9",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-8.0.9.tgz",
-      "integrity": "sha512-I7zd+MW5wk8rQA5VopZgBfxGKUd91jgZ6Vzj2gMqFf2iGGtKwvI5SVTrIJcSFaOXK88T2EUsbsIKugDtoqOcZQ==",
-      "requires": {
-        "@babel/runtime": "^7.5.5",
-        "@testing-library/dom": "^5.6.1"
-      }
-    },
     "@testing-library/react-hooks": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-3.4.1.tgz",
@@ -10194,15 +10227,6 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
         "sprintf-js": "~1.0.2"
-      }
-    },
-    "aria-query": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
-      "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
-      "requires": {
-        "ast-types-flow": "0.0.7",
-        "commander": "^2.11.0"
       }
     },
     "arr-diff": {
@@ -21327,14 +21351,19 @@
       "integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg=="
     },
     "highlight.js": {
-      "version": "9.18.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
-      "integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ=="
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.0.tgz",
+      "integrity": "sha512-EfrUGcQ63oLJbj0J0RI9ebX6TAITbsDBLbsjr881L/X5fMO9+oadKzEF21C7R3ULKG6Gv3uoab2HiqVJa/4+oA=="
     },
     "highlightjs-graphql": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/highlightjs-graphql/-/highlightjs-graphql-1.0.1.tgz",
-      "integrity": "sha512-g5kt/orsUJTjIt5pgs/uvi78kXndpCtYwzE7H3D0d07r3ETs9oHSZHD0EGaRPndiQ/4EYXt12rnsDkljn3ilAA=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/highlightjs-graphql/-/highlightjs-graphql-1.0.2.tgz",
+      "integrity": "sha512-jShTftpKQDwMXc+7OHOpHXRYSweT08EO2YOIcLbwU00e9yuwJMYXGLF1eiDO0aUPeQU4/5EjAh5HtPt3ly7rvg=="
+    },
+    "highlightjs-line-numbers.js": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/highlightjs-line-numbers.js/-/highlightjs-line-numbers.js-2.8.0.tgz",
+      "integrity": "sha512-TEf1gw0c8mb8nan0QwliqS7obT4cpUd9hzsGzsZLweteNnWea/VIqy5/aQqsa5wnz9lnvmtAkS1ZtDTjB/goYQ=="
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -33968,11 +33997,6 @@
       "requires": {
         "xml-name-validator": "^3.0.0"
       }
-    },
-    "wait-for-expect": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.3.0.tgz",
-      "integrity": "sha512-8fJU7jiA96HfGPt+P/UilelSAZfhMBJ52YhKzlmZQvKEZU2EcD1GQ0yqGB6liLdHjYtYAoGVigYwdxr5rktvzA=="
     },
     "walker": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@emotion/core": "^10.0.35",
     "@emotion/styled": "^10.0.27",
     "@leafygreen-ui/checkbox": "^4.1.1",
-    "@leafygreen-ui/code": "^3.5.0",
+    "@leafygreen-ui/code": "^7.3.0",
     "@leafygreen-ui/icon": "^6.4.2",
     "@leafygreen-ui/tabs": "^3.0.1",
     "@reach/router": "^1.3.4",

--- a/src/components/dev-hub/codeblock.js
+++ b/src/components/dev-hub/codeblock.js
@@ -5,7 +5,7 @@ import Code from '@leafygreen-ui/code';
 import { lineHeight, size } from './theme';
 import CopyButton, { COPY_BUTTON_WIDTH } from './copy-button';
 
-const LEAFY_LINENUMBER_PADDING = 24;
+const LEAFY_LINENUMBER_PADDING = size.stripUnit(size.mediumLarge);
 
 const CodeContainer = styled('div')`
     display: inline-block;

--- a/src/components/dev-hub/codeblock.js
+++ b/src/components/dev-hub/codeblock.js
@@ -5,8 +5,7 @@ import Code from '@leafygreen-ui/code';
 import { lineHeight, size } from './theme';
 import CopyButton, { COPY_BUTTON_WIDTH } from './copy-button';
 
-const LEAFY_CODEBLOCK_PADDING = 12;
-const LEAFY_LINENUMBER_PADDING = 42;
+const LEAFY_LINENUMBER_PADDING = 24;
 
 const CodeContainer = styled('div')`
     display: inline-block;
@@ -27,20 +26,22 @@ const CopyContainer = styled('div')`
     left: calc(100% - ${COPY_BUTTON_WIDTH}px - ${size.tiny});
     position: absolute;
     top: ${size.tiny};
+    z-index: 1;
 `;
 
 const StyledCode = styled(Code)`
     border: 1px solid ${({ theme }) => theme.colorMap.greyDarkThree};
     border-radius: ${size.small};
     line-height: ${lineHeight.xsmall};
-    padding-right: ${size.xlarge};
     padding-top: ${size.large};
-    ${({ numdigits }) =>
-        `padding-left: calc(${LEAFY_LINENUMBER_PADDING}px + ${
-            numdigits * size.stripUnit(size.xsmall)
-        }px)`};
-    /* Line Numbers */
-    > div {
+    position: relative;
+    z-index: 1;
+    /* Line number text */
+    td:first-of-type {
+        color: ${({ theme }) => theme.colorMap.greyLightTwo};
+    }
+    /* Line number background */
+    :before {
         background-color: ${({ theme }) => theme.colorMap.greyDarkTwo};
         border-image: linear-gradient(
                 0deg,
@@ -51,15 +52,23 @@ const StyledCode = styled(Code)`
             1;
         border-width: 0 2px 0 0;
         border-right-style: solid;
+        bottom: 0;
         color: ${({ theme }) => theme.colorMap.greyLightTwo};
+        content: '';
         left: 0;
-        padding: ${LEAFY_CODEBLOCK_PADDING}px;
-        padding-top: ${size.large};
-        text-align: right;
+        position: absolute;
+        top: 0;
+        ${({ numdigits }) =>
+            `width: calc(${LEAFY_LINENUMBER_PADDING}px + ${
+                numdigits * size.stripUnit(size.xsmall)
+            }px)`};
+        z-index: -1;
     }
 `;
 
-const CodeBlock = ({ nodeData: { lang = null, value } }) => {
+const CodeBlock = ({
+    nodeData: { emphasize_lines: emphasizeLines, lang = null, value },
+}) => {
     // We wish to up padding based on the number of lines based on the size of the max number length
     const numLines = useMemo(() => value.split(/\r|\n/).length, [value]);
     const numDigits = useMemo(() => Math.floor(Math.log10(numLines) + 1), [
@@ -71,10 +80,11 @@ const CodeBlock = ({ nodeData: { lang = null, value } }) => {
         <CodeContainer>
             <StyledCode
                 copyable={false}
+                darkMode={true}
+                highlightLines={emphasizeLines}
                 language={language}
                 numdigits={numDigits}
                 showLineNumbers
-                variant="dark"
             >
                 {value}
             </StyledCode>

--- a/src/components/dev-hub/codeblock.js
+++ b/src/components/dev-hub/codeblock.js
@@ -29,6 +29,9 @@ const CopyContainer = styled('div')`
     z-index: 1;
 `;
 
+const lineNumberWidth = numdigits =>
+    LEAFY_LINENUMBER_PADDING + numdigits * size.stripUnit(size.xsmall);
+
 const StyledCode = styled(Code)`
     border: 1px solid ${({ theme }) => theme.colorMap.greyDarkThree};
     border-radius: ${size.small};
@@ -39,9 +42,14 @@ const StyledCode = styled(Code)`
     /* Line number text */
     td:first-of-type {
         color: ${({ theme }) => theme.colorMap.greyLightTwo};
+        ${({ numdigits }) =>
+            `width: ${
+                lineNumberWidth(numdigits) + size.stripUnit(size.default)
+            }px`}
     }
     table {
-        width: unset;
+        table-layout: fixed;
+        width: 100%;
     }
     /* Line number background */
     :before {
@@ -61,10 +69,7 @@ const StyledCode = styled(Code)`
         left: 0;
         position: absolute;
         top: 0;
-        ${({ numdigits }) =>
-            `width: calc(${LEAFY_LINENUMBER_PADDING}px + ${
-                numdigits * size.stripUnit(size.xsmall)
-            }px)`};
+        ${({ numdigits }) => `width: ${lineNumberWidth(numdigits)}px`};
         z-index: -1;
     }
 `;

--- a/src/components/dev-hub/codeblock.js
+++ b/src/components/dev-hub/codeblock.js
@@ -40,6 +40,9 @@ const StyledCode = styled(Code)`
     td:first-of-type {
         color: ${({ theme }) => theme.colorMap.greyLightTwo};
     }
+    table {
+        width: unset;
+    }
     /* Line number background */
     :before {
         background-color: ${({ theme }) => theme.colorMap.greyDarkTwo};
@@ -75,7 +78,7 @@ const CodeBlock = ({
         numLines,
     ]);
     // Leafy expects 'csp' as 'cs'
-    const language = lang === 'csp' ? 'cs' : lang || 'auto';
+    const language = lang === 'csp' ? 'cs' : lang || 'none';
     return (
         <CodeContainer>
             <StyledCode


### PR DESCRIPTION
[Staging Article](https://docs-mongodbcom-staging.corp.mongodb.com/remove-auto-option/devhub/jordanstapinski/DEVHUB-258/article/3-things-to-know-switch-from-sql-mongodb)
[Prod Article](developer.mongodb.com/article/3-things-to-know-switch-from-sql-mongodb)

This cannot be merged until a PR in devhub content is approved. This is because `auto` is no longer supported.

This PR upgrades the LeafyGreen code block to v7 from v3. This re-structures how the component is rendered on the DOM so we had to update the styling here as well since it is now using a CSS table for the overall layout.

What we do now is use an absolute element for the light grey background on the line numbers and gradient. Check out the staging links to see the style and highlighting in action!