### PR TITLE
DEVHUB-295: Add Share Something CTA

### DIFF
--- a/src/components/dev-hub/stories/student-spotlight.stories.mdx
+++ b/src/components/dev-hub/stories/student-spotlight.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
-import { GithubStudentPack } from '../student-spotlight';
+import { GithubStudentPack, ShareProjectCTA } from '../student-spotlight';
 
 <Meta title="Student Spotlight" />
 
@@ -8,5 +8,8 @@ import { GithubStudentPack } from '../student-spotlight';
 <Preview>
     <Story name="GithubStudentPack">
         <GithubStudentPack />
+    </Story>
+    <Story name="Share Project CTA">
+        <ShareProjectCTA />
     </Story>
 </Preview>

--- a/src/components/dev-hub/student-spotlight/index.js
+++ b/src/components/dev-hub/student-spotlight/index.js
@@ -1,3 +1,4 @@
 import GithubStudentPack from './github-student-pack';
+import ShareProjectCTA from './share-project-cta';
 
-export { GithubStudentPack };
+export { GithubStudentPack, ShareProjectCTA };

--- a/src/components/dev-hub/student-spotlight/share-project-cta.js
+++ b/src/components/dev-hub/student-spotlight/share-project-cta.js
@@ -4,8 +4,8 @@ import { H3 } from '../text';
 import Button from '../button';
 import { size } from '../theme';
 
-const MAX_WIDTH = '600px';
 const FORM_LINK = '/student-spotlight-form/';
+const MAX_WIDTH = '600px';
 
 const MaxWidthContainer = styled('div')`
     margin: 0 auto;

--- a/src/components/dev-hub/student-spotlight/share-project-cta.js
+++ b/src/components/dev-hub/student-spotlight/share-project-cta.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { H3 } from '../text';
+import Button from '../button';
+import { size } from '../theme';
+
+const MAX_WIDTH = '600px';
+const FORM_LINK = '/student-spotlight-form/';
+
+const MaxWidthContainer = styled('div')`
+    margin: 0 auto;
+    max-width: ${MAX_WIDTH};
+    text-align: center;
+`;
+
+const HeaderWithIncreasedMargin = styled(H3)`
+    margin-bottom: ${size.medium};
+`;
+
+const ShareProjectCTA = () => (
+    <MaxWidthContainer>
+        <HeaderWithIncreasedMargin>
+            Have an interesting MongoDB project to share? Let us know!
+        </HeaderWithIncreasedMargin>
+        <Button primary to={FORM_LINK}>
+            Share something you're proud of
+        </Button>
+    </MaxWidthContainer>
+);
+
+export default ShareProjectCTA;

--- a/src/components/dev-hub/student-spotlight/share-project-cta.js
+++ b/src/components/dev-hub/student-spotlight/share-project-cta.js
@@ -23,7 +23,7 @@ const ShareProjectCTA = () => (
             Have an interesting MongoDB project to share? Let us know!
         </HeaderWithIncreasedMargin>
         <Button primary to={FORM_LINK}>
-            Share something you're proud of
+            Show off your work
         </Button>
     </MaxWidthContainer>
 );


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DEVHUB-295)

This PR adds a simple component to encourage students to share their work by giving some short text and a CTA. On "small mobile" (< 350px) the copy breaks line, so perhaps we want to shorten the copy.

![Screen Shot 2020-12-14 at 5 18 25 PM](https://user-images.githubusercontent.com/9064401/102142730-e407c980-3e30-11eb-8d89-b5696c234cf4.png)
![Screen Shot 2020-12-14 at 5 18 34 PM](https://user-images.githubusercontent.com/9064401/102142731-e4a06000-3e30-11eb-81a4-8f6bc3ffb6ae.png)