### PR TITLE
Update GH actions to point at test Strapi instance

### DIFF
--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -1,7 +1,5 @@
 name: DevHub CI test
-on:
-    pull_request:
-        branches: [master, staging]
+on: [pull_request]
 jobs:
     build:
         runs-on: ubuntu-latest
@@ -36,7 +34,7 @@ jobs:
                   echo "GATSBY_PARSER_USER=jordanstapinski" >> .env.production; \
                   echo "GATSBY_PARSER_BRANCH=CI" >> .env.production; \
                   echo "GATSBY_SNOOTY_DEV=true" >> .env.production; \
-                  echo "STRAPI_URL=http://54.219.137.111:1337" >> .env.production
+                  echo "STRAPI_URL=http://18.144.177.6:1337" >> .env.production
             - name: Build Gatsby
               run: npm run buildTest
             - name: Cypress run

--- a/.github/workflows/devhub-npm-test.yaml
+++ b/.github/workflows/devhub-npm-test.yaml
@@ -2,11 +2,7 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: DevHub npm test
-
-on:
-    pull_request:
-        branches: [master, staging]
-
+on: [pull_request]
 jobs:
     build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
This PR updates only testing infrastructure.

We set up a new EC2 testing instance for the CMS so we can isolate testing data and have a "staging" CMS environment before going to production. Now, we can comfortably control the test data coming in for CI purposes. I also updated the config to run on any PR now.

All tests and builds should pass on this branch.