### PR TITLE
Lazy load react-player for videos

### DIFF
--- a/src/components/dev-hub/video-embed.js
+++ b/src/components/dev-hub/video-embed.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import ReactPlayer from 'react-player';
+import ReactPlayer from 'react-player/lazy';
 import Button from './button';
 import { size } from './theme';
 import PLACEHOLDER_IMAGE from '../../images/mock-video-placeholder.png';


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/lazy-load-videos/)

This PR removes some unused JS by using the react player `lazy` option. We already do this on podcasts but missed it for videos.

This saves about 50Kib of unused JS.