### PR TITLE
DEVHUB 372: Move projects out of info in GraphQL Queries

### DIFF
--- a/src/queries/fragments/project.js
+++ b/src/queries/fragments/project.js
@@ -3,6 +3,7 @@ import { graphql } from 'gatsby';
 export const featuredGalleryProject = graphql`
     fragment FeaturedGalleryProject on StrapiStudentSpotlightFeatured {
         FeaturedGalleryProject {
+            name
             students {
                 bio {
                     name
@@ -12,7 +13,6 @@ export const featuredGalleryProject = graphql`
                 }
             }
             info {
-                name
                 description
                 slug
                 image {
@@ -35,6 +35,7 @@ export const featuredGalleryProject = graphql`
 export const featuredHomePageProjects = graphql`
     fragment FeaturedHomePageProjects on StrapiStudentSpotlightFeatured {
         FeaturedHomePageProjects {
+            name
             students {
                 bio {
                     name
@@ -44,7 +45,6 @@ export const featuredHomePageProjects = graphql`
                 }
             }
             info {
-                name
                 description
                 slug
                 image {
@@ -66,6 +66,7 @@ export const featuredHomePageProjects = graphql`
 
 export const projectFragment = graphql`
     fragment ProjectFragment on StrapiProjects {
+        name
         students {
             bio {
                 name
@@ -75,7 +76,6 @@ export const projectFragment = graphql`
             }
         }
         info {
-            name
             description
             slug
             image {

--- a/src/utils/transform-project-strapi-data.js
+++ b/src/utils/transform-project-strapi-data.js
@@ -1,5 +1,6 @@
 export const transformProjectStrapiData = project => {
     const result = {
+        name: project.name,
         image_url: project.info.image.url,
         ...project.info,
     };


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-372/)

This change reflects Strapi model changes in [this CMS PR](https://github.com/10gen/devhub-cms/pull/9). In order to view `name` on the table view for a collection we had to move it out of a repeatable type `BasicInfo`. This change just updates queries pulling in `name` accordingly.

Project cards still show `name` where desired thanks to the mapping :)