### PR TITLE
Modularize Home Page

### DIFF
--- a/src/components/pages/home/academia-feature.js
+++ b/src/components/pages/home/academia-feature.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import Card from '../../dev-hub/card';
+import MediaBlock from '../../dev-hub/media-block';
+import { H2, P } from '../../dev-hub/text';
+import { screenSize, size } from '../../dev-hub/theme';
+import Button from '../../dev-hub/button';
+import academiaImage from '../../../images/1x/Academia.svg';
+import GradientUnderline from '../../dev-hub/gradient-underline';
+import { useTheme } from 'emotion-theming';
+import FeatureSection from './feature-section';
+
+const MEDIA_WIDTH = '550';
+
+const DescriptiveText = styled(P)`
+    color: ${({ theme }) => theme.colorMap.greyLightTwo};
+    margin-bottom: ${size.medium};
+`;
+
+const SectionContent = styled('div')`
+    padding: 0 ${size.default};
+    @media ${screenSize.largeAndUp} {
+        margin-top: 15%;
+        padding: 8%;
+    }
+`;
+
+const AcademiaFeature = () => {
+    const theme = useTheme();
+    return (
+        <FeatureSection altBackground>
+            <MediaBlock
+                mediaComponent={
+                    <Card image={academiaImage} maxWidth={MEDIA_WIDTH}></Card>
+                }
+            >
+                <SectionContent>
+                    <H2>
+                        <GradientUnderline
+                            gradient={theme.gradientMap.magentaSalmonSherbet}
+                        >
+                            MongoDB for Academia
+                        </GradientUnderline>
+                    </H2>
+                    <DescriptiveText>
+                        MongoDB for Academia gives educators hands-on learning
+                        experiences to inspire, teach and learn with MongoDB.
+                    </DescriptiveText>
+                    <div>
+                        <Button to="/academia/educators/" secondary>
+                            Learn more
+                        </Button>
+                    </div>
+                </SectionContent>
+            </MediaBlock>
+        </FeatureSection>
+    );
+};
+
+export default AcademiaFeature;

--- a/src/components/pages/home/community-feature.js
+++ b/src/components/pages/home/community-feature.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import Card from '../../dev-hub/card';
+import MediaBlock from '../../dev-hub/media-block';
+import { H2, P } from '../../dev-hub/text';
+import { screenSize, size } from '../../dev-hub/theme';
+import Button from '../../dev-hub/button';
+import buildImage from '../../../images/2x/Build@2x.png';
+import GradientUnderline from '../../dev-hub/gradient-underline';
+import { useTheme } from 'emotion-theming';
+import FeatureSection from './feature-section';
+import ProjectSignUpForm from '../../dev-hub/project-sign-up-form';
+
+const MEDIA_WIDTH = '550';
+
+const DescriptiveText = styled(P)`
+    color: ${({ theme }) => theme.colorMap.greyLightTwo};
+    margin-bottom: ${size.medium};
+`;
+
+const SectionContent = styled('div')`
+    padding: 0 ${size.default};
+    @media ${screenSize.largeAndUp} {
+        margin-top: 15%;
+        padding: 8%;
+    }
+`;
+
+const CommunityFeature = () => {
+    const theme = useTheme();
+    return (
+        <FeatureSection>
+            <MediaBlock
+                mediaComponent={
+                    <Card image={buildImage} maxWidth={MEDIA_WIDTH}></Card>
+                }
+            >
+                <SectionContent>
+                    <H2>
+                        <GradientUnderline
+                            gradient={theme.gradientMap.magentaSalmonSherbet}
+                        >
+                            Show Your Stuff
+                        </GradientUnderline>
+                    </H2>
+                    <DescriptiveText>
+                        Building something on MongoDB? Share your stories,
+                        demos, and wisdom with those still learning.
+                    </DescriptiveText>
+                    <ProjectSignUpForm
+                        triggerComponent={<Button secondary>Share</Button>}
+                    />
+                </SectionContent>
+            </MediaBlock>
+        </FeatureSection>
+    );
+};
+
+export default CommunityFeature;

