### PR TITLE
DEVHUB-291: Hover Card

### DIFF
--- a/src/components/dev-hub/hover-card.js
+++ b/src/components/dev-hub/hover-card.js
@@ -37,6 +37,7 @@ const Image = styled('img')`
 const RoundedContainer = styled('div')`
     border-radius: ${size.small};
     height: 100%;
+    display: block;
     position: relative;
     text-align: center;
     width: 100%;

--- a/src/components/dev-hub/hover-card.js
+++ b/src/components/dev-hub/hover-card.js
@@ -36,8 +36,8 @@ const Image = styled('img')`
 
 const RoundedContainer = styled('div')`
     border-radius: ${size.small};
-    height: 100%;
     display: block;
+    height: 100%;
     position: relative;
     text-align: center;
     width: 100%;

--- a/src/components/dev-hub/hover-card.js
+++ b/src/components/dev-hub/hover-card.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+import Link from './link';
+import { size } from './theme';
+
+const hoverBackground = theme => css`
+    :before {
+        content: '';
+        background-color: ${theme.colorMap.greyDarkThree};
+        opacity: 0;
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        border-radius: ${size.small};
+        transition: opacity 0.15s linear;
+    }
+`;
+
+const HoverContent = styled('div')`
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    opacity: 0;
+    transform: translate(-50%, -50%);
+    visibility: hidden;
+    transition: opacity 0.15s linear;
+`;
+const RoundedContainer = styled('div')`
+    border-radius: ${size.small};
+    text-align: center;
+    position: relative;
+    height: 100%;
+    width: 100%;
+    ${({ theme }) => hoverBackground(theme)};
+    &:hover,
+    &:focus {
+        div {
+            opacity: 1;
+            visibility: visible;
+        }
+        :before {
+            opacity: 0.8;
+        }
+    }
+`;
+
+const Image = styled('img')`
+    border-radius: ${size.small};
+    height: 100%;
+    object-fit: cover;
+    width: 100%;
+`;
+
+const HoverCard = ({ alt, children, image, to, ...props }) => {
+    const ContentWrapper = to
+        ? RoundedContainer.withComponent(Link)
+        : RoundedContainer;
+    return (
+        <ContentWrapper tabIndex="0" role="tooltip" {...props}>
+            <Image alt={alt} loading="lazy" src={image} />
+            <HoverContent>{children}</HoverContent>
+        </ContentWrapper>
+    );
+};
+
+export default HoverCard;

