### PR TITLE
DEVHUB-299 [Part 2]: Swap Home-Page Featured Projects to use Single Type

### DIFF
--- a/src/components/pages/home/project-card-grid.js
+++ b/src/components/pages/home/project-card-grid.js
@@ -13,17 +13,19 @@ const GridContainer = styled('div')`
 
 const homeFeaturedProjects = graphql`
     query HomeFeaturedProjects {
-        allStrapiProjects(limit: 3) {
-            nodes {
-                ...ProjectFragment
-            }
+        strapiStudentSpotlightFeatured {
+            ...FeaturedHomePageProjects
         }
     }
 `;
 
 const ProjectCardGrid = () => {
     const data = useStaticQuery(homeFeaturedProjects);
-    const projects = dlv(data, ['allStrapiProjects', 'nodes'], []);
+    const projects = dlv(
+        data,
+        ['strapiStudentSpotlightFeatured', 'FeaturedHomePageProjects'],
+        []
+    );
     const mappedProjects = projects.map(transformProjectStrapiData);
     return (
         <GridContainer>

--- a/src/queries/fragments/project.js
+++ b/src/queries/fragments/project.js
@@ -32,6 +32,38 @@ export const featuredGalleryProject = graphql`
     }
 `;
 
+export const featuredHomePageProjects = graphql`
+    fragment FeaturedHomePageProjects on StrapiStudentSpotlightFeatured {
+        FeaturedHomePageProjects {
+            students {
+                bio {
+                    name
+                    image {
+                        url
+                    }
+                }
+            }
+            info {
+                name
+                description
+                slug
+                image {
+                    url
+                }
+                languages {
+                    language
+                }
+                products {
+                    product
+                }
+                tags {
+                    tag
+                }
+            }
+        }
+    }
+`;
+
 export const projectFragment = graphql`
     fragment ProjectFragment on StrapiProjects {
         students {


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-299-from-strapi/)

Now that the single type is set, this PR swaps the query to use the single type field for the featured home page projects. Since GraphQL does not think this is a Project type we cannot use an existing fragment. There is likely a workaround here but did not find anything quickly so will come back to it for cleanup.