--- a/src/components/pages/home/events-feature.js
+++ b/src/components/pages/home/events-feature.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import Card from '../../dev-hub/card';
+import MediaBlock from '../../dev-hub/media-block';
+import { H2, P } from '../../dev-hub/text';
+import { screenSize, size } from '../../dev-hub/theme';
+import Button from '../../dev-hub/button';
+import meetupsImage from '../../../images/1x/Meetups.png';
+import GradientUnderline from '../../dev-hub/gradient-underline';
+import { useTheme } from 'emotion-theming';
+import FeatureSection from './feature-section';
+
+const MEDIA_WIDTH = '550';
+
+const DescriptiveText = styled(P)`
+    color: ${({ theme }) => theme.colorMap.greyLightTwo};
+    margin-bottom: ${size.medium};
+`;
+
+const SectionContent = styled('div')`
+    padding: 0 ${size.default};
+    @media ${screenSize.largeAndUp} {
+        margin-top: 15%;
+        padding: 8%;
+    }
+`;
+
+const EventsFeature = () => {
+    const theme = useTheme();
+    return (
+        <FeatureSection data-test="events">
+            <MediaBlock
+                mediaComponent={
+                    <Card image={meetupsImage} maxWidth={MEDIA_WIDTH}></Card>
+                }
+                mediaWidth={MEDIA_WIDTH}
+                reverse
+            >
+                <SectionContent>
+                    <H2>
+                        <GradientUnderline
+                            gradient={theme.gradientMap.greenTeal}
+                        >
+                            Events
+                        </GradientUnderline>
+                    </H2>
+                    <DescriptiveText>
+                        Join us at our MongoDB .local and community events.
+                    </DescriptiveText>
+                    <DescriptiveText>
+                        Come to learn, stay to connect.
+                    </DescriptiveText>
+                    <Button to="/community/events" secondary>
+                        Join Us
+                    </Button>
+                </SectionContent>
+            </MediaBlock>
+        </FeatureSection>
+    );
+};
+
+export default EventsFeature;

--- a/src/components/pages/home/feature-section.js
+++ b/src/components/pages/home/feature-section.js
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+import { screenSize, size } from '../../dev-hub/theme';
+
+const FeatureSection = styled('section')`
+    ${({ altBackground, theme }) =>
+        altBackground && `background-color: ${theme.colorMap.devBlack};`};
+    @media ${screenSize.upToLarge} {
+        margin-bottom: ${size.medium};
+        padding: 0;
+        padding-bottom: ${size.medium};
+    }
+    @media ${screenSize.largeAndUp} {
+        margin: 0 ${size.large} ${size.medium};
+        padding-top: ${size.medium};
+    }
+`;
+
+export default FeatureSection;

