### PR TITLE
DEVHUB-388: Add Hover States for Menu Items

### DIFF
--- a/src/components/dev-hub/global-nav.js
+++ b/src/components/dev-hub/global-nav.js
@@ -11,6 +11,7 @@ import useMedia from '~hooks/use-media';
 
 // nav height is 58px: 24px line height + 2 * 17px vertical padding
 const LINK_VERTICAL_PADDING = '17px';
+const SUBITEM_MAX_WIDTH = '364px';
 
 const GlobalNav = styled('nav')`
     background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
@@ -77,16 +78,23 @@ const NavListHeader = styled(NavLink)`
 `;
 const NavItemList = styled('div')``;
 const NavItemSublist = styled('ul')`
-    background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
     display: ${({ isExpanded }) => (isExpanded ? 'block' : 'none')};
     list-style: none;
-    margin-top: 2px;
+    margin-top: 0px;
+    padding-top: 1px;
+    border-top: 1px solid transparent;
+    max-width: ${SUBITEM_MAX_WIDTH};
     padding-left: 0;
     position: absolute;
     z-index: ${layer.front};
     > li {
+        background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
         margin: 0;
         padding: ${size.medium} ${size.large};
+        &:hover,
+        &[aria-current='page'] {
+            background-color: #2c3d47;
+        }
         :not(:last-of-type) {
             box-shadow: 0px 1px 0px #3d4f58;
         }
@@ -96,10 +104,6 @@ const SubItemLink = styled(NavLink)`
     height: 100%;
     width: 100%;
     padding: 0;
-    &:hover,
-    &[aria-current='page'] {
-        background-color: #2c3d47;
-    }
 `;
 const SubItemDescriptionText = styled(P3)`
     color: ${({ theme }) => theme.colorMap.greyLightTwo};

--- a/src/components/dev-hub/global-nav.js
+++ b/src/components/dev-hub/global-nav.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import dlv from 'dlv';
 import styled from '@emotion/styled';
 import { graphql, useStaticQuery } from 'gatsby';
 import DevLeafDesktop from './icons/mdb-dev-leaf-desktop';
 import DevLeafMobile from './icons/mdb-dev-leaf-mobile';
 import Link from '../Link';
-import { fontSize, lineHeight, screenSize, size } from './theme';
+import { fontSize, layer, lineHeight, screenSize, size } from './theme';
 import useMedia from '~hooks/use-media';
 
 // nav height is 58px: 24px line height + 2 * 17px vertical padding
@@ -71,6 +71,24 @@ const HomeLink = styled(NavLink)`
     }
 `;
 
+const NavListHeader = styled(NavLink)`
+    position: relative;
+`;
+const NavItemList = styled('div')``;
+const NavItemSublist = styled('ul')`
+    background-color: red;
+    display: ${({ isExpanded }) => (isExpanded ? 'block' : 'none')};
+    list-style: none;
+    margin-top: 2px;
+    padding-left: 0;
+    position: absolute;
+    z-index: ${layer.front};
+    > li {
+        margin: 0;
+        padding: 0;
+    }
+`;
+
 const topNavItems = graphql`
     query TopNavItems {
         strapiTopNav {
@@ -81,12 +99,33 @@ const topNavItems = graphql`
     }
 `;
 
-// TODO: Update with new behavior
+const NavItemSubItem = ({ subitem }) => (
+    <NavLink to={subitem.url}>{subitem.name}</NavLink>
+);
+
 const NavItem = ({ item }) => {
+    const [isExpanded, setIsExpanded] = useState(false);
     const hasSubMenu = !!item.subitems.length;
     if (hasSubMenu) {
-        const NavListHeader = NavLink.withComponent('div');
-        return <NavListHeader>{item.name}</NavListHeader>;
+        const NavListHeaderDiv = NavListHeader.withComponent('div');
+        return (
+            <NavItemList
+                onBlur={() => setIsExpanded(false)}
+                onMouseLeave={() => setIsExpanded(false)}
+                onMouseEnter={() => setIsExpanded(true)}
+                onFocus={() => setIsExpanded(true)}
+                tabIndex="0"
+            >
+                <NavListHeaderDiv>{item.name}</NavListHeaderDiv>
+                <NavItemSublist isExpanded={isExpanded} tabIndex="0">
+                    {item.subitems.map(subitem => (
+                        <li tabIndex="0">
+                            <NavItemSubItem tabIndex="0" subitem={subitem} />
+                        </li>
+                    ))}
+                </NavItemSublist>
+            </NavItemList>
+        );
     }
     return <NavLink to={item.url}>{item.name}</NavLink>;
 };

--- a/src/components/dev-hub/global-nav.js
+++ b/src/components/dev-hub/global-nav.js
@@ -5,6 +5,7 @@ import { graphql, useStaticQuery } from 'gatsby';
 import DevLeafDesktop from './icons/mdb-dev-leaf-desktop';
 import DevLeafMobile from './icons/mdb-dev-leaf-mobile';
 import Link from '../Link';
+import { P, P3 } from './text';
 import { fontSize, layer, lineHeight, screenSize, size } from './theme';
 import useMedia from '~hooks/use-media';
 
@@ -76,7 +77,7 @@ const NavListHeader = styled(NavLink)`
 `;
 const NavItemList = styled('div')``;
 const NavItemSublist = styled('ul')`
-    background-color: red;
+    background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
     display: ${({ isExpanded }) => (isExpanded ? 'block' : 'none')};
     list-style: none;
     margin-top: 2px;
@@ -85,8 +86,23 @@ const NavItemSublist = styled('ul')`
     z-index: ${layer.front};
     > li {
         margin: 0;
-        padding: 0;
+        padding: ${size.medium} ${size.large};
+        :not(:last-of-type) {
+            box-shadow: 0px 1px 0px #3d4f58;
+        }
     }
+`;
+const SubItemLink = styled(NavLink)`
+    height: 100%;
+    width: 100%;
+    padding: 0;
+    &:hover,
+    &[aria-current='page'] {
+        background-color: #2c3d47;
+    }
+`;
+const SubItemDescriptionText = styled(P3)`
+    color: ${({ theme }) => theme.colorMap.greyLightTwo};
 `;
 
 const topNavItems = graphql`
@@ -100,7 +116,14 @@ const topNavItems = graphql`
 `;
 
 const NavItemSubItem = ({ subitem }) => (
-    <NavLink to={subitem.url}>{subitem.name}</NavLink>
+    <SubItemLink to={subitem.url}>
+        <div>
+            <P>{subitem.name}</P>
+            <SubItemDescriptionText collapse>
+                {subitem.description}
+            </SubItemDescriptionText>
+        </div>
+    </SubItemLink>
 );
 
 const NavItem = ({ item }) => {
@@ -119,7 +142,7 @@ const NavItem = ({ item }) => {
                 <NavListHeaderDiv>{item.name}</NavListHeaderDiv>
                 <NavItemSublist isExpanded={isExpanded} tabIndex="0">
                     {item.subitems.map(subitem => (
-                        <li tabIndex="0">
+                        <li>
                             <NavItemSubItem tabIndex="0" subitem={subitem} />
                         </li>
                     ))}

--- a/src/components/dev-hub/global-nav.js
+++ b/src/components/dev-hub/global-nav.js
@@ -1,17 +1,16 @@
-import React, { useState } from 'react';
+import React from 'react';
 import dlv from 'dlv';
 import styled from '@emotion/styled';
 import { graphql, useStaticQuery } from 'gatsby';
 import DevLeafDesktop from './icons/mdb-dev-leaf-desktop';
 import DevLeafMobile from './icons/mdb-dev-leaf-mobile';
 import Link from '../Link';
-import { P, P3 } from './text';
-import { fontSize, layer, lineHeight, screenSize, size } from './theme';
+import { fontSize, lineHeight, screenSize, size } from './theme';
 import useMedia from '~hooks/use-media';
+import NavItem from './nav-item';
 
 // nav height is 58px: 24px line height + 2 * 17px vertical padding
 const LINK_VERTICAL_PADDING = '17px';
-const SUBITEM_MAX_WIDTH = '364px';
 
 const GlobalNav = styled('nav')`
     background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
@@ -73,42 +72,6 @@ const HomeLink = styled(NavLink)`
     }
 `;
 
-const NavListHeader = styled(NavLink)`
-    position: relative;
-`;
-const NavItemList = styled('div')``;
-const NavItemSublist = styled('ul')`
-    display: ${({ isExpanded }) => (isExpanded ? 'block' : 'none')};
-    list-style: none;
-    margin-top: 0px;
-    padding-top: 1px;
-    border-top: 1px solid transparent;
-    max-width: ${SUBITEM_MAX_WIDTH};
-    padding-left: 0;
-    position: absolute;
-    z-index: ${layer.front};
-    > li {
-        background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
-        margin: 0;
-        padding: ${size.medium} ${size.large};
-        &:hover,
-        &[aria-current='page'] {
-            background-color: #2c3d47;
-        }
-        :not(:last-of-type) {
-            box-shadow: 0px 1px 0px #3d4f58;
-        }
-    }
-`;
-const SubItemLink = styled(NavLink)`
-    height: 100%;
-    width: 100%;
-    padding: 0;
-`;
-const SubItemDescriptionText = styled(P3)`
-    color: ${({ theme }) => theme.colorMap.greyLightTwo};
-`;
-
 const topNavItems = graphql`
     query TopNavItems {
         strapiTopNav {
@@ -118,44 +81,6 @@ const topNavItems = graphql`
         }
     }
 `;
-
-const NavItemSubItem = ({ subitem }) => (
-    <SubItemLink to={subitem.url}>
-        <div>
-            <P>{subitem.name}</P>
-            <SubItemDescriptionText collapse>
-                {subitem.description}
-            </SubItemDescriptionText>
-        </div>
-    </SubItemLink>
-);
-
-const NavItem = ({ item }) => {
-    const [isExpanded, setIsExpanded] = useState(false);
-    const hasSubMenu = !!item.subitems.length;
-    if (hasSubMenu) {
-        const NavListHeaderDiv = NavListHeader.withComponent('div');
-        return (
-            <NavItemList
-                onBlur={() => setIsExpanded(false)}
-                onMouseLeave={() => setIsExpanded(false)}
-                onMouseEnter={() => setIsExpanded(true)}
-                onFocus={() => setIsExpanded(true)}
-                tabIndex="0"
-            >
-                <NavListHeaderDiv>{item.name}</NavListHeaderDiv>
-                <NavItemSublist isExpanded={isExpanded} tabIndex="0">
-                    {item.subitems.map(subitem => (
-                        <li>
-                            <NavItemSubItem tabIndex="0" subitem={subitem} />
-                        </li>
-                    ))}
-                </NavItemSublist>
-            </NavItemList>
-        );
-    }
-    return <NavLink to={item.url}>{item.name}</NavLink>;
-};
 
 export default () => {
     const data = useStaticQuery(topNavItems);

--- a/src/components/dev-hub/global-nav.js
+++ b/src/components/dev-hub/global-nav.js
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import { graphql, useStaticQuery } from 'gatsby';
 import DevLeafDesktop from './icons/mdb-dev-leaf-desktop';
 import DevLeafMobile from './icons/mdb-dev-leaf-mobile';
-import Link from './link';
+import Link from '../Link';
 import { fontSize, lineHeight, screenSize, size } from './theme';
 import useMedia from '~hooks/use-media';
 
@@ -83,7 +83,12 @@ const topNavItems = graphql`
 
 // TODO: Update with new behavior
 const NavItem = ({ item }) => {
-    return <NavLink>{item.name}</NavLink>;
+    const hasSubMenu = !!item.subitems.length;
+    if (hasSubMenu) {
+        const NavListHeader = NavLink.withComponent('div');
+        return <NavListHeader>{item.name}</NavListHeader>;
+    }
+    return <NavLink to={item.url}>{item.name}</NavLink>;
 };
 
 export default () => {

--- a/src/components/dev-hub/nav-item.js
+++ b/src/components/dev-hub/nav-item.js
@@ -7,6 +7,9 @@ import { fontSize, layer, lineHeight, screenSize, size } from './theme';
 
 // nav height is 58px: 24px line height + 2 * 17px vertical padding
 const LINK_VERTICAL_PADDING = '17px';
+/* greyDarkTwo at 40% opacity on greyDarkThree */
+const HOVER_STATE_BACKGROUND_COLOR = '#2c3d47';
+const HOVER_STATE_GREEN_COLOR = '#0ad05b';
 const SUBITEM_MAX_WIDTH = '364px';
 
 const hoverEffect = css`
@@ -14,9 +17,8 @@ const hoverEffect = css`
     &:hover,
     &:focus,
     &:focus-within {
-        /* greyDarkTwo at 40% opacity on greyDarkThree */
-        background-color: #2c3d47;
-        color: #0ad05b;
+        background-color: ${HOVER_STATE_BACKGROUND_COLOR};
+        color: ${HOVER_STATE_GREEN_COLOR};
     }
 `;
 
@@ -40,7 +42,7 @@ const linkTextStyles = css`
 const subItemBoxShadow = css`
     margin-bottom: 1px;
     :not(:last-of-type) {
-        box-shadow: 0px 1px 0px #3d4f58;
+        box-shadow: 0px 1px 0px ${({ theme }) => theme.colorMap.greyDarkTwo};
     }
     :last-of-type {
         border-radius: 0 0 6px 6px;
@@ -55,7 +57,8 @@ const NavLink = styled(Link)`
 
 const NavListHeader = styled(NavLink)`
     position: relative;
-    ${({ isExpanded }) => isExpanded && `background-color: #2c3d47`}
+    ${({ isExpanded }) =>
+        isExpanded && `background-color: ${HOVER_STATE_BACKGROUND_COLOR}`}
 `;
 
 const NavListSubItem = styled('li')`
@@ -81,9 +84,9 @@ const NavItemMenu = styled('div')`
     &:hover,
     &:focus,
     &:focus-within {
-        color: #0ad05b;
+        color: ${HOVER_STATE_GREEN_COLOR};
     }
-    ${({ isExpanded }) => isExpanded && `color: #0ad05b`};
+    ${({ isExpanded }) => isExpanded && `color: ${HOVER_STATE_GREEN_COLOR}`};
 `;
 
 const SubItemContents = styled('div')`
@@ -97,9 +100,9 @@ const SubItemDescriptionText = styled(P3)`
 const SubItemLink = styled(NavLink)`
     padding: 0;
     &:hover {
-        color: white;
+        color: ${({ theme }) => theme.colorMap.devWhite};
         ${SubItemDescriptionText} {
-            color: #f9fbfa;
+            color: ${({ theme }) => theme.colorMap.devWhite};
         }
     }
 `;

--- a/src/components/dev-hub/nav-item.js
+++ b/src/components/dev-hub/nav-item.js
@@ -15,7 +15,10 @@ const NavLink = styled(Link)`
     line-height: ${lineHeight.small};
     padding: ${LINK_VERTICAL_PADDING} ${size.xlarge};
     text-decoration: none;
+    &:active,
     &:hover,
+    &:focus,
+    &:focus-within,
     &[aria-current='page'] {
         /* greyDarkTwo at 40% opacity on greyDarkThree */
         background-color: #2c3d47;
@@ -44,7 +47,10 @@ const NavItemSublist = styled('ul')`
     > li {
         background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
         margin-bottom: 1px;
+        &:active,
         &:hover,
+        &:focus,
+        &:focus-within,
         &[aria-current='page'] {
             background-color: #2c3d47;
         }

--- a/src/components/dev-hub/nav-item.js
+++ b/src/components/dev-hub/nav-item.js
@@ -59,6 +59,7 @@ const NavListSubItem = styled('li')`
     ${hoverEffect};
     ${subItemBoxShadow};
 `;
+
 const NavItemSublist = styled('ul')`
     display: ${({ isExpanded }) => (isExpanded ? 'block' : 'none')};
     list-style: none;
@@ -69,20 +70,43 @@ const NavItemSublist = styled('ul')`
     z-index: ${layer.front};
     ${showGreenDivider};
 `;
+
+const NavItemMenu = styled('div')`
+    &:active,
+    &:hover,
+    &:focus,
+    &:focus-within {
+        color: #0ad05b;
+    }
+    ${({ isExpanded }) => isExpanded && `color: #0ad05b`};
+`;
+
 const SubItemContents = styled('div')`
     padding: ${size.medium} ${size.large};
 `;
-const SubItemLink = styled(NavLink)`
-    padding: 0;
-`;
+
 const SubItemDescriptionText = styled(P3)`
     color: ${({ theme }) => theme.colorMap.greyLightTwo};
+`;
+
+const SubItemLink = styled(NavLink)`
+    padding: 0;
+    &:hover {
+        color: white;
+        ${SubItemDescriptionText} {
+            color: #f9fbfa;
+        }
+    }
+`;
+
+const SubItemText = styled(P)`
+    margin-bottom: 4px;
 `;
 
 const NavItemSubItem = ({ subitem }) => (
     <SubItemLink to={subitem.url}>
         <SubItemContents>
-            <P>{subitem.name}</P>
+            <SubItemText>{subitem.name}</SubItemText>
             <SubItemDescriptionText collapse>
                 {subitem.description}
             </SubItemDescriptionText>
@@ -97,13 +121,11 @@ const NavItem = ({ item }) => {
     const hasSubMenu = !!item.subitems.length;
     const closeOptionsOnBlur = useCallback(
         e => {
-            // Check the event to see if the next element would be a list element
-            // otherwise, close the options
-            const isTabbingThroughOptions =
-                e.relatedTarget &&
-                (e.relatedTarget.tagName === 'UL' ||
-                    (e.relatedTarget.tagName === 'A' &&
-                        e.relatedTarget.className.includes('SubItemLink')));
+            // Check the event to see if the next element is a child here
+            // Tabbing is a bit off due to display: none
+            const isTabbingThroughOptions = e.currentTarget.contains(
+                e.relatedTarget
+            );
             if (!isTabbingThroughOptions) {
                 closeMenu();
             }
@@ -113,11 +135,12 @@ const NavItem = ({ item }) => {
     if (hasSubMenu) {
         const NavListHeaderDiv = NavListHeader.withComponent('div');
         return (
-            <div
+            <NavItemMenu
                 onBlur={closeOptionsOnBlur}
                 onMouseLeave={closeMenu}
                 onMouseEnter={expandMenu}
                 onFocus={expandMenu}
+                isExpanded={isExpanded}
                 tabIndex="0"
             >
                 <NavListHeaderDiv>{item.name}</NavListHeaderDiv>
@@ -128,7 +151,7 @@ const NavItem = ({ item }) => {
                         </NavListSubItem>
                     ))}
                 </NavItemSublist>
-            </div>
+            </NavItemMenu>
         );
     }
     return <NavLink to={item.url}>{item.name}</NavLink>;

--- a/src/components/dev-hub/nav-item.js
+++ b/src/components/dev-hub/nav-item.js
@@ -75,8 +75,8 @@ const NavItemSubItem = ({ subitem }) => (
 );
 
 const NavItem = ({ item }) => {
-    const [isExpanded, setIsExpanded] = useState(true);
-    const closeMenu = useCallback(() => setIsExpanded(true), [setIsExpanded]);
+    const [isExpanded, setIsExpanded] = useState(false);
+    const closeMenu = useCallback(() => setIsExpanded(false), [setIsExpanded]);
     const expandMenu = useCallback(() => setIsExpanded(true), [setIsExpanded]);
     const hasSubMenu = !!item.subitems.length;
     const closeOptionsOnBlur = useCallback(

--- a/src/components/dev-hub/nav-item.js
+++ b/src/components/dev-hub/nav-item.js
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from 'react';
+import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import Link from '../Link';
 import { P, P3 } from './text';
@@ -8,13 +9,7 @@ import { fontSize, layer, lineHeight, screenSize, size } from './theme';
 const LINK_VERTICAL_PADDING = '17px';
 const SUBITEM_MAX_WIDTH = '364px';
 
-const NavLink = styled(Link)`
-    font-size: ${fontSize.small};
-    font-weight: 300;
-    letter-spacing: 1px;
-    line-height: ${lineHeight.small};
-    padding: ${LINK_VERTICAL_PADDING} ${size.xlarge};
-    text-decoration: none;
+const hoverEffect = css`
     &:active,
     &:hover,
     &:focus,
@@ -23,6 +18,18 @@ const NavLink = styled(Link)`
         /* greyDarkTwo at 40% opacity on greyDarkThree */
         background-color: #2c3d47;
     }
+`;
+
+const showGreenDivider = css`
+    padding-top: 1px;
+    border-top: 1px solid transparent;
+`;
+
+const linkTextStyles = css`
+    font-size: ${fontSize.small};
+    letter-spacing: 1px;
+    line-height: ${lineHeight.small};
+    text-decoration: none;
     @media ${screenSize.upToMedium} {
         font-size: ${fontSize.tiny};
         line-height: ${lineHeight.xlarge};
@@ -30,39 +37,42 @@ const NavLink = styled(Link)`
     }
 `;
 
+const subItemBoxShadow = css`
+    margin-bottom: 1px;
+    :not(:last-of-type) {
+        box-shadow: 0px 1px 0px #3d4f58;
+    }
+`;
+
+const NavLink = styled(Link)`
+    padding: ${LINK_VERTICAL_PADDING} ${size.xlarge};
+    ${hoverEffect};
+    ${linkTextStyles};
+`;
+
 const NavListHeader = styled(NavLink)`
     position: relative;
 `;
-const NavItemList = styled('div')``;
+
+const NavListSubItem = styled('li')`
+    background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
+    ${hoverEffect};
+    ${subItemBoxShadow};
+`;
 const NavItemSublist = styled('ul')`
     display: ${({ isExpanded }) => (isExpanded ? 'block' : 'none')};
     list-style: none;
     margin-top: 0px;
-    padding-top: 1px;
-    border-top: 1px solid transparent;
     max-width: ${SUBITEM_MAX_WIDTH};
     padding-left: 0;
     position: absolute;
     z-index: ${layer.front};
-    > li {
-        background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
-        margin-bottom: 1px;
-        &:active,
-        &:hover,
-        &:focus,
-        &:focus-within,
-        &[aria-current='page'] {
-            background-color: #2c3d47;
-        }
-        :not(:last-of-type) {
-            box-shadow: 0px 1px 0px #3d4f58;
-        }
-    }
+    ${showGreenDivider};
+`;
+const SubItemContents = styled('div')`
+    padding: ${size.medium} ${size.large};
 `;
 const SubItemLink = styled(NavLink)`
-    > div {
-        padding: ${size.medium} ${size.large};
-    }
     padding: 0;
 `;
 const SubItemDescriptionText = styled(P3)`
@@ -71,12 +81,12 @@ const SubItemDescriptionText = styled(P3)`
 
 const NavItemSubItem = ({ subitem }) => (
     <SubItemLink to={subitem.url}>
-        <div>
+        <SubItemContents>
             <P>{subitem.name}</P>
             <SubItemDescriptionText collapse>
                 {subitem.description}
             </SubItemDescriptionText>
-        </div>
+        </SubItemContents>
     </SubItemLink>
 );
 
@@ -103,7 +113,7 @@ const NavItem = ({ item }) => {
     if (hasSubMenu) {
         const NavListHeaderDiv = NavListHeader.withComponent('div');
         return (
-            <NavItemList
+            <div
                 onBlur={closeOptionsOnBlur}
                 onMouseLeave={closeMenu}
                 onMouseEnter={expandMenu}
@@ -113,12 +123,12 @@ const NavItem = ({ item }) => {
                 <NavListHeaderDiv>{item.name}</NavListHeaderDiv>
                 <NavItemSublist isExpanded={isExpanded}>
                     {item.subitems.map(subitem => (
-                        <li>
+                        <NavListSubItem key={subitem.name}>
                             <NavItemSubItem tabIndex="0" subitem={subitem} />
-                        </li>
+                        </NavListSubItem>
                     ))}
                 </NavItemSublist>
-            </NavItemList>
+            </div>
         );
     }
     return <NavLink to={item.url}>{item.name}</NavLink>;

--- a/src/components/dev-hub/nav-item.js
+++ b/src/components/dev-hub/nav-item.js
@@ -39,33 +39,40 @@ const linkTextStyles = css`
     }
 `;
 
-const subItemBoxShadow = css`
+const subItemBoxShadow = theme => css`
     margin-bottom: 1px;
     :not(:last-of-type) {
-        box-shadow: 0px 1px 0px ${({ theme }) => theme.colorMap.greyDarkTwo};
+        box-shadow: 0px 1px 0px ${theme.colorMap.greyDarkTwo};
     }
     :last-of-type {
         border-radius: 0 0 6px 6px;
     }
 `;
 
-const NavLink = styled(Link)`
+/**
+ * Nav main items (a link or the top of a sublist)
+ */
+
+const navTopItemStyling = css`
     padding: ${LINK_VERTICAL_PADDING} ${size.xlarge};
     ${hoverEffect};
     ${linkTextStyles};
 `;
 
-const NavListHeader = styled(NavLink)`
+const NavLink = styled(Link)`
+    ${navTopItemStyling};
+`;
+
+const NavListHeader = styled('div')`
+    ${navTopItemStyling};
     position: relative;
     ${({ isExpanded }) =>
         isExpanded && `background-color: ${HOVER_STATE_BACKGROUND_COLOR}`}
 `;
 
-const NavListSubItem = styled('li')`
-    background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
-    ${hoverEffect};
-    ${subItemBoxShadow};
-`;
+/**
+ * Expandable sub-list containers
+ */
 
 const NavItemSublist = styled('ul')`
     display: ${({ isExpanded }) => (isExpanded ? 'block' : 'none')};
@@ -89,6 +96,16 @@ const NavItemMenu = styled('div')`
     ${({ isExpanded }) => isExpanded && `color: ${HOVER_STATE_GREEN_COLOR}`};
 `;
 
+/**
+ * Nav menu sub-item
+ */
+
+const NavListSubItem = styled('li')`
+    background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
+    ${hoverEffect};
+    ${({ theme }) => subItemBoxShadow(theme)};
+`;
+
 const SubItemContents = styled('div')`
     padding: ${size.medium} ${size.large};
 `;
@@ -97,7 +114,8 @@ const SubItemDescriptionText = styled(P3)`
     color: ${({ theme }) => theme.colorMap.greyLightTwo};
 `;
 
-const SubItemLink = styled(NavLink)`
+const SubItemLink = styled(Link)`
+    ${navTopItemStyling};
     padding: 0;
     &:hover {
         color: ${({ theme }) => theme.colorMap.devWhite};
@@ -141,7 +159,6 @@ const NavItem = ({ item }) => {
         [closeMenu]
     );
     if (hasSubMenu) {
-        const NavListHeaderDiv = NavListHeader.withComponent('div');
         return (
             <NavItemMenu
                 onBlur={closeOptionsOnBlur}
@@ -151,9 +168,9 @@ const NavItem = ({ item }) => {
                 isExpanded={isExpanded}
                 tabIndex="0"
             >
-                <NavListHeaderDiv isExpanded={isExpanded}>
+                <NavListHeader isExpanded={isExpanded}>
                     {item.name}
-                </NavListHeaderDiv>
+                </NavListHeader>
                 <NavItemSublist isExpanded={isExpanded}>
                     {item.subitems.map(subitem => (
                         <NavListSubItem key={subitem.name}>

--- a/src/components/dev-hub/nav-item.js
+++ b/src/components/dev-hub/nav-item.js
@@ -1,0 +1,121 @@
+import React, { useCallback, useState } from 'react';
+import styled from '@emotion/styled';
+import Link from '../Link';
+import { P, P3 } from './text';
+import { fontSize, layer, lineHeight, screenSize, size } from './theme';
+
+// nav height is 58px: 24px line height + 2 * 17px vertical padding
+const LINK_VERTICAL_PADDING = '17px';
+const SUBITEM_MAX_WIDTH = '364px';
+
+const NavLink = styled(Link)`
+    font-size: ${fontSize.small};
+    font-weight: 300;
+    letter-spacing: 1px;
+    line-height: ${lineHeight.small};
+    padding: ${LINK_VERTICAL_PADDING} ${size.xlarge};
+    text-decoration: none;
+    &:hover,
+    &[aria-current='page'] {
+        /* greyDarkTwo at 40% opacity on greyDarkThree */
+        background-color: #2c3d47;
+    }
+    @media ${screenSize.upToMedium} {
+        font-size: ${fontSize.tiny};
+        line-height: ${lineHeight.xlarge};
+        padding: ${size.small} ${size.default};
+    }
+`;
+
+const NavListHeader = styled(NavLink)`
+    position: relative;
+`;
+const NavItemList = styled('div')``;
+const NavItemSublist = styled('ul')`
+    display: ${({ isExpanded }) => (isExpanded ? 'block' : 'none')};
+    list-style: none;
+    margin-top: 0px;
+    padding-top: 1px;
+    border-top: 1px solid transparent;
+    max-width: ${SUBITEM_MAX_WIDTH};
+    padding-left: 0;
+    position: absolute;
+    z-index: ${layer.front};
+    > li {
+        background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
+        margin-bottom: 1px;
+        &:hover,
+        &[aria-current='page'] {
+            background-color: #2c3d47;
+        }
+        :not(:last-of-type) {
+            box-shadow: 0px 1px 0px #3d4f58;
+        }
+    }
+`;
+const SubItemLink = styled(NavLink)`
+    > div {
+        padding: ${size.medium} ${size.large};
+    }
+    padding: 0;
+`;
+const SubItemDescriptionText = styled(P3)`
+    color: ${({ theme }) => theme.colorMap.greyLightTwo};
+`;
+
+const NavItemSubItem = ({ subitem }) => (
+    <SubItemLink to={subitem.url}>
+        <div>
+            <P>{subitem.name}</P>
+            <SubItemDescriptionText collapse>
+                {subitem.description}
+            </SubItemDescriptionText>
+        </div>
+    </SubItemLink>
+);
+
+const NavItem = ({ item }) => {
+    const [isExpanded, setIsExpanded] = useState(true);
+    const closeMenu = useCallback(() => setIsExpanded(true), [setIsExpanded]);
+    const expandMenu = useCallback(() => setIsExpanded(true), [setIsExpanded]);
+    const hasSubMenu = !!item.subitems.length;
+    const closeOptionsOnBlur = useCallback(
+        e => {
+            // Check the event to see if the next element would be a list element
+            // otherwise, close the options
+            const isTabbingThroughOptions =
+                e.relatedTarget &&
+                (e.relatedTarget.tagName === 'UL' ||
+                    (e.relatedTarget.tagName === 'A' &&
+                        e.relatedTarget.className.includes('SubItemLink')));
+            if (!isTabbingThroughOptions) {
+                closeMenu();
+            }
+        },
+        [closeMenu]
+    );
+    if (hasSubMenu) {
+        const NavListHeaderDiv = NavListHeader.withComponent('div');
+        return (
+            <NavItemList
+                onBlur={closeOptionsOnBlur}
+                onMouseLeave={closeMenu}
+                onMouseEnter={expandMenu}
+                onFocus={expandMenu}
+                tabIndex="0"
+            >
+                <NavListHeaderDiv>{item.name}</NavListHeaderDiv>
+                <NavItemSublist isExpanded={isExpanded}>
+                    {item.subitems.map(subitem => (
+                        <li>
+                            <NavItemSubItem tabIndex="0" subitem={subitem} />
+                        </li>
+                    ))}
+                </NavItemSublist>
+            </NavItemList>
+        );
+    }
+    return <NavLink to={item.url}>{item.name}</NavLink>;
+};
+
+export default NavItem;

--- a/src/components/dev-hub/nav-item.js
+++ b/src/components/dev-hub/nav-item.js
@@ -13,10 +13,10 @@ const hoverEffect = css`
     &:active,
     &:hover,
     &:focus,
-    &:focus-within,
-    &[aria-current='page'] {
+    &:focus-within {
         /* greyDarkTwo at 40% opacity on greyDarkThree */
         background-color: #2c3d47;
+        color: #0ad05b;
     }
 `;
 
@@ -42,6 +42,9 @@ const subItemBoxShadow = css`
     :not(:last-of-type) {
         box-shadow: 0px 1px 0px #3d4f58;
     }
+    :last-of-type {
+        border-radius: 0 0 6px 6px;
+    }
 `;
 
 const NavLink = styled(Link)`
@@ -52,6 +55,7 @@ const NavLink = styled(Link)`
 
 const NavListHeader = styled(NavLink)`
     position: relative;
+    ${({ isExpanded }) => isExpanded && `background-color: #2c3d47`}
 `;
 
 const NavListSubItem = styled('li')`
@@ -72,6 +76,7 @@ const NavItemSublist = styled('ul')`
 `;
 
 const NavItemMenu = styled('div')`
+    cursor: pointer;
     &:active,
     &:hover,
     &:focus,
@@ -143,7 +148,9 @@ const NavItem = ({ item }) => {
                 isExpanded={isExpanded}
                 tabIndex="0"
             >
-                <NavListHeaderDiv>{item.name}</NavListHeaderDiv>
+                <NavListHeaderDiv isExpanded={isExpanded}>
+                    {item.name}
+                </NavListHeaderDiv>
                 <NavItemSublist isExpanded={isExpanded}>
                     {item.subitems.map(subitem => (
                         <NavListSubItem key={subitem.name}>


### PR DESCRIPTION
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-388/)
[Figma](https://www.figma.com/proto/8m3qEliKXVtcqjf17jtVjL/DevHub-Nav?node-id=379%3A1454&scaling=min-zoom)

This PR adds hover actions to the top-nav based on the Figma designs. The goal is to create accessible sub-menus which appear on hover or focus.