--- a/src/components/dev-hub/hover-card.js
+++ b/src/components/dev-hub/hover-card.js
@@ -62,7 +62,7 @@ const HoverCard = ({ alt, children, image, to, ...props }) => {
         ? RoundedContainer.withComponent(Link)
         : RoundedContainer;
     return (
-        <ContentWrapper role="tooltip" tabIndex="0" to={to} {...props}>
+        <ContentWrapper tabIndex="0" to={to} {...props}>
             <Image alt={alt} loading="lazy" src={image} />
             <HoverContent>{children}</HoverContent>
         </ContentWrapper>

--- a/src/components/dev-hub/hover-card.js
+++ b/src/components/dev-hub/hover-card.js
@@ -5,46 +5,26 @@ import Link from './link';
 import { size } from './theme';
 
 const hoverBackground = theme => css`
-    :before {
-        content: '';
-        background-color: ${theme.colorMap.greyDarkThree};
-        opacity: 0;
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        border-radius: ${size.small};
-        transition: opacity 0.15s linear;
-    }
+    background-color: ${theme.colorMap.greyDarkThree};
+    border-radius: ${size.small};
+    bottom: 0;
+    content: '';
+    left: 0;
+    position: absolute;
+    right: 0;
+    opacity: 0;
+    top: 0;
+    transition: opacity 0.15s linear;
 `;
 
 const HoverContent = styled('div')`
-    position: absolute;
-    top: 50%;
     left: 50%;
     opacity: 0;
+    position: absolute;
+    top: 50%;
     transform: translate(-50%, -50%);
-    visibility: hidden;
     transition: opacity 0.15s linear;
-`;
-const RoundedContainer = styled('div')`
-    border-radius: ${size.small};
-    text-align: center;
-    position: relative;
-    height: 100%;
-    width: 100%;
-    ${({ theme }) => hoverBackground(theme)};
-    &:hover,
-    &:focus {
-        div {
-            opacity: 1;
-            visibility: visible;
-        }
-        :before {
-            opacity: 0.8;
-        }
-    }
+    visibility: hidden;
 `;
 
 const Image = styled('img')`
@@ -54,12 +34,35 @@ const Image = styled('img')`
     width: 100%;
 `;
 
+const RoundedContainer = styled('div')`
+    border-radius: ${size.small};
+    height: 100%;
+    position: relative;
+    text-align: center;
+    width: 100%;
+    :before {
+        ${({ theme }) => hoverBackground(theme)};
+    }
+    &:hover,
+    &:focus {
+        color: unset;
+        ${HoverContent} {
+            opacity: 1;
+            visibility: visible;
+        }
+        /* Parent controls the background opacity */
+        :before {
+            opacity: 0.8;
+        }
+    }
+`;
+
 const HoverCard = ({ alt, children, image, to, ...props }) => {
     const ContentWrapper = to
         ? RoundedContainer.withComponent(Link)
         : RoundedContainer;
     return (
-        <ContentWrapper tabIndex="0" role="tooltip" {...props}>
+        <ContentWrapper role="tooltip" tabIndex="0" to={to} {...props}>
             <Image alt={alt} loading="lazy" src={image} />
             <HoverContent>{children}</HoverContent>
         </ContentWrapper>

--- a/src/components/dev-hub/hover-card.js
+++ b/src/components/dev-hub/hover-card.js
@@ -2,34 +2,50 @@ import React from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import Link from './link';
-import { size } from './theme';
+import { animationSpeed, size } from './theme';
 
-const hoverBackground = theme => css`
-    background-color: ${theme.colorMap.greyDarkThree};
-    border-radius: ${size.small};
-    bottom: 0;
-    content: '';
-    left: 0;
-    position: absolute;
-    right: 0;
-    opacity: 0;
-    top: 0;
-    transition: opacity 0.15s linear;
-`;
-
-const HoverContent = styled('div')`
+const centerContentAbsolutely = css`
     left: 50%;
     opacity: 0;
     position: absolute;
     top: 50%;
     transform: translate(-50%, -50%);
-    transition: opacity 0.15s linear;
+`;
+
+const fillEntireSpaceAbsolutely = css`
+    bottom: 0;
+    content: '';
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+`;
+
+const hoverBackground = theme => css`
+    background-color: ${theme.colorMap.greyDarkThree};
+    border-radius: ${size.small};
+    opacity: 0;
+    transition: opacity ${animationSpeed.fast} linear;
+    ${fillEntireSpaceAbsolutely};
+`;
+
+const HoverContent = styled('div')`
+    transition: opacity ${animationSpeed.fast} linear;
     visibility: hidden;
+    ${centerContentAbsolutely};
+`;
+
+const showHoverContent = css`
+    ${HoverContent} {
+        opacity: 1;
+        visibility: visible;
+    }
 `;
 
 const Image = styled('img')`
     border-radius: ${size.small};
     height: 100%;
+    /* Preserve aspect ratio but fill appropriately */
     object-fit: cover;
     width: 100%;
 `;
@@ -46,12 +62,9 @@ const RoundedContainer = styled('div')`
     }
     &:hover,
     &:focus {
+        /* Remove any focus effects from Link */
         color: unset;
-        ${HoverContent} {
-            opacity: 1;
-            visibility: visible;
-        }
-        /* Parent controls the background opacity */
+        ${showHoverContent};
         :before {
             opacity: 0.8;
         }

--- a/src/components/dev-hub/stories/card.stories.mdx
+++ b/src/components/dev-hub/stories/card.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
 import Card from '../card';
+import HoverCard from '../hover-card';
 import { colorMap } from '../theme';
 import mockCardImage from '../../../images/360-mock-img.png';
 import { mapTagTypeToUrl } from '../../../utils/map-tag-type-to-url';
@@ -12,7 +13,7 @@ A card can have a link, image, title, and description.
 
 <Preview>
     <Story name="default card">
-        <div style={{display: 'flex'}}>
+        <div style={{ display: 'flex' }}>
             <Card
                 distinct
                 image={mockCardImage}
@@ -30,13 +31,35 @@ A card can have a link, image, title, and description.
             />
         </div>
     </Story>
+    <Story name="hover card">
+        <div>
+            <div
+                style={{
+                    display: 'grid',
+                    columnGap: '32px',
+                    gridTemplateColumns: '1fr 1fr 1fr',
+                    gridTemplateRows: '300px',
+                }}
+            >
+                <HoverCard
+                    image={mockCardImage}
+                    style={{ gridColumnEnd: 'span 2' }}
+                >
+                    An interesting article
+                </HoverCard>
+                <HoverCard image={mockCardImage}>
+                    An interesting article
+                </HoverCard>
+            </div>
+        </div>
+    </Story>
 </Preview>
 
 Cards can also have a list of tags associated with them (max 5 tags).
 
 <Preview>
     <Story name="tag-list card">
-        <div style={{display: 'flex'}}>
+        <div style={{ display: 'flex' }}>
             <Card
                 distinct
                 image={mockCardImage}
@@ -64,7 +87,7 @@ the max number of lines a title can have using the `maxTitleLines` prop.
 
 <Preview>
     <Story name="no-image card">
-        <div style={{display: 'flex'}}>
+        <div style={{ display: 'flex' }}>
             <Card
                 width="300px"
                 title="I'm a card with a really really really really really really really really really really long title"

--- a/src/components/dev-hub/stories/card.stories.mdx
+++ b/src/components/dev-hub/stories/card.stories.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
 import Card from '../card';
 import HoverCard from '../hover-card';
+import { H3, P3 } from '../text';
 import { colorMap } from '../theme';
 import mockCardImage from '../../../images/360-mock-img.png';
 import { mapTagTypeToUrl } from '../../../utils/map-tag-type-to-url';
@@ -42,10 +43,12 @@ A card can have a link, image, title, and description.
                 }}
             >
                 <HoverCard
+                    to="/"
                     image={mockCardImage}
                     style={{ gridColumnEnd: 'span 2' }}
                 >
-                    An interesting article
+                    <H3>An interesting article</H3>
+                    <P3>With an even better caption</P3>
                 </HoverCard>
                 <HoverCard image={mockCardImage}>
                     An interesting article

--- a/tests/unit/HoverCard.test.js
+++ b/tests/unit/HoverCard.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import HoverCard from '../../src/components/dev-hub/hover-card';
+
+const getHoverCard = to =>
+    shallow(
+        <HoverCard
+            alt="Image with first cluster"
+            image="/images/firstcluster.png"
+            to={to}
+        >
+            <p>Here is some content</p>
+        </HoverCard>
+    );
+
+it('hover cards without a link render correctly', () => {
+    const tree = getHoverCard();
+    expect(tree).toMatchSnapshot();
+});
+
+it('hover cards with a link render correctly', () => {
+    const tree = getHoverCard('/');
+    expect(tree).toMatchSnapshot();
+});

--- a/tests/unit/__snapshots__/HoverCard.test.js.snap
+++ b/tests/unit/__snapshots__/HoverCard.test.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`hover cards with a link render correctly 1`] = `
+<ContentWrapper
+  tabIndex="0"
+  to="/"
+>
+  <Image
+    alt="Image with first cluster"
+    loading="lazy"
+    src="/images/firstcluster.png"
+  />
+  <HoverContent>
+    <p>
+      Here is some content
+    </p>
+  </HoverContent>
+</ContentWrapper>
+`;
+
+exports[`hover cards without a link render correctly 1`] = `
+<RoundedContainer
+  tabIndex="0"
+>
+  <Image
+    alt="Image with first cluster"
+    loading="lazy"
+    src="/images/firstcluster.png"
+  />
+  <HoverContent>
+    <p>
+      Here is some content
+    </p>
+  </HoverContent>
+</RoundedContainer>
+`;


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DEVHUB-291)
[Figma](https://www.figma.com/proto/QuUf86imwSoPNYoxZX3az2/Academia---Student-Spotlights?node-id=508%3A379&scaling=min-zoom)
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-291/) (check out the events image on the home page, this is now a Hover Card. This home page change is not part of the PR)

This PR adds a new unused component to the library: `HoverCard`. This component presents an image and on focus or hover, displays its children above an opaque backdrop.