### PR TITLE
DEVHUB-322: Let captions float with images in figures

### DIFF
--- a/src/components/Figure.js
+++ b/src/components/Figure.js
@@ -2,20 +2,31 @@ import React from 'react';
 import styled from '@emotion/styled';
 import CaptionLegend from './CaptionLegend';
 import Image from './Image';
+import { getImageAlignmentStyle } from '../utils/get-image-alignment-style';
 import { getNestedValue } from '../utils/get-nested-value';
 import { size } from './dev-hub/theme';
 
 const Figure = styled('figure')`
     margin: 0 0 ${size.articleContent};
+    width: ${({ figWidth }) => figWidth};
+    ${({ alignStyle }) => alignStyle};
 `;
-export default ({ nodeData, ...rest }) => (
-    <Figure
-        className="figure"
-        style={{
-            width: getNestedValue(['options', 'figwidth'], nodeData) || 'auto',
-        }}
-    >
-        <Image nodeData={nodeData} captioned={!!nodeData.children.length} />
-        <CaptionLegend {...rest} nodeData={nodeData} />
-    </Figure>
-);
+
+const removeAlignOption = nodeData => delete nodeData['options']['align'];
+
+export default ({ nodeData, ...rest }) => {
+    const customAlign = getNestedValue(['options', 'align'], nodeData);
+    if (customAlign) {
+        // Apply the alignment to the figure, no need to also apply to image
+        removeAlignOption(nodeData);
+    }
+    const alignStyle = getImageAlignmentStyle(customAlign);
+    const figWidth =
+        getNestedValue(['options', 'figwidth'], nodeData) || 'auto';
+    return (
+        <Figure alignStyle={alignStyle} figWidth={figWidth}>
+            <Image nodeData={nodeData} captioned={!!nodeData.children.length} />
+            <CaptionLegend {...rest} nodeData={nodeData} />
+        </Figure>
+    );
+};

--- a/src/components/Figure.js
+++ b/src/components/Figure.js
@@ -12,14 +12,8 @@ const Figure = styled('figure')`
     ${({ alignStyle }) => alignStyle};
 `;
 
-const removeAlignOption = nodeData => delete nodeData['options']['align'];
-
 export default ({ nodeData, ...rest }) => {
     const customAlign = getNestedValue(['options', 'align'], nodeData);
-    if (customAlign) {
-        // Apply the alignment to the figure, no need to also apply to image
-        removeAlignOption(nodeData);
-    }
     const alignStyle = getImageAlignmentStyle(customAlign);
     const figWidth =
         getNestedValue(['options', 'figwidth'], nodeData) || 'auto';

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -2,32 +2,12 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { withPrefix } from 'gatsby';
 import { css } from '@emotion/core';
+import { getImageAlignmentStyle } from '../utils/get-image-alignment-style';
 import { getNestedValue } from '../utils/get-nested-value';
 import { size } from './dev-hub/theme';
 
-const getAlignment = align => {
-    switch (align) {
-        case 'left':
-            return css`
-                float: left;
-            `;
-        case 'right':
-            return css`
-                float: right;
-            `;
-        case 'center':
-            return css`
-                display: block;
-                margin-left: auto;
-                margin-right: auto;
-            `;
-        default:
-            return null;
-    }
-};
-
 const ArticleImageStyle = (captioned, customAlign, scale) => css`
-    ${getAlignment(customAlign)}
+    ${getImageAlignmentStyle(customAlign)}
     border-radius: ${size.small};
     margin-bottom: ${captioned ? size.small : size.articleContent};
     vertical-align: bottom; /* prevent the default image spacing below image */

--- a/src/utils/get-image-alignment-style.js
+++ b/src/utils/get-image-alignment-style.js
@@ -1,0 +1,29 @@
+import { css } from '@emotion/core';
+import { screenSize, size } from '../components/dev-hub/theme';
+
+export const getImageAlignmentStyle = align => {
+    switch (align) {
+        case 'left':
+            return css`
+                float: left;
+                @media ${screenSize.mediumAndUp} {
+                    margin-right: ${size.default};
+                }
+            `;
+        case 'right':
+            return css`
+                float: right;
+                @media ${screenSize.mediumAndUp} {
+                    margin-left: ${size.default};
+                }
+            `;
+        case 'center':
+            return css`
+                display: block;
+                margin-left: auto;
+                margin-right: auto;
+            `;
+        default:
+            return null;
+    }
+};

--- a/tests/unit/__snapshots__/Figure.test.js.snap
+++ b/tests/unit/__snapshots__/Figure.test.js.snap
@@ -2,8 +2,7 @@
 
 exports[`renders correctly 1`] = `
 <figure
-  class="figure css-qwl3ci-Figure e1afvbh00"
-  style="width:700px"
+  class="css-73jyry-Figure e1afvbh00"
 >
   <img
     alt="/images/firstcluster.png"
@@ -17,8 +16,7 @@ exports[`renders correctly 1`] = `
 
 exports[`renders lightbox correctly when specified as an option 1`] = `
 <figure
-  class="figure css-qwl3ci-Figure e1afvbh00"
-  style="width:700px"
+  class="css-73jyry-Figure e1afvbh00"
 >
   <img
     alt="/images/firstcluster.png"


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DEVHUB-322)

[Broken Article](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/staging/article/schema-design-anti-pattern-bloated-documents)
[Fixed Article](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-322/article/schema-design-anti-pattern-bloated-documents)

This PR fixes a bug that has been around but not uncovered until now. The idea is that with a `figure` that has some `align` option and a caption, the caption does not float with the image. The solution is to have the entire block float together! I also took this chance to clean up some CSS in the `figure`

Check out the article in the staging link and the broken article link. In the latter you will see for some GIFs the caption looks out of place. This is fixed here in the staging link!

A/C:
- Captions float with images
- Figure is unaffected in any other way
- Image is unaffected in any other way