--- a/src/components/pages/home/hero.js
+++ b/src/components/pages/home/hero.js
@@ -1,0 +1,83 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import Card from '../../dev-hub/card';
+import { H1, SubHeader } from '../../dev-hub/text';
+import { screenSize, size } from '../../dev-hub/theme';
+import Button from '../../dev-hub/button';
+import { getFeaturedCardFields } from '../../../utils/get-featured-card-fields';
+
+const Header = styled('header')`
+    color: ${({ theme }) => theme.colorMap.devWhite};
+    padding: ${size.xlarge} ${size.large};
+    @media ${screenSize.upToMedium} {
+        padding: ${size.large} ${size.medium};
+    }
+    text-align: center;
+`;
+const TitleText = styled(H1)`
+    max-width: 920px;
+    margin: ${size.default} auto;
+    word-wrap: break-word;
+`;
+const Sub = styled(SubHeader)`
+    margin: ${size.default} 0;
+`;
+const CardGallery = styled('section')`
+    display: flex;
+    justify-content: center;
+    margin: ${size.default} ${size.xlarge} ${size.large};
+    @media ${screenSize.upToLarge} {
+        flex-wrap: wrap;
+    }
+    @media ${screenSize.upToMedium} {
+        margin: ${size.default};
+    }
+`;
+const StyledTopCard = styled(Card)`
+    width: 100%;
+    @media ${screenSize.upToLarge} {
+        flex-basis: 50%;
+    }
+    @media ${screenSize.upToMedium} {
+        flex-basis: 100%;
+    }
+`;
+
+// TODO: Generalize as new content types are supported
+const FeaturedHomePageItem = ({ item }) => {
+    if (item.type === 'article') {
+        const { image, slug, title } = getFeaturedCardFields(item);
+        return (
+            <StyledTopCard
+                maxTitleLines={3}
+                image={image}
+                to={slug}
+                title={title}
+                key={title}
+            />
+        );
+    }
+};
+
+const Hero = ({ featuredItems }) => (
+    <Header>
+        <TitleText>
+            {`ideas.find({"attributes":`}
+            <br />
+            {`["fast", "innovative", "original"]})`}
+        </TitleText>
+        <Sub>What will you create today?</Sub>
+        <CardGallery>
+            {featuredItems.map(item => (
+                <FeaturedHomePageItem item={item} />
+            ))}
+        </CardGallery>
+        <div>
+            <Button to="/learn" primary>
+                Learn MongoDB
+            </Button>
+        </div>
+    </Header>
+);
+
+export default Hero;

--- a/src/components/pages/home/index.js
+++ b/src/components/pages/home/index.js
@@ -1,3 +1,4 @@
+import EventsFeature from './events-feature';
 import TwitchFeature from './twitch-feature';
 
-export { TwitchFeature };
+export { EventsFeature, TwitchFeature };

--- a/src/components/pages/home/index.js
+++ b/src/components/pages/home/index.js
@@ -1,0 +1,3 @@
+import TwitchFeature from './twitch-feature';
+
+export { TwitchFeature };

--- a/src/components/pages/home/index.js
+++ b/src/components/pages/home/index.js
@@ -1,4 +1,5 @@
+import AcademiaFeature from './academia-feature';
 import EventsFeature from './events-feature';
 import TwitchFeature from './twitch-feature';
 
-export { EventsFeature, TwitchFeature };
+export { AcademiaFeature, EventsFeature, TwitchFeature };

--- a/src/components/pages/home/index.js
+++ b/src/components/pages/home/index.js
@@ -1,6 +1,13 @@
 import AcademiaFeature from './academia-feature';
 import CommunityFeature from './community-feature';
 import EventsFeature from './events-feature';
+import Hero from './hero';
 import TwitchFeature from './twitch-feature';
 
-export { AcademiaFeature, CommunityFeature, EventsFeature, TwitchFeature };
+export {
+    AcademiaFeature,
+    CommunityFeature,
+    EventsFeature,
+    Hero,
+    TwitchFeature,
+};

--- a/src/components/pages/home/index.js
+++ b/src/components/pages/home/index.js
@@ -1,5 +1,6 @@
 import AcademiaFeature from './academia-feature';
+import CommunityFeature from './community-feature';
 import EventsFeature from './events-feature';
 import TwitchFeature from './twitch-feature';
 
-export { AcademiaFeature, EventsFeature, TwitchFeature };
+export { AcademiaFeature, CommunityFeature, EventsFeature, TwitchFeature };

