### PR TITLE
Refactor build time pages

### DIFF
--- a/src/utils/setup/find-articles-from-slugs.js
+++ b/src/utils/setup/find-articles-from-slugs.js
@@ -1,0 +1,25 @@
+export const findArticleWithSlug = (allArticles, slug) => {
+    const targetSlug = new RegExp(`^/?${slug}$`);
+    const targetArticle = allArticles.find(x =>
+        x.query_fields.slug.match(targetSlug)
+    );
+    if (targetArticle) {
+        targetArticle['type'] = 'article';
+        return targetArticle;
+    }
+};
+
+export const findArticlesFromSlugs = (allArticles, articleSlugs, maxSize) => {
+    const result = [];
+    // If maxSize is undefined, this will return a shallow copy of articleSlugs
+    articleSlugs.slice(0, maxSize).forEach((featuredSlug, i) => {
+        const targetArticle = findArticleWithSlug(allArticles, featuredSlug);
+        if (targetArticle) {
+            result.push(targetArticle);
+        } else {
+            // This article was not found. pick an existing article and add it instead.
+            result.push(allArticles[i]);
+        }
+    });
+    return result;
+};

--- a/src/utils/setup/get-learn-page-filters.js
+++ b/src/utils/setup/get-learn-page-filters.js
@@ -1,0 +1,62 @@
+export const getLearnPageFilters = allArticles => {
+    const languages = {};
+    const products = {};
+
+    allArticles.forEach(article => {
+        const languagesForArticle = article.query_fields.languages;
+        const productsForArticle = article.query_fields.products;
+        // Go through languages for this article and update filter info.
+        // Add a count of how many times this language appears and keep track
+        // of how many itmes we see a product with this language
+        if (languagesForArticle) {
+            languagesForArticle.forEach(language => {
+                const currentLanguage = languages[language];
+                if (currentLanguage) {
+                    currentLanguage.count++;
+                } else {
+                    // Update language reference directly in outer block object
+                    languages[language] = {
+                        count: 1,
+                        products: {},
+                    };
+                }
+                if (productsForArticle) {
+                    // If this article also has products, update those counts as well for this language
+                    const productsForLanguage = languages[language].products;
+                    productsForArticle.forEach(product => {
+                        productsForLanguage[product]
+                            ? productsForLanguage[product]++
+                            : (productsForLanguage[product] = 1);
+                    });
+                }
+            });
+        }
+        // Go through products for this article and update filter info.
+        // Add a count of how many times this product appears and keep track
+        // of how many itmes we see a language with this product
+        if (productsForArticle) {
+            productsForArticle.forEach(product => {
+                const currentProduct = products[product];
+                if (currentProduct) {
+                    currentProduct.count++;
+                } else {
+                    // Update product reference directly in outer block object
+                    products[product] = {
+                        count: 1,
+                        languages: {},
+                    };
+                }
+                if (languagesForArticle) {
+                    // If this article also has languages, update those counts as well for this products
+                    const languagesForProduct = products[product].languages;
+                    languagesForArticle.forEach(language => {
+                        languagesForProduct[language]
+                            ? languagesForProduct[language]++
+                            : (languagesForProduct[language] = 1);
+                    });
+                }
+            });
+        }
+    });
+    return { languages, products };
+};

--- a/src/utils/setup/handle-create-home-page.js
+++ b/src/utils/setup/handle-create-home-page.js
@@ -1,17 +1,7 @@
+import { findArticleWithSlug } from './find-articles-from-slugs';
 import { getItemTypeFromUrl } from './get-item-type-from-url';
 
 const MAX_HOME_PAGE_FEATURED_ARTICLES = 4;
