### PR TITLE
DEVHUB-302 [Part 4]: Basic Gallery Layout

### DIFF
--- a/src/components/dev-hub/blog-tag-list.js
+++ b/src/components/dev-hub/blog-tag-list.js
@@ -54,7 +54,7 @@ const BlogTag = ({ children, ...props }) => {
     );
 };
 
-const BlogTagList = ({ navigates = true, tags = [] }) => {
+const BlogTagList = ({ className, navigates = true, tags = [] }) => {
     const canExpand = tags.length >= MINIMUM_EXPANDABLE_SIZE;
     // By default any list of blog tags under the minimum expandable size is already expanded
     const [isExpanded, setIsExpanded] = useState(!canExpand);
@@ -72,7 +72,7 @@ const BlogTagList = ({ navigates = true, tags = [] }) => {
     };
 
     return (
-        <TagList>
+        <TagList className={className}>
             {isExpanded &&
                 tags.slice(0, MAX_TAG_LIST_SIZE).map(mapTagToComponent)}
             {!isExpanded && canExpand && (

--- a/src/components/dev-hub/blog-tag-list.js
+++ b/src/components/dev-hub/blog-tag-list.js
@@ -6,7 +6,7 @@ import { fontSize, lineHeight, screenSize, size } from './theme';
 const MINIMUM_EXPANDABLE_SIZE = 3;
 const MAX_TAG_LIST_SIZE = 5;
 
-const TagLink = styled(Link)`
+const TagLink = styled('div')`
     background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
     border: 1px solid ${({ theme }) => theme.colorMap.greyDarkThree};
     border-radius: ${size.medium};
@@ -42,13 +42,19 @@ const TagListItem = styled('li')`
     display: inline-block;
 `;
 
-const BlogTag = ({ children, ...props }) => (
-    <TagListItem>
-        <TagLink {...props}>{children}</TagLink>
-    </TagListItem>
-);
+const BlogTag = ({ children, ...props }) => {
+    const renderAsLink = !!(props.to || props.onClick);
+    const TagLinkComponent = renderAsLink
+        ? TagLink.withComponent(Link)
+        : TagLink;
+    return (
+        <TagListItem>
+            <TagLinkComponent {...props}>{children}</TagLinkComponent>
+        </TagListItem>
+    );
+};
 
-const BlogTagList = ({ tags = [] }) => {
+const BlogTagList = ({ navigates = true, tags = [] }) => {
     const canExpand = tags.length >= MINIMUM_EXPANDABLE_SIZE;
     // By default any list of blog tags under the minimum expandable size is already expanded
     const [isExpanded, setIsExpanded] = useState(!canExpand);
@@ -56,21 +62,24 @@ const BlogTagList = ({ tags = [] }) => {
     if (!tags.length) {
         return null;
     }
+
+    const mapTagToComponent = t => {
+        const props = { key: t.label };
+        if (navigates) {
+            props.to = t.to;
+        }
+        return <BlogTag {...props}>{t.label}</BlogTag>;
+    };
+
     return (
         <TagList>
             {isExpanded &&
-                tags.slice(0, MAX_TAG_LIST_SIZE).map(t => (
-                    <BlogTag key={t.label} to={t.to}>
-                        {t.label}
-                    </BlogTag>
-                ))}
+                tags.slice(0, MAX_TAG_LIST_SIZE).map(mapTagToComponent)}
             {!isExpanded && canExpand && (
                 <>
-                    {tags.slice(0, MINIMUM_EXPANDABLE_SIZE).map(t => (
-                        <BlogTag key={t.label} to={t.to}>
-                            {t.label}
-                        </BlogTag>
-                    ))}
+                    {tags
+                        .slice(0, MINIMUM_EXPANDABLE_SIZE)
+                        .map(mapTagToComponent)}
                     {tags.length !== MINIMUM_EXPANDABLE_SIZE ? (
                         <BlogTag onClick={expandList}>...</BlogTag>
                     ) : null}

--- a/src/components/dev-hub/grid.js
+++ b/src/components/dev-hub/grid.js
@@ -48,7 +48,6 @@ const Grid = ({
             ),
         [children, gridLayout]
     );
-    console.log(children, gridElements);
     return (
         <GridContainer
             gridGap={gridGap}

--- a/src/components/dev-hub/grid.js
+++ b/src/components/dev-hub/grid.js
@@ -8,14 +8,13 @@ const GridContainer = styled('div')`
     display: grid;
     grid-template-columns: repeat(${({ layoutCols }) => layoutCols}, 1fr);
     grid-auto-rows: ${({ rowHeight }) => rowHeight};
-    gap: ${size.default};
+    grid-gap: ${({ gridGap }) => gridGap};
 `;
 
-const gridSpan = ({ rowSpan, colSpan }) => css`
-    grid-row-end: span ${rowSpan};
-    grid-column-end: span ${colSpan};
-`;
-
+const gridSpan = ({ rowSpan, colSpan }) => ({
+    gridColumnEnd: `span ${colSpan}`,
+    gridRowEnd: `span ${rowSpan}`,
+});
 /**
  * "layout" is an object which describes the repetitive nature of the grid with
  * two properties "rowSpan" and "colSpan" which both are arrays defining the
@@ -24,7 +23,14 @@ const gridSpan = ({ rowSpan, colSpan }) => css`
  *
  * See utils/grid-layout.js and grid.stories.mdx for more.
  */
-const Grid = ({ children, layout, numCols, rowHeight = '1fr', ...props }) => {
+const Grid = ({
+    children,
+    layout,
+    numCols,
+    gridGap = size.default,
+    rowHeight = '1fr',
+    ...props
+}) => {
     const gridLayout = useMemo(
         () => new GridLayout(layout.rowSpan, layout.colSpan),
         [layout]
@@ -33,14 +39,23 @@ const Grid = ({ children, layout, numCols, rowHeight = '1fr', ...props }) => {
         () =>
             children.map((child, i) =>
                 React.cloneElement(child, {
-                    css: gridSpan(gridLayout.position(i)),
+                    style: {
+                        ...gridSpan(gridLayout.position(i)),
+                        ...child.style,
+                    },
                     key: i,
                 })
             ),
         [children, gridLayout]
     );
+    console.log(children, gridElements);
     return (
-        <GridContainer rowHeight={rowHeight} layoutCols={numCols} {...props}>
+        <GridContainer
+            gridGap={gridGap}
+            rowHeight={rowHeight}
+            layoutCols={numCols}
+            {...props}
+        >
             {gridElements}
         </GridContainer>
     );

--- a/src/components/dev-hub/student-spotlight/github-student-pack.js
+++ b/src/components/dev-hub/student-spotlight/github-student-pack.js
@@ -4,7 +4,12 @@ import githubStudentPackPng from '../../../images/github-backpack-mongo.png';
 import Link from '../link';
 import MediaBlock from '../media-block';
 import { H4, P } from '../text';
-import { screenSize } from '../theme';
+import { screenSize, size } from '../theme';
+
+const StyledMediaBlock = styled(MediaBlock)`
+    background-color: ${({ theme }) => theme.colorMap.devBlack};
+    padding: ${size.xlarge} ${size.xxlarge};
+`;
 
 const LightText = styled(P)`
     color: ${({ theme }) => theme.colorMap.greyLightTwo};
@@ -61,9 +66,9 @@ const GithubStudentContent = () => (
 );
 
 const GithubStudentPack = () => (
-    <MediaBlock reverse mediaComponent={<GithubBackpackImg />}>
+    <StyledMediaBlock reverse mediaComponent={<GithubBackpackImg />}>
         <GithubStudentContent />
-    </MediaBlock>
+    </StyledMediaBlock>
 );
 
 export default GithubStudentPack;

--- a/src/components/dev-hub/student-spotlight/share-project-cta.js
+++ b/src/components/dev-hub/student-spotlight/share-project-cta.js
@@ -17,8 +17,8 @@ const HeaderWithIncreasedMargin = styled(H3)`
     margin-bottom: ${size.medium};
 `;
 
-const ShareProjectCTA = () => (
-    <MaxWidthContainer>
+const ShareProjectCTA = ({ ...props }) => (
+    <MaxWidthContainer {...props}>
         <HeaderWithIncreasedMargin>
             Have an interesting MongoDB project to share? Let us know!
         </HeaderWithIncreasedMargin>

--- a/src/components/pages/students/all-projects.js
+++ b/src/components/pages/students/all-projects.js
@@ -44,6 +44,7 @@ const AllProjects = () => {
         [projects]
     );
     const gridProps = {
+        gridGap: '48px',
         rowHeight: GRID_ROW_HEIGHT,
         numCols: 3,
         layout: gridLayout,

--- a/src/components/pages/students/featured-project.js
+++ b/src/components/pages/students/featured-project.js
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import dlv from 'dlv';
 import { useStaticQuery, graphql } from 'gatsby';
 import styled from '@emotion/styled';
+import BlogTagList from '~components/dev-hub/blog-tag-list';
 import Link from '~components/dev-hub/link';
 import AuthorImageList from '~components/dev-hub/author-image-list';
 import Badge from '~components/dev-hub/badge';
@@ -10,12 +11,20 @@ import { H5, P } from '~components/dev-hub/text';
 import { size } from '~components/dev-hub/theme';
 import { transformProjectStrapiData } from '~utils/transform-project-strapi-data';
 
+const AuthorImageListWithMargin = styled(AuthorImageList)`
+    margin-bottom: ${size.large};
+`;
+
 const DescriptionText = styled(P)`
     color: ${({ theme }) => theme.colorMap.greyLightTwo};
+    margin-bottom: 48px;
 `;
 
 const FeaturedImage = styled('img')`
     border-radius: ${size.xsmall};
+    height: 100%;
+    /* Preserve aspect ratio but fill appropriately */
+    object-fit: cover;
 `;
 
 const GridWithBottomBorder = styled(Grid)`
@@ -27,6 +36,14 @@ const RelativePositionedBadge = styled(Badge)`
     margin-left: 0;
     position: relative;
     width: fit-content;
+`;
+
+const StyledLink = styled(Link)`
+    color: ${({ theme }) => theme.colorMap.devWhite};
+`;
+
+const TagListWithMargin = styled(BlogTagList)`
+    margin-bottom: 48px;
 `;
 
 const galleryFeaturedProject = graphql`
@@ -51,18 +68,25 @@ const FeaturedProject = () => {
         name,
         slug,
         students,
+        tags,
     } = transformProjectStrapiData(project);
     return (
-        <GridWithBottomBorder layout={gridLayout} gridGap="48px" numCols={3}>
+        <GridWithBottomBorder
+            layout={gridLayout}
+            gridGap="48px"
+            rowHeight="460px"
+            numCols={3}
+        >
             <FeaturedImage src={image_url} />
             <div>
                 <RelativePositionedBadge contentType="featured" />
                 <H5>{name}</H5>
                 <DescriptionText>{description}</DescriptionText>
-                <AuthorImageList size={30} students={students} />
-                <Link tertiary to={slug}>
+                <AuthorImageListWithMargin size={30} students={students} />
+                <TagListWithMargin navigates={false} tags={tags} />
+                <StyledLink tertiary to={slug}>
                     View Project
-                </Link>
+                </StyledLink>
             </div>
         </GridWithBottomBorder>
     );

--- a/src/components/pages/students/featured-project.js
+++ b/src/components/pages/students/featured-project.js
@@ -1,13 +1,14 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import dlv from 'dlv';
 import { useStaticQuery, graphql } from 'gatsby';
+import css from '@emotion/core';
 import styled from '@emotion/styled';
 import Link from '~components/dev-hub/link';
 import AuthorImageList from '~components/dev-hub/author-image-list';
 import Badge from '~components/dev-hub/badge';
-import MediaBlock from '~components/dev-hub/media-block';
+import Grid from '~components/dev-hub/grid';
 import { H5, P } from '~components/dev-hub/text';
-import { size } from '~components/dev-hub/theme';
+import { screenSize, size } from '~components/dev-hub/theme';
 import { transformProjectStrapiData } from '~utils/transform-project-strapi-data';
 
 const DescriptionText = styled(P)`
@@ -17,6 +18,8 @@ const DescriptionText = styled(P)`
 const FeaturedImage = styled('img')`
     border-radius: ${size.xsmall};
 `;
+
+const Container = styled('div')``;
 
 const RelativePositionedBadge = styled(Badge)`
     margin-left: 0;
@@ -33,6 +36,7 @@ const galleryFeaturedProject = graphql`
 `;
 
 const FeaturedProject = () => {
+    const gridLayout = useMemo(() => ({ rowSpan: [1], colSpan: [2, 1] }), []);
     const data = useStaticQuery(galleryFeaturedProject);
     const project = dlv(
         data,
@@ -47,18 +51,18 @@ const FeaturedProject = () => {
         students,
     } = transformProjectStrapiData(project);
     return (
-        <MediaBlock
-            mediaComponent={<FeaturedImage src={image_url} />}
-            mediaWidth="66%"
-        >
-            <RelativePositionedBadge contentType="featured" />
-            <H5>{name}</H5>
-            <DescriptionText>{description}</DescriptionText>
-            <AuthorImageList size={30} students={students} />
-            <Link tertiary to={slug}>
-                View Project
-            </Link>
-        </MediaBlock>
+        <Grid layout={gridLayout} gridGap="48px" numCols={3}>
+            <FeaturedImage src={image_url} />
+            <Container>
+                <RelativePositionedBadge contentType="featured" />
+                <H5>{name}</H5>
+                <DescriptionText>{description}</DescriptionText>
+                <AuthorImageList size={30} students={students} />
+                <Link tertiary to={slug}>
+                    View Project
+                </Link>
+            </Container>
+        </Grid>
     );
 };
 

--- a/src/components/pages/students/featured-project.js
+++ b/src/components/pages/students/featured-project.js
@@ -1,14 +1,13 @@
 import React, { useMemo } from 'react';
 import dlv from 'dlv';
 import { useStaticQuery, graphql } from 'gatsby';
-import css from '@emotion/core';
 import styled from '@emotion/styled';
 import Link from '~components/dev-hub/link';
 import AuthorImageList from '~components/dev-hub/author-image-list';
 import Badge from '~components/dev-hub/badge';
 import Grid from '~components/dev-hub/grid';
 import { H5, P } from '~components/dev-hub/text';
-import { screenSize, size } from '~components/dev-hub/theme';
+import { size } from '~components/dev-hub/theme';
 import { transformProjectStrapiData } from '~utils/transform-project-strapi-data';
 
 const DescriptionText = styled(P)`
@@ -19,7 +18,10 @@ const FeaturedImage = styled('img')`
     border-radius: ${size.xsmall};
 `;
 
-const Container = styled('div')``;
+const GridWithBottomBorder = styled(Grid)`
+    border-bottom: 1px solid ${({ theme }) => theme.colorMap.greyDarkTwo};
+    padding-bottom: ${size.xlarge};
+`;
 
 const RelativePositionedBadge = styled(Badge)`
     margin-left: 0;
@@ -51,9 +53,9 @@ const FeaturedProject = () => {
         students,
     } = transformProjectStrapiData(project);
     return (
-        <Grid layout={gridLayout} gridGap="48px" numCols={3}>
+        <GridWithBottomBorder layout={gridLayout} gridGap="48px" numCols={3}>
             <FeaturedImage src={image_url} />
-            <Container>
+            <div>
                 <RelativePositionedBadge contentType="featured" />
                 <H5>{name}</H5>
                 <DescriptionText>{description}</DescriptionText>
@@ -61,8 +63,8 @@ const FeaturedProject = () => {
                 <Link tertiary to={slug}>
                     View Project
                 </Link>
-            </Container>
-        </Grid>
+            </div>
+        </GridWithBottomBorder>
     );
 };
 

--- a/src/pages/academia/students/index.js
+++ b/src/pages/academia/students/index.js
@@ -20,15 +20,20 @@ const ContentContainer = styled('div')`
     }
 `;
 
+const TopPaddedShareProjectCTA = styled(ShareProjectCTA)`
+    padding-top: ${size.xlarge};
+    padding-bottom: 88px;
+`;
+
 const Students = () => (
     <Layout>
         <GalleryHeroBanner />
         <ContentContainer>
             <FeaturedProject />
             <AllProjects />
-            <ShareProjectCTA />
-            <GithubStudentPack />
+            <TopPaddedShareProjectCTA />
         </ContentContainer>
+        <GithubStudentPack />
     </Layout>
 );
 

--- a/src/pages/academia/students/index.js
+++ b/src/pages/academia/students/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import styled from '@emotion/styled';
 import Layout from '~components/dev-hub/layout';
 import {
     GithubStudentPack,
@@ -7,14 +8,27 @@ import {
 import FeaturedProject from '~components/pages/students/featured-project';
 import AllProjects from '~components/pages/students/all-projects';
 import GalleryHeroBanner from '~components/pages/students/gallery-hero-banner';
+import { screenSize, size } from '~components/dev-hub/theme';
+
+const ContentContainer = styled('div')`
+    padding-left: ${size.xxlarge};
+    padding-right: ${size.xxlarge};
+    @media ${screenSize.upToLarge} {
+        /* Show image as child under breadcrumbs instead */
+        padding: ${size.medium};
+        width: 100%;
+    }
+`;
 
 const Students = () => (
     <Layout>
         <GalleryHeroBanner />
-        <FeaturedProject />
-        <AllProjects />
-        <ShareProjectCTA />
-        <GithubStudentPack />
+        <ContentContainer>
+            <FeaturedProject />
+            <AllProjects />
+            <ShareProjectCTA />
+            <GithubStudentPack />
+        </ContentContainer>
     </Layout>
 );
 

--- a/src/queries/fragments/project.js
+++ b/src/queries/fragments/project.js
@@ -18,6 +18,15 @@ export const featuredGalleryProject = graphql`
                 image {
                     url
                 }
+                languages {
+                    language
+                }
+                products {
+                    product
+                }
+                tags {
+                    tag
+                }
             }
         }
     }
@@ -39,6 +48,15 @@ export const projectFragment = graphql`
             slug
             image {
                 url
+            }
+            languages {
+                language
+            }
+            products {
+                product
+            }
+            tags {
+                tag
             }
         }
     }

--- a/src/utils/transform-project-strapi-data.js
+++ b/src/utils/transform-project-strapi-data.js
@@ -3,6 +3,9 @@ export const transformProjectStrapiData = project => {
         image_url: project.info.image.url,
         ...project.info,
     };
+    result.languages = result.languages.map(l => l.language);
+    result.products = result.products.map(p => p.product);
+    result.tags = result.tags.map(t => t.tag);
     result.students = [];
     project.students.forEach(student => {
         result.students.push({

--- a/src/utils/transform-project-strapi-data.js
+++ b/src/utils/transform-project-strapi-data.js
@@ -3,9 +3,10 @@ export const transformProjectStrapiData = project => {
         image_url: project.info.image.url,
         ...project.info,
     };
-    result.languages = result.languages.map(l => l.language);
-    result.products = result.products.map(p => p.product);
-    result.tags = result.tags.map(t => t.tag);
+    const languages = result.languages.map(l => ({ label: l.language }));
+    const products = result.products.map(p => ({ label: p.product }));
+    const tags = result.tags.map(t => ({ label: t.tag }));
+    result.tags = [...products, ...languages, ...tags];
     result.students = [];
     project.students.forEach(student => {
         result.students.push({


### PR DESCRIPTION
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-302-layout/academia/students/)

This PR adds the rest of the data into the Gallery page and fixes layout on desktop (mobile still WIP from design). We had to do some additional refactorings here:
- Switched Grid from copying in `css` to copying in `style`
- Allowed the `BlogTagList` to not navigate
- Added tags into query calls