### PR TITLE
DEVHUB-372: Move Student Name in Query

### DIFF
--- a/src/queries/fragments/project.js
+++ b/src/queries/fragments/project.js
@@ -5,8 +5,8 @@ export const featuredGalleryProject = graphql`
         FeaturedGalleryProject {
             name
             students {
+                name
                 bio {
-                    name
                     image {
                         url
                     }
@@ -37,8 +37,8 @@ export const featuredHomePageProjects = graphql`
         FeaturedHomePageProjects {
             name
             students {
+                name
                 bio {
-                    name
                     image {
                         url
                     }
@@ -68,8 +68,8 @@ export const projectFragment = graphql`
     fragment ProjectFragment on StrapiProjects {
         name
         students {
+            name
             bio {
-                name
                 image {
                     url
                 }


### PR DESCRIPTION
No staging link since this is not yet in use, a successful build means the queries are still valid

This PR moves the `name` field for querying a student from within bio to out of bio to reflect the CMS change [here](https://github.com/10gen/devhub-cms/pull/11).