-
-const findArticleWithSlug = (allArticles, slug) => {
-    const targetSlug = new RegExp(`^/?${slug}$`);
-    const targetArticle = allArticles.find(x =>
-        x.query_fields.slug.match(targetSlug)
-    );
-    if (targetArticle) {
-        targetArticle['type'] = 'article';
-        return targetArticle;
-    }
-};
 
 export const handleCreateHomePage = async (
     page,

--- a/src/utils/setup/handle-create-home-page.js
+++ b/src/utils/setup/handle-create-home-page.js
@@ -1,0 +1,51 @@
+import { getItemTypeFromUrl } from './get-item-type-from-url';
+
+const MAX_HOME_PAGE_FEATURED_ARTICLES = 4;
+
+const findArticleWithSlug = (allArticles, slug) => {
+    const targetSlug = new RegExp(`^/?${slug}$`);
+    const targetArticle = allArticles.find(x =>
+        x.query_fields.slug.match(targetSlug)
+    );
+    if (targetArticle) {
+        targetArticle['type'] = 'article';
+        return targetArticle;
+    }
+};
+
+export const handleCreateHomePage = async (
+    page,
+    actions,
+    homeFeaturedArticles,
+    allArticles
+) => {
+    const { createPage, deletePage } = actions;
+    const featuredItems = [];
+    homeFeaturedArticles
+        .slice(0, MAX_HOME_PAGE_FEATURED_ARTICLES)
+        .forEach(item => {
+            // Currently, only articles are supported here
+            // TODO: Support items of all content types
+            const itemType = getItemTypeFromUrl(item);
+            switch (itemType) {
+                case 'article':
+                    const article = findArticleWithSlug(allArticles, item);
+                    if (article) {
+                        featuredItems.push(article);
+                    } else {
+                        throw new Error(`Featured article not found: ${item}`);
+                    }
+                    break;
+                default:
+                    throw new Error(`Featured article not found: ${item}`);
+            }
+        });
+    deletePage(page);
+    createPage({
+        ...page,
+        context: {
+            ...page.context,
+            featuredItems,
+        },
+    });
+};

--- a/src/utils/setup/handle-create-learn-page.js
+++ b/src/utils/setup/handle-create-learn-page.js
@@ -1,0 +1,131 @@
+import memoizerific from 'memoizerific';
+import { fetchBuildTimeMedia } from './fetch-build-time-media';
+import { removeExcludedArticles } from './remove-excluded-articles';
+
+const MAX_LEARN_PAGE_FEATURED_ARTICLES = 3;
+
+export const getLearnPageFilters = allArticles => {
+    const languages = {};
+    const products = {};
+
+    allArticles.forEach(article => {
+        const languagesForArticle = article.query_fields.languages;
+        const productsForArticle = article.query_fields.products;
+        // Go through languages for this article and update filter info.
+        // Add a count of how many times this language appears and keep track
+        // of how many itmes we see a product with this language
+        if (languagesForArticle) {
+            languagesForArticle.forEach(language => {
+                const currentLanguage = languages[language];
+                if (currentLanguage) {
+                    currentLanguage.count++;
+                } else {
+                    // Update language reference directly in outer block object
+                    languages[language] = {
+                        count: 1,
+                        products: {},
+                    };
+                }
+                if (productsForArticle) {
+                    // If this article also has products, update those counts as well for this language
+                    const productsForLanguage = languages[language].products;
+                    productsForArticle.forEach(product => {
+                        productsForLanguage[product]
+                            ? productsForLanguage[product]++
+                            : (productsForLanguage[product] = 1);
+                    });
+                }
+            });
+        }
+        // Go through products for this article and update filter info.
+        // Add a count of how many times this product appears and keep track
+        // of how many itmes we see a language with this product
+        if (productsForArticle) {
+            productsForArticle.forEach(product => {
+                const currentProduct = products[product];
+                if (currentProduct) {
+                    currentProduct.count++;
+                } else {
+                    // Update product reference directly in outer block object
+                    products[product] = {
+                        count: 1,
+                        languages: {},
+                    };
+                }
+                if (languagesForArticle) {
+                    // If this article also has languages, update those counts as well for this products
+                    const languagesForProduct = products[product].languages;
+                    languagesForArticle.forEach(language => {
+                        languagesForProduct[language]
+                            ? languagesForProduct[language]++
+                            : (languagesForProduct[language] = 1);
+                    });
+                }
+            });
+        }
+    });
+    return { languages, products };
+};
+
+const findArticleWithSlug = (allArticles, slug) => {
+    const targetSlug = new RegExp(`^/?${slug}$`);
+    const targetArticle = allArticles.find(x =>
+        x.query_fields.slug.match(targetSlug)
+    );
+    if (targetArticle) {
+        targetArticle['type'] = 'article';
+        return targetArticle;
+    }
+};
+
+export const findArticlesFromSlugs = (allArticles, articleSlugs, maxSize) => {
+    const result = [];
+    // If maxSize is undefined, this will return a shallow copy of articleSlugs
+    articleSlugs.slice(0, maxSize).forEach((featuredSlug, i) => {
+        const targetArticle = findArticleWithSlug(allArticles, featuredSlug);
+        if (targetArticle) {
+            result.push(targetArticle);
+        } else {
+            // This article was not found. pick an existing article and add it instead.
+            result.push(allArticles[i]);
+        }
+    });
+    return result;
+};
+
+const memoizedBuildTimeMedia = memoizerific(1)(
+    async () => await fetchBuildTimeMedia()
+);
+
+export const handleCreateLearnPage = async (
+    page,
+    actions,
+    learnFeaturedArticles,
+    excludedLearnPageArticles,
+    allArticles
+) => {
+    const { createPage, deletePage } = actions;
+    const learnPageArticles = removeExcludedArticles(
+        allArticles,
+        excludedLearnPageArticles
+    );
+    const filters = await getLearnPageFilters(learnPageArticles);
+    const featuredLearnArticles = findArticlesFromSlugs(
+        learnPageArticles,
+        learnFeaturedArticles,
+        MAX_LEARN_PAGE_FEATURED_ARTICLES
+    );
+    const { allPodcasts, allVideos } = await memoizedBuildTimeMedia();
+    deletePage(page);
+    createPage({
+        ...page,
+        context: {
+            ...page.context,
+            allArticles: learnPageArticles,
+            allPodcasts,
+            allVideos,
+            featuredArticles: featuredLearnArticles,
+            filters,
+        },
+    });
+};

--- a/src/utils/setup/handle-create-learn-page.js
+++ b/src/utils/setup/handle-create-learn-page.js
@@ -1,97 +1,10 @@
 import memoizerific from 'memoizerific';
 import { fetchBuildTimeMedia } from './fetch-build-time-media';
+import { findArticlesFromSlugs } from './find-articles-from-slugs';
+import { getLearnPageFilters } from './get-learn-page-filters';
 import { removeExcludedArticles } from './remove-excluded-articles';
 
 const MAX_LEARN_PAGE_FEATURED_ARTICLES = 3;
-
-export const getLearnPageFilters = allArticles => {
-    const languages = {};
-    const products = {};
-
-    allArticles.forEach(article => {
-        const languagesForArticle = article.query_fields.languages;
-        const productsForArticle = article.query_fields.products;
-        // Go through languages for this article and update filter info.
-        // Add a count of how many times this language appears and keep track
-        // of how many itmes we see a product with this language
-        if (languagesForArticle) {
-            languagesForArticle.forEach(language => {
-                const currentLanguage = languages[language];
-                if (currentLanguage) {
-                    currentLanguage.count++;
-                } else {
-                    // Update language reference directly in outer block object
-                    languages[language] = {
-                        count: 1,
-                        products: {},
-                    };
-                }
-                if (productsForArticle) {
-                    // If this article also has products, update those counts as well for this language
-                    const productsForLanguage = languages[language].products;
-                    productsForArticle.forEach(product => {
-                        productsForLanguage[product]
-                            ? productsForLanguage[product]++
-                            : (productsForLanguage[product] = 1);
-                    });
-                }
-            });
-        }
-        // Go through products for this article and update filter info.
-        // Add a count of how many times this product appears and keep track
-        // of how many itmes we see a language with this product
-        if (productsForArticle) {
-            productsForArticle.forEach(product => {
-                const currentProduct = products[product];
-                if (currentProduct) {
-                    currentProduct.count++;
-                } else {
-                    // Update product reference directly in outer block object
-                    products[product] = {
-                        count: 1,
-                        languages: {},
-                    };
-                }
-                if (languagesForArticle) {
-                    // If this article also has languages, update those counts as well for this products
-                    const languagesForProduct = products[product].languages;
-                    languagesForArticle.forEach(language => {
-                        languagesForProduct[language]
-                            ? languagesForProduct[language]++
-                            : (languagesForProduct[language] = 1);
-                    });
-                }
-            });
-        }
-    });
-    return { languages, products };
-};
-
-const findArticleWithSlug = (allArticles, slug) => {
-    const targetSlug = new RegExp(`^/?${slug}$`);
-    const targetArticle = allArticles.find(x =>
-        x.query_fields.slug.match(targetSlug)
-    );
-    if (targetArticle) {
-        targetArticle['type'] = 'article';
-        return targetArticle;
-    }
-};
-
-export const findArticlesFromSlugs = (allArticles, articleSlugs, maxSize) => {
-    const result = [];
-    // If maxSize is undefined, this will return a shallow copy of articleSlugs
-    articleSlugs.slice(0, maxSize).forEach((featuredSlug, i) => {
-        const targetArticle = findArticleWithSlug(allArticles, featuredSlug);
-        if (targetArticle) {
-            result.push(targetArticle);
-        } else {
-            // This article was not found. pick an existing article and add it instead.
-            result.push(allArticles[i]);
-        }
-    });
-    return result;
-};
 
 const memoizedBuildTimeMedia = memoizerific(1)(
     async () => await fetchBuildTimeMedia()

--- a/tests/utils/find-articles-from-slugs.test.js
+++ b/tests/utils/find-articles-from-slugs.test.js
@@ -1,4 +1,4 @@
-import { findArticlesFromSlugs } from '../../src/utils/setup/handle-create-learn-page';
+import { findArticlesFromSlugs } from '../../src/utils/setup/find-articles-from-slugs';
 
 it('should correctly find featured articles given a set of requested articles', () => {
     let requestedFeaturedSlugs = [

--- a/tests/utils/find-articles-from-slugs.test.js
+++ b/tests/utils/find-articles-from-slugs.test.js
@@ -1,4 +1,4 @@
-import { findArticlesFromSlugs } from '../../src/utils/setup/handle-create-page';
+import { findArticlesFromSlugs } from '../../src/utils/setup/handle-create-learn-page';
 
 it('should correctly find featured articles given a set of requested articles', () => {
     let requestedFeaturedSlugs = [

--- a/tests/utils/get-learn-page-filters.test.js
+++ b/tests/utils/get-learn-page-filters.test.js
@@ -1,4 +1,4 @@
-import { getLearnPageFilters } from '../../src/utils/setup/handle-create-page';
+import { getLearnPageFilters } from '../../src/utils/setup/handle-create-learn-page';
 
 it('should correctly create filters for the learn page based on article tags', () => {
     const allArticles = [

--- a/tests/utils/get-learn-page-filters.test.js
+++ b/tests/utils/get-learn-page-filters.test.js
@@ -1,4 +1,4 @@
-import { getLearnPageFilters } from '../../src/utils/setup/handle-create-learn-page';
+import { getLearnPageFilters } from '../../src/utils/setup/get-learn-page-filters';
 
 it('should correctly create filters for the learn page based on article tags', () => {
     const allArticles = [


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/refactor-build-time-pages/)

When I was getting ready to work on Student Spotlight for the home page, I noticed an opportunity for refactoring. We had many pieces of logic in `handle-create-page.js` relating to the home and learn pages. Additionally this file was becoming quite bloated.

This PR splits the logic from that one module into five with `handle-create-page` become a much lighter `switch` for routing logic to the correct page handler. This makes our code also much more clear to read.