### PR TITLE
DEVHUB-348: Add Trailing Slash to Auto-Generated Canonical

### DIFF
--- a/cypress/integration/article.js
+++ b/cypress/integration/article.js
@@ -122,7 +122,7 @@ describe('Sample Article Page', () => {
             'property="og:url"',
             'http://developer-test.mongodb.com/article/3-things-to-know-switch-from-sql-mongodb'
         );
-        cy.get('link[ref="canonical"]').should(
+        cy.get('link[rel="canonical"]').should(
             'have.prop',
             'content',
             `${PROD_ARTICLE_URL}/`

--- a/cypress/integration/article.js
+++ b/cypress/integration/article.js
@@ -122,7 +122,11 @@ describe('Sample Article Page', () => {
             'property="og:url"',
             'http://developer-test.mongodb.com/article/3-things-to-know-switch-from-sql-mongodb'
         );
-        cy.checkMetaContentProperty('ref="canonical"', `${PROD_ARTICLE_URL}/`);
+        cy.get('link[ref="canonical"]').should(
+            'have.prop',
+            'content',
+            `${PROD_ARTICLE_URL}/`
+        );
         // An og:description exists, so we should populate the tag with it
         cy.checkMetaContentProperty(
             'property="og:description"',

--- a/cypress/integration/article.js
+++ b/cypress/integration/article.js
@@ -124,7 +124,7 @@ describe('Sample Article Page', () => {
         );
         cy.get('link[rel="canonical"]').should(
             'have.prop',
-            'content',
+            'href',
             `${PROD_ARTICLE_URL}/`
         );
         // An og:description exists, so we should populate the tag with it

--- a/cypress/integration/article.js
+++ b/cypress/integration/article.js
@@ -122,6 +122,7 @@ describe('Sample Article Page', () => {
             'property="og:url"',
             'http://developer-test.mongodb.com/article/3-things-to-know-switch-from-sql-mongodb'
         );
+        cy.checkMetaContentProperty('ref="canonical"', `${PROD_ARTICLE_URL}/`);
         // An og:description exists, so we should populate the tag with it
         cy.checkMetaContentProperty(
             'property="og:description"',

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -17,6 +17,7 @@ import { toDateString } from '../utils/format-dates';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 import ShareMenu from '../components/dev-hub/share-menu';
 import ContentsMenu from '../components/dev-hub/contents-menu';
+import { addTrailingSlashIfMissing } from '../utils/add-trailing-slash-if-missing';
 import { getNestedValue } from '../utils/get-nested-value';
 import { findSectionHeadings } from '../utils/find-section-headings';
 import { getNestedText } from '../utils/get-nested-text';
@@ -157,7 +158,7 @@ const Article = props => {
     const canonicalUrl = dlv(
         __refDocMapping,
         'ast.options.canonical-href',
-        og.url || articleUrl
+        addTrailingSlashIfMissing(articleUrl)
     );
 
     return (

--- a/src/utils/add-trailing-slash-if-missing.js
+++ b/src/utils/add-trailing-slash-if-missing.js
@@ -1,0 +1,6 @@
+export const addTrailingSlashIfMissing = url => {
+    if (url && url.match(/\/$/)) {
+        return url;
+    }
+    return `${url}/`;
+};

--- a/tests/utils/add-trailing-slash-if-missing.test.js
+++ b/tests/utils/add-trailing-slash-if-missing.test.js
@@ -1,0 +1,13 @@
+import { addTrailingSlashIfMissing } from '../../src/utils/add-trailing-slash-if-missing';
+
+it('should add trailing slashes to links if they are missing', () => {
+    const linkWithoutSlash = 'foo.bar';
+    const linkWithSlash = `${linkWithoutSlash}/`;
+    expect(addTrailingSlashIfMissing(linkWithSlash)).toBe(linkWithSlash);
+
+    // Should ignore anything without a slash
+    expect(addTrailingSlashIfMissing(linkWithoutSlash)).toBe(linkWithSlash);
+
+    // Should handle null/empty inputs
+    expect(addTrailingSlashIfMissing('')).toBe('/');
+});


### PR DESCRIPTION
[Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-348/)
[Staging Article](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-348/how-to/realm-google-authentication-android)

[CROUD diagnosis (Row 1)](https://docs.google.com/spreadsheets/d/16N2GL58j3y2SRATvpIUFiVq_MftYY6lphwyJVrAbyg0/edit#gid=993232630)

This PR adds logic for adding a trailing slash (if missing) to a canonical URL when it is auto-generated by this software. If an author provides a canonical URL we respect it as-is, but if they omit a canonical URL (as they should) we will generate the correct version for them.

To verify:
- Check out the article in the staging link
- Check the source code and find "canonical", this URL should now have a trailing slash applied.