### PR TITLE
DEVHUB-362 [Tag Pages]: Add Missing Canonicals to Tag Pages

### DIFF
--- a/cypress/integration/tag.js
+++ b/cypress/integration/tag.js
@@ -1,5 +1,6 @@
 const TAG_ARTICLE_URL = '/article/3-things-to-know-switch-from-sql-mongodb';
 const TAG_PAGE_URL = '/tag/sql';
+const PROD_TAG_PAGE_URL = `https://developer.mongodb.com${TAG_PAGE_URL}`;
 const TITLE = 'SQL';
 
 describe('Tag page', () => {
@@ -49,5 +50,10 @@ describe('Tag page', () => {
     });
     it('should not be indexed for SEO', () => {
         cy.checkMetaContentProperty('name="robots"', 'noindex');
+        cy.get('link[rel="canonical"]').should(
+            'have.prop',
+            'href',
+            `${PROD_TAG_PAGE_URL}/`
+        );
     });
 });

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -77,17 +77,19 @@ const Tag = props => {
             type,
         },
     } = props;
-    const metadata = useSiteMetadata();
+    const { siteUrl, title: siteTitle } = useSiteMetadata();
     const isAuthor = type === 'author';
     const articles = constructArticles(pages);
     const capitalizedBreadcrumb = name.charAt(0).toUpperCase() + name.slice(1);
+    const canonicalUrl = `${siteUrl}${slug}/`;
     return (
         <Layout>
             <Helmet>
                 <title>
-                    {name} - {metadata.title}
+                    {name} - {siteTitle}
                 </title>
                 {!isAuthor && <meta name="robots" content="noindex" />}
+                <link rel="canonical" href={canonicalUrl} />
             </Helmet>
             <HeroBanner
                 breadcrumb={[


### PR DESCRIPTION
[Staging Link (Product Page)](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-362-tags/product/mongodb)
[Staging Link (Author Page)](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-362-tags/author/maxime-beugnet)

[Croud Diagnosis (Line 41)](https://docs.google.com/spreadsheets/d/16N2GL58j3y2SRATvpIUFiVq_MftYY6lphwyJVrAbyg0/edit#gid=993232630)

This PR adds missing Canonical URLs to the Tag page template, which impacts the aggregate pages for an author (/author/), or tag/product/language/type (/tag/, /product/, /language/, /type/). Croud identified these had no canonical at all before.

I also added a quick CI test as well as ensured a trailing slash is present.