### PR TITLE
Create Generic Pagination

### DIFF
--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -1,41 +1,21 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import styled from '@emotion/styled';
-import { useLocation } from '@reach/router';
 import Audio from './audio';
 import Card from './card';
-import Button from './button';
-import { screenSize, size } from './theme';
 import { withPrefix } from 'gatsby';
-import { buildQueryString, parseQueryString } from '../../utils/query-string';
-import { getNestedText } from '../../utils/get-nested-text';
-import { getTagLinksFromMeta } from '../../utils/get-tag-links-from-meta';
-import getTwitchThumbnail from '../../utils/get-twitch-thumbnail';
+import Paginate from './paginate';
+import { getNestedText } from '~utils/get-nested-text';
+import { getTagLinksFromMeta } from '~utils/get-tag-links-from-meta';
+import getTwitchThumbnail from '~utils/get-twitch-thumbnail';
 
 const CARD_LIST_LIMIT = 12;
 
-const CardContainer = styled('div')`
-    display: grid;
-    grid-template-columns: repeat(auto-fill, 350px);
-    grid-row-gap: ${size.small};
-    justify-content: center;
-    margin: 0 -${size.medium};
-
-    @media ${screenSize.upToMedium} {
-        display: block;
-    }
-`;
 const ArticleCard = styled(Card)`
     flex: 1 1 360px;
 `;
 
 const VideoCard = styled(Card)`
     flex: 1 1 360px;
-`;
-
-const HasMoreButtonContainer = styled('div')`
-    margin-bottom: ${size.large};
-    margin-top: ${size.large};
-    text-align: center;
 `;
 
 const getThumbnailUrl = media => {
@@ -107,24 +87,6 @@ const renderContentTypeCard = (item, openAudio) => {
 
 export default React.memo(
     ({ videos, articles, podcasts, limit = CARD_LIST_LIMIT }) => {
-        const { pathname, search } = useLocation();
-        const localPage = pathname.replace(__PATH_PREFIX__, '');
-        // Build next link, preserving other links
-        const nextPageLink = useMemo(() => {
-            // Get page if exists from search
-            const { page = 1, ...params } = parseQueryString(search);
-            // Have to parseInt because string + number gives a string
-            const pageNumber = parseInt(page) + 1;
-            return (
-                localPage + buildQueryString({ page: pageNumber, ...params })
-            );
-        }, [localPage, search]);
-
-        useEffect(() => {
-            const { page = 1 } = parseQueryString(search);
-            setVisibleCards(page * limit);
-        }, [limit, search]);
-        // Prevent jump to top
         videos = videos || [];
         articles = articles || [];
         podcasts = podcasts || [];
@@ -132,10 +94,7 @@ export default React.memo(
         const fullContentList = sortCardsByDate(
             videos.concat(articles, podcasts)
         );
-        const { page = 1 } = parseQueryString(search);
-        const [visibleCards, setVisibleCards] = useState(page * limit);
 
-        const hasMore = fullContentList.length > visibleCards;
         const [activePodcast, setActivePodcast] = useState(false);
 
         const openAudio = useCallback(podcast => {
@@ -148,21 +107,11 @@ export default React.memo(
 
         return (
             <>
-                <CardContainer data-test="card-list">
-                    {fullContentList
-                        .slice(0, visibleCards)
-                        .map(contentType =>
-                            renderContentTypeCard(contentType, openAudio)
-                        )}
-                </CardContainer>
-
-                {hasMore && (
-                    <HasMoreButtonContainer>
-                        <Button secondary pagination to={nextPageLink}>
-                            Load more
-                        </Button>
-                    </HasMoreButtonContainer>
-                )}
+                <Paginate limit={limit} data-test="card-list">
+                    {fullContentList.map(contentType =>
+                        renderContentTypeCard(contentType, openAudio)
+                    )}
+                </Paginate>
                 {podcasts.length ? (
                     <Audio onClose={closeAudio} podcast={activePodcast} />
                 ) : null}

--- a/src/components/dev-hub/paginate.js
+++ b/src/components/dev-hub/paginate.js
@@ -1,0 +1,66 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import styled from '@emotion/styled';
+import { useLocation } from '@reach/router';
+import { buildQueryString, parseQueryString } from '~utils/query-string';
+import Button from './button';
+import { screenSize, size } from './theme';
+
+const CardContainer = styled('div')`
+    display: grid;
+    grid-template-columns: repeat(auto-fill, 350px);
+    grid-row-gap: ${size.small};
+    justify-content: center;
+    margin: 0 -${size.medium};
+
+    @media ${screenSize.upToMedium} {
+        display: block;
+    }
+`;
+
+const HasMoreButtonContainer = styled('div')`
+    margin-bottom: ${size.large};
+    margin-top: ${size.large};
+    text-align: center;
+`;
+
+const Paginate = ({ children, limit, ...props }) => {
+    const { pathname, search } = useLocation();
+    const localPage = pathname.replace(__PATH_PREFIX__, '');
+    // Build next link, preserving other links
+    const nextPageLink = useMemo(() => {
+        // Get page if exists from search
+        const { page = 1, ...params } = parseQueryString(search);
+        // Have to parseInt because string + number gives a string
+        const pageNumber = parseInt(page) + 1;
+        return localPage + buildQueryString({ page: pageNumber, ...params });
+    }, [localPage, search]);
+
+    useEffect(() => {
+        const { page = 1 } = parseQueryString(search);
+        setVisibleCards(page * limit);
+    }, [limit, search]);
+
+    const { page = 1 } = parseQueryString(search);
+    const [visibleCards, setVisibleCards] = useState(page * limit);
+
+    const hasMore = children.length > visibleCards;
+    const visibleElements = useMemo(() => children.slice(0, visibleCards), [
+        children,
+        visibleCards,
+    ]);
+
+    return (
+        <div {...props}>
+            <CardContainer>{visibleElements}</CardContainer>
+            {hasMore && (
+                <HasMoreButtonContainer>
+                    <Button secondary pagination to={nextPageLink}>
+                        Load more
+                    </Button>
+                </HasMoreButtonContainer>
+            )}
+        </div>
+    );
+};
+
+export default Paginate;

--- a/src/components/dev-hub/paginate.js
+++ b/src/components/dev-hub/paginate.js
@@ -7,8 +7,8 @@ import { screenSize, size } from './theme';
 
 const CardContainer = styled('div')`
     display: grid;
-    grid-template-columns: repeat(auto-fill, 350px);
     grid-row-gap: ${size.small};
+    grid-template-columns: repeat(auto-fill, 350px);
     justify-content: center;
     margin: 0 -${size.medium};
 
@@ -37,16 +37,16 @@ const Paginate = ({ children, limit, ...props }) => {
 
     useEffect(() => {
         const { page = 1 } = parseQueryString(search);
-        setVisibleCards(page * limit);
+        setVisibleLength(page * limit);
     }, [limit, search]);
 
     const { page = 1 } = parseQueryString(search);
-    const [visibleCards, setVisibleCards] = useState(page * limit);
+    const [visibleLength, setVisibleLength] = useState(page * limit);
 
-    const hasMore = children.length > visibleCards;
-    const visibleElements = useMemo(() => children.slice(0, visibleCards), [
+    const hasMore = children.length > visibleLength;
+    const visibleElements = useMemo(() => children.slice(0, visibleLength), [
         children,
-        visibleCards,
+        visibleLength,
     ]);
 
     return (

--- a/src/components/dev-hub/paginate.js
+++ b/src/components/dev-hub/paginate.js
@@ -5,7 +5,7 @@ import { buildQueryString, parseQueryString } from '~utils/query-string';
 import Button from './button';
 import { screenSize, size } from './theme';
 
-const CardContainer = styled('div')`
+const ElementGrid = styled('div')`
     display: grid;
     grid-row-gap: ${size.small};
     grid-template-columns: repeat(auto-fill, 350px);
@@ -51,7 +51,7 @@ const Paginate = ({ children, limit, ...props }) => {
 
     return (
         <div {...props}>
-            <CardContainer>{visibleElements}</CardContainer>
+            <ElementGrid>{visibleElements}</ElementGrid>
             {hasMore && (
                 <HasMoreButtonContainer>
                     <Button secondary pagination to={nextPageLink}>


### PR DESCRIPTION
[Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/generic-pagination/learn)

This PR takes some pagination logic from the card list and moves it into a more general `Pagination` component which will allow us to paginate any group of items (not just `Card`s).

This behavior is covered by a test on the learn page. There should be no functional differences from the existing behavior.

To verify:
- Check out any page with pagination
- Click "Load more"
- More items should appear as normal and the `?page=...` in the URL should update as consistent with production