### PR TITLE
Remove option if not centered to repeat duplicated CSS

### DIFF
--- a/src/components/Figure.js
+++ b/src/components/Figure.js
@@ -12,8 +12,15 @@ const Figure = styled('figure')`
     ${({ alignStyle }) => alignStyle};
 `;
 
+const removeAlignOption = nodeData => delete nodeData['options']['align'];
+
 export default ({ nodeData, ...rest }) => {
     const customAlign = getNestedValue(['options', 'align'], nodeData);
+    const isCentered = customAlign === 'center';
+    if (!isCentered) {
+        // Apply the alignment to the figure, no need to also apply to image
+        removeAlignOption(nodeData);
+    }
     const alignStyle = getImageAlignmentStyle(customAlign);
     const figWidth =
         getNestedValue(['options', 'figwidth'], nodeData) || 'auto';


### PR DESCRIPTION
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-322/article/schema-design-anti-pattern-bloated-documents#example)

fyi @sophstad I added some margin in #567 that then got repeated by leaving `nodeData` align alone. This is a happy medium by allowing the centering to persist, but not duplicating anything else