--- a/src/components/pages/home/twitch-feature.js
+++ b/src/components/pages/home/twitch-feature.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import MediaBlock from '../../dev-hub/media-block';
+import TwitchFallbackCard from '../../dev-hub/twitch-fallback-card';
+import getTwitchThumbnail from '../../../utils/get-twitch-thumbnail';
+import VideoModal from '../../dev-hub/video-modal';
+import Card from '../../dev-hub/card';
+import { H2, P } from '../../dev-hub/text';
+import FeatureSection from './feature-section';
+import { screenSize, size } from '../../dev-hub/theme';
+import GradientUnderline from '../../dev-hub/gradient-underline';
+import { useTheme } from 'emotion-theming';
+import Button from '../../dev-hub/button';
+
+const MEDIA_WIDTH = '550';
+
+const DescriptiveText = styled(P)`
+    color: ${({ theme }) => theme.colorMap.greyLightTwo};
+    margin-bottom: ${size.medium};
+`;
+
+const SectionContent = styled('div')`
+    padding: 0 ${size.default};
+    @media ${screenSize.largeAndUp} {
+        margin-top: 15%;
+        padding: 8%;
+    }
+`;
+
+const TwitchFeature = ({ twitchVideo }) => {
+    const theme = useTheme();
+    return (
+        <FeatureSection altBackground data-test="twitch">
+            <MediaBlock
+                mediaWidth={MEDIA_WIDTH}
+                mediaComponent={
+                    twitchVideo ? (
+                        <Card
+                            image={getTwitchThumbnail(twitchVideo.thumbnailUrl)}
+                            maxWidth={MEDIA_WIDTH}
+                            title={twitchVideo.title}
+                            videoModalThumbnail={getTwitchThumbnail(
+                                twitchVideo.thumbnailUrl,
+                                1200
+                            )}
+                            video={twitchVideo}
+                        />
+                    ) : (
+                        <TwitchFallbackCard maxWidth={MEDIA_WIDTH} />
+                    )
+                }
+            >
+                <SectionContent>
+                    <H2>
+                        <GradientUnderline
+                            gradient={theme.gradientMap.tealVioletPurple}
+                        >
+                            Live Coding on Our Twitch Channel
+                        </GradientUnderline>
+                    </H2>
+                    <DescriptiveText>
+                        Every Friday at noon EST come watch our developers make
+                        the MongoDB platform come alive.
+                    </DescriptiveText>
+                    {twitchVideo && (
+                        <VideoModal
+                            id={twitchVideo.videoId}
+                            name={twitchVideo.mediaType}
+                            trigger={<Button secondary>Watch</Button>}
+                            thumbnail={getTwitchThumbnail(
+                                twitchVideo.thumbnailUrl,
+                                1200
+                            )}
+                        />
+                    )}
+                </SectionContent>
+            </MediaBlock>
+        </FeatureSection>
+    );
+};
+
+export default TwitchFeature;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -15,12 +15,10 @@ import GradientUnderline from '../components/dev-hub/gradient-underline';
 import homepageBackground from '../images/1x/homepage-background.png';
 import ProjectSignUpForm from '../components/dev-hub/project-sign-up-form';
 import useTwitchApi from '../hooks/use-twitch-api';
-import TwitchFallbackCard from '../components/dev-hub/twitch-fallback-card';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 import { getFeaturedCardFields } from '../utils/get-featured-card-fields';
-import getTwitchThumbnail from '../utils/get-twitch-thumbnail';
-import VideoModal from '../components/dev-hub/video-modal';
 import { useTheme } from 'emotion-theming';
+import { TwitchFeature } from '../components/pages/home';
 
 const MEDIA_WIDTH = '550';
 
