### PR TITLE
DEVHUB-348: Add Trailing Slash to Auto-Generated Canonical (#577)

### DIFF
--- a/cypress/integration/article.js
+++ b/cypress/integration/article.js
@@ -122,6 +122,11 @@ describe('Sample Article Page', () => {
             'property="og:url"',
             'http://developer-test.mongodb.com/article/3-things-to-know-switch-from-sql-mongodb'
         );
+        cy.get('link[rel="canonical"]').should(
+            'have.prop',
+            'href',
+            `${PROD_ARTICLE_URL}/`
+        );
         // An og:description exists, so we should populate the tag with it
         cy.checkMetaContentProperty(
             'property="og:description"',

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -17,6 +17,7 @@ import { toDateString } from '../utils/format-dates';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 import ShareMenu from '../components/dev-hub/share-menu';
 import ContentsMenu from '../components/dev-hub/contents-menu';
+import { addTrailingSlashIfMissing } from '../utils/add-trailing-slash-if-missing';
 import { getNestedValue } from '../utils/get-nested-value';
 import { findSectionHeadings } from '../utils/find-section-headings';
 import { getNestedText } from '../utils/get-nested-text';
@@ -157,7 +158,7 @@ const Article = props => {
     const canonicalUrl = dlv(
         __refDocMapping,
         'ast.options.canonical-href',
-        og.url || articleUrl
+        addTrailingSlashIfMissing(articleUrl)
     );
 
     return (

--- a/src/utils/add-trailing-slash-if-missing.js
+++ b/src/utils/add-trailing-slash-if-missing.js
@@ -1,0 +1,6 @@
+export const addTrailingSlashIfMissing = url => {
+    if (url && url.match(/\/$/)) {
+        return url;
+    }
+    return `${url}/`;
+};

--- a/tests/utils/add-trailing-slash-if-missing.test.js
+++ b/tests/utils/add-trailing-slash-if-missing.test.js
@@ -1,0 +1,13 @@
+import { addTrailingSlashIfMissing } from '../../src/utils/add-trailing-slash-if-missing';
+
+it('should add trailing slashes to links if they are missing', () => {
+    const linkWithoutSlash = 'foo.bar';
+    const linkWithSlash = `${linkWithoutSlash}/`;
+    expect(addTrailingSlashIfMissing(linkWithSlash)).toBe(linkWithSlash);
+
+    // Should ignore anything without a slash
+    expect(addTrailingSlashIfMissing(linkWithoutSlash)).toBe(linkWithSlash);
+
+    // Should handle null/empty inputs
+    expect(addTrailingSlashIfMissing('')).toBe('/');
+});


### PR DESCRIPTION
[Job](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=5ff36737ceb0c9c2e5f4cdf6)
[Staging](http://docs-devhub-staging.s3-website-us-east-1.amazonaws.com/1770f61/devhub/docsworker-xlarge/canonical-with-slash-articles/)

```
staging using branch origin/staging
production using branch origin/master

changes in staging but not production:
9cb70b9 DEVHUB-348: Add Trailing Slash to Auto-Generated Canonical (#577)
```