@@ -139,56 +137,7 @@ const IndexPageContent = ({ stream, title, twitchVideo, featuredItems }) => {
                         </Button>
                     </div>
                 </Hero>
-                <FeatureSection altBackground data-test="twitch">
-                    <MediaBlock
-                        mediaWidth={MEDIA_WIDTH}
-                        mediaComponent={
-                            twitchVideo ? (
-                                <Card
-                                    image={getTwitchThumbnail(
-                                        twitchVideo.thumbnailUrl
-                                    )}
-                                    maxWidth={MEDIA_WIDTH}
-                                    title={twitchVideo.title}
-                                    videoModalThumbnail={getTwitchThumbnail(
-                                        twitchVideo.thumbnailUrl,
-                                        1200
-                                    )}
-                                    video={twitchVideo}
-                                />
-                            ) : (
-                                <TwitchFallbackCard maxWidth={MEDIA_WIDTH} />
-                            )
-                        }
-                    >
-                        <SectionContent>
-                            <H2>
-                                <GradientUnderline
-                                    gradient={
-                                        theme.gradientMap.tealVioletPurple
-                                    }
-                                >
-                                    Live Coding on Our Twitch Channel
-                                </GradientUnderline>
-                            </H2>
-                            <DescriptiveText>
-                                Every Friday at noon EST come watch our
-                                developers make the MongoDB platform come alive.
-                            </DescriptiveText>
-                            {twitchVideo && (
-                                <VideoModal
-                                    id={twitchVideo.videoId}
-                                    name={twitchVideo.mediaType}
-                                    trigger={<Button secondary>Watch</Button>}
-                                    thumbnail={getTwitchThumbnail(
-                                        twitchVideo.thumbnailUrl,
-                                        1200
-                                    )}
-                                />
-                            )}
-                        </SectionContent>
-                    </MediaBlock>
-                </FeatureSection>
+                <TwitchFeature twitchVideo={twitchVideo} />
                 <FeatureSection data-test="events">
                     <MediaBlock
                         mediaComponent={

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,7 +9,6 @@ import { H1, H2, P, SubHeader } from '../components/dev-hub/text';
 import { screenSize, size } from '../components/dev-hub/theme';
 import Button from '../components/dev-hub/button';
 import buildImage from '../images/2x/Build@2x.png';
-import academiaImage from '../images/1x/Academia.svg';
 import GradientUnderline from '../components/dev-hub/gradient-underline';
 import homepageBackground from '../images/1x/homepage-background.png';
 import ProjectSignUpForm from '../components/dev-hub/project-sign-up-form';
@@ -17,7 +16,11 @@ import useTwitchApi from '../hooks/use-twitch-api';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 import { getFeaturedCardFields } from '../utils/get-featured-card-fields';
 import { useTheme } from 'emotion-theming';
-import { EventsFeature, TwitchFeature } from '../components/pages/home';
+import {
+    AcademiaFeature,
+    EventsFeature,
+    TwitchFeature,
+} from '../components/pages/home';
 
 const MEDIA_WIDTH = '550';
 
@@ -138,38 +141,7 @@ const IndexPageContent = ({ stream, title, twitchVideo, featuredItems }) => {
                 </Hero>
                 <TwitchFeature twitchVideo={twitchVideo} />
                 <EventsFeature />
-                <FeatureSection altBackground>
-                    <MediaBlock
-                        mediaComponent={
-                            <Card
-                                image={academiaImage}
-                                maxWidth={MEDIA_WIDTH}
-                            ></Card>
-                        }
-                    >
-                        <SectionContent>
-                            <H2>
-                                <GradientUnderline
-                                    gradient={
-                                        theme.gradientMap.magentaSalmonSherbet
-                                    }
-                                >
-                                    MongoDB for Academia
-                                </GradientUnderline>
-                            </H2>
-                            <DescriptiveText>
-                                MongoDB for Academia gives educators hands-on
-                                learning experiences to inspire, teach and learn
-                                with MongoDB.
-                            </DescriptiveText>
-                            <div>
-                                <Button to="/academia/educators/" secondary>
-                                    Learn more
-                                </Button>
-                            </div>
-                        </SectionContent>
-                    </MediaBlock>
-                </FeatureSection>
+                <AcademiaFeature />
                 <FeatureSection>
                     <MediaBlock
                         mediaComponent={

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,20 +1,16 @@
 import React, { useMemo } from 'react';
 import styled from '@emotion/styled';
 import { Helmet } from 'react-helmet';
-import Card from '../components/dev-hub/card';
 import Layout from '../components/dev-hub/layout';
 import Notification from '../components/dev-hub/notification';
-import { H1, SubHeader } from '../components/dev-hub/text';
-import { screenSize, size } from '../components/dev-hub/theme';
-import Button from '../components/dev-hub/button';
 import homepageBackground from '../images/1x/homepage-background.png';
 import useTwitchApi from '../hooks/use-twitch-api';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
-import { getFeaturedCardFields } from '../utils/get-featured-card-fields';
 import {
     AcademiaFeature,
     CommunityFeature,
     EventsFeature,
+    Hero,
     TwitchFeature,
 } from '../components/pages/home';
 
@@ -22,60 +18,8 @@ const BackgroundImage = styled('div')`
     background-image: url(${homepageBackground});
     background-size: cover;
 `;
-const Hero = styled('header')`
-    color: ${({ theme }) => theme.colorMap.devWhite};
-    padding: ${size.xlarge} ${size.large};
-    @media ${screenSize.upToMedium} {
-        padding: ${size.large} ${size.medium};
-    }
-    text-align: center;
-`;
-const Heading = styled(H1)`
-    max-width: 920px;
-    margin: ${size.default} auto;
-    word-wrap: break-word;
-`;
-const Sub = styled(SubHeader)`
-    margin: ${size.default} 0;
-`;
-const CardGallery = styled('section')`
-    display: flex;
-    justify-content: center;
-    margin: ${size.default} ${size.xlarge} ${size.large};
-    @media ${screenSize.upToLarge} {
-        flex-wrap: wrap;
-    }
-    @media ${screenSize.upToMedium} {
-        margin: ${size.default};
-    }
-`;
-const StyledTopCard = styled(Card)`
-    width: 100%;
-    @media ${screenSize.upToLarge} {
-        flex-basis: 50%;
-    }
-    @media ${screenSize.upToMedium} {
-        flex-basis: 100%;
-    }
-`;
 
-// TODO: Generalize as new content types are supported
-const FeaturedHomePageItem = ({ item }) => {
-    if (item.type === 'article') {
-        const { image, slug, title } = getFeaturedCardFields(item);
-        return (
-            <StyledTopCard
-                maxTitleLines={3}
-                image={image}
-                to={slug}
-                title={title}
-                key={title}
-            />
-        );
-    }
-};
-
-export default ({ pageContext: { featuredItems } }) => {
+const Index = ({ pageContext: { featuredItems } }) => {
     const { stream, videos } = useTwitchApi();
     const { title } = useSiteMetadata();
     const twitchVideo = useMemo(() => {
@@ -96,24 +40,7 @@ export default ({ pageContext: { featuredItems } }) => {
                 {stream && (
                     <Notification link={stream.url} title={stream.title} />
                 )}
-                <Hero>
-                    <Heading>
-                        {`ideas.find({"attributes":`}
-                        <br />
-                        {`["fast", "innovative", "original"]})`}
-                    </Heading>
-                    <Sub>What will you create today?</Sub>
-                    <CardGallery>
-                        {featuredItems.map(item => (
-                            <FeaturedHomePageItem item={item} />
-                        ))}
-                    </CardGallery>
-                    <div>
-                        <Button to="/learn" primary>
-                            Learn MongoDB
-                        </Button>
-                    </div>
-                </Hero>
+                <Hero featuredItems={featuredItems} />
                 <TwitchFeature twitchVideo={twitchVideo} />
                 <EventsFeature />
                 <AcademiaFeature />
@@ -122,3 +49,5 @@ export default ({ pageContext: { featuredItems } }) => {
         </Layout>
     );
 };
+
+export default Index;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,7 +9,6 @@ import { H1, H2, P, SubHeader } from '../components/dev-hub/text';
 import { screenSize, size } from '../components/dev-hub/theme';
 import Button from '../components/dev-hub/button';
 import buildImage from '../images/2x/Build@2x.png';
-import meetupsImage from '../images/1x/Meetups.png';
 import academiaImage from '../images/1x/Academia.svg';
 import GradientUnderline from '../components/dev-hub/gradient-underline';
 import homepageBackground from '../images/1x/homepage-background.png';
@@ -18,7 +17,7 @@ import useTwitchApi from '../hooks/use-twitch-api';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 import { getFeaturedCardFields } from '../utils/get-featured-card-fields';
 import { useTheme } from 'emotion-theming';
-import { TwitchFeature } from '../components/pages/home';
+import { EventsFeature, TwitchFeature } from '../components/pages/home';
 
 const MEDIA_WIDTH = '550';
 
@@ -138,38 +137,7 @@ const IndexPageContent = ({ stream, title, twitchVideo, featuredItems }) => {
                     </div>
                 </Hero>
                 <TwitchFeature twitchVideo={twitchVideo} />
-                <FeatureSection data-test="events">
-                    <MediaBlock
-                        mediaComponent={
-                            <Card
-                                image={meetupsImage}
-                                maxWidth={MEDIA_WIDTH}
-                            ></Card>
-                        }
-                        mediaWidth={MEDIA_WIDTH}
-                        reverse
-                    >
-                        <SectionContent>
-                            <H2>
-                                <GradientUnderline
-                                    gradient={theme.gradientMap.greenTeal}
-                                >
-                                    Events
-                                </GradientUnderline>
-                            </H2>
-                            <DescriptiveText>
-                                Join us at our MongoDB .local and community
-                                events.
-                            </DescriptiveText>
-                            <DescriptiveText>
-                                Come to learn, stay to connect.
-                            </DescriptiveText>
-                            <Button to="/community/events" secondary>
-                                Join Us
-                            </Button>
-                        </SectionContent>
-                    </MediaBlock>
-                </FeatureSection>
+                <EventsFeature />
                 <FeatureSection altBackground>
                     <MediaBlock
                         mediaComponent={

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,27 +2,21 @@ import React, { useMemo } from 'react';
 import styled from '@emotion/styled';
 import { Helmet } from 'react-helmet';
 import Card from '../components/dev-hub/card';
-import MediaBlock from '../components/dev-hub/media-block';
 import Layout from '../components/dev-hub/layout';
 import Notification from '../components/dev-hub/notification';
-import { H1, H2, P, SubHeader } from '../components/dev-hub/text';
+import { H1, SubHeader } from '../components/dev-hub/text';
 import { screenSize, size } from '../components/dev-hub/theme';
 import Button from '../components/dev-hub/button';
-import buildImage from '../images/2x/Build@2x.png';
-import GradientUnderline from '../components/dev-hub/gradient-underline';
 import homepageBackground from '../images/1x/homepage-background.png';
-import ProjectSignUpForm from '../components/dev-hub/project-sign-up-form';
 import useTwitchApi from '../hooks/use-twitch-api';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 import { getFeaturedCardFields } from '../utils/get-featured-card-fields';
-import { useTheme } from 'emotion-theming';
 import {
     AcademiaFeature,
+    CommunityFeature,
     EventsFeature,
     TwitchFeature,
 } from '../components/pages/home';
-
-const MEDIA_WIDTH = '550';
 
 const BackgroundImage = styled('div')`
     background-image: url(${homepageBackground});
@@ -65,31 +59,6 @@ const StyledTopCard = styled(Card)`
     }
 `;
 
-const FeatureSection = styled('section')`
-    ${({ altBackground, theme }) =>
-        altBackground && `background-color: ${theme.colorMap.devBlack};`};
-    @media ${screenSize.upToLarge} {
-        margin-bottom: ${size.medium};
-        padding: 0;
-        padding-bottom: ${size.medium};
-    }
-    @media ${screenSize.largeAndUp} {
-        margin: 0 ${size.large} ${size.medium};
-        padding-top: ${size.medium};
-    }
-`;
-const SectionContent = styled('div')`
-    padding: 0 ${size.default};
-    @media ${screenSize.largeAndUp} {
-        margin-top: 15%;
-        padding: 8%;
-    }
-`;
-const DescriptiveText = styled(P)`
-    color: ${({ theme }) => theme.colorMap.greyLightTwo};
-    margin-bottom: ${size.medium};
-`;
-
 // TODO: Generalize as new content types are supported
 const FeaturedHomePageItem = ({ item }) => {
     if (item.type === 'article') {
@@ -106,10 +75,16 @@ const FeaturedHomePageItem = ({ item }) => {
     }
 };
 
-const IndexPageContent = ({ stream, title, twitchVideo, featuredItems }) => {
-    const theme = useTheme();
+export default ({ pageContext: { featuredItems } }) => {
+    const { stream, videos } = useTwitchApi();
+    const { title } = useSiteMetadata();
+    const twitchVideo = useMemo(() => {
+        if (stream) return stream;
+        if (videos && videos.length) return videos[0];
+        return null;
+    }, [stream, videos]);
     return (
-        <>
+        <Layout>
             <Helmet>
                 <title>{title}</title>
                 <meta
@@ -142,59 +117,8 @@ const IndexPageContent = ({ stream, title, twitchVideo, featuredItems }) => {
                 <TwitchFeature twitchVideo={twitchVideo} />
                 <EventsFeature />
                 <AcademiaFeature />
-                <FeatureSection>
-                    <MediaBlock
-                        mediaComponent={
-                            <Card
-                                image={buildImage}
-                                maxWidth={MEDIA_WIDTH}
-                            ></Card>
-                        }
-                    >
-                        <SectionContent>
-                            <H2>
-                                <GradientUnderline
-                                    gradient={
-                                        theme.gradientMap.magentaSalmonSherbet
-                                    }
-                                >
-                                    Show Your Stuff
-                                </GradientUnderline>
-                            </H2>
-                            <DescriptiveText>
-                                Building something on MongoDB? Share your
-                                stories, demos, and wisdom with those still
-                                learning.
-                            </DescriptiveText>
-                            <ProjectSignUpForm
-                                triggerComponent={
-                                    <Button secondary>Share</Button>
-                                }
-                            />
-                        </SectionContent>
-                    </MediaBlock>
-                </FeatureSection>
+                <CommunityFeature />
             </BackgroundImage>
-        </>
-    );
-};
-
-export default ({ pageContext: { featuredItems } }) => {
-    const { stream, videos } = useTwitchApi();
-    const { title } = useSiteMetadata();
-    const twitchVideo = useMemo(() => {
-        if (stream) return stream;
-        if (videos && videos.length) return videos[0];
-        return null;
-    }, [stream, videos]);
-    return (
-        <Layout>
-            <IndexPageContent
-                stream={stream}
-                title={title}
-                twitchVideo={twitchVideo}
-                featuredItems={featuredItems}
-            />
         </Layout>
     );
 };


### PR DESCRIPTION
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/modularize-home-page/)

This PR does some cleanup of the home page as we move closer to Student Spotlight and Strapi. Managing the home page has become somewhat cumbersome as all logic and components were located in one file. Moving the key sub-components into a new file structure gives us some benefits and patterns for the future:

1. Easier to read/maintain code.
2. Allows us to better use Gatsby's `Static Queries` to interact with Strapi data on the component level, letting us scale in the future by grabbing data only where it is needed versus potential prop drilling.
3. Sets up logic for building scalable pages in the `pages/` or `templates/` directories as we move towards a period of generating new pages.

There are no functional differences with this PR and there is room for further refactoring, however this gives the start we need to define a pattern for building scalable pages that will interact well with Gatsby's architecture.