### PR TITLE
DEVHUB-300 [Part 2]: Desktop Academia Entry Page with Content

### DIFF
--- a/src/components/pages/academia/index.js
+++ b/src/components/pages/academia/index.js
@@ -1,4 +1,5 @@
-import TopBanner from './top-banner';
 import ProjectGrid from './project-grid';
+import StudentsEducatorsDetails from './students-educators-details';
+import TopBanner from './top-banner';
 
-export { ProjectGrid, TopBanner };
+export { ProjectGrid, StudentsEducatorsDetails, TopBanner };

--- a/src/components/pages/academia/students-educators-details.js
+++ b/src/components/pages/academia/students-educators-details.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import GreenBulletedList from '../educators/green-bulleted-list';
+//TODO: Replace image with Visual Design asset once available
+import HeroBannerImage from '~images/1x/Academia.svg';
+import { H5 } from '~components/dev-hub/text';
+
+const BenefitCardLayout = styled('div')`
+    display: flex;
+    flex: 1;
+`;
+
+const BenefitCardsLayout = styled('div')`
+    display: flex;
+`;
+
+const BenefitTypeCard = ({ bullets, image }) => (
+    <BenefitCardLayout>
+        <img width="110px" height="92px" alt="" src={image} />
+        <div>
+            <H5>For Students</H5>
+            <GreenBulletedList children={bullets} />
+        </div>
+    </BenefitCardLayout>
+);
+
+const StudentsEducatorsDetails = () => (
+    <BenefitCardsLayout>
+        <BenefitTypeCard
+            image={HeroBannerImage}
+            bullets={[
+                'Join our GitHub Student Developer Pack offer',
+                'MongoDB Atlas: create a free Tier, or use $200 in Credits',
+                'MongoDB University On-Demand and Free Certification',
+            ]}
+        />
+        <BenefitTypeCard
+            image={HeroBannerImage}
+            bullets={[
+                'Access MongoDB course material & content support',
+                'On-demand access to MongoDB University, cohort tracking and usage analytics',
+                'Access our MongoDB for Academia community to collaborate, share tips and get inspired',
+            ]}
+        />
+    </BenefitCardsLayout>
+);
+
+export default StudentsEducatorsDetails;

--- a/src/components/pages/academia/students-educators-details.js
+++ b/src/components/pages/academia/students-educators-details.js
@@ -5,25 +5,34 @@ import GreenBulletedList from '../educators/green-bulleted-list';
 import HeroBannerImage from '~images/1x/Academia.svg';
 import Card from '~components/dev-hub/card';
 import { H5, P } from '~components/dev-hub/text';
+import { size } from '~components/dev-hub/theme';
+
+const IMAGE_HEIGHT = '98px';
+const IMAGE_WIDTH = '130px';
 
 const BenefitCardLayout = styled('div')`
-    display: flex;
+    column-gap: 20px;
+    display: grid;
+    grid-template-columns: ${IMAGE_WIDTH} auto;
+    grid-template-rows: ${IMAGE_HEIGHT} auto;
     flex: 1;
-    max-width: 588px;
-    > img {
-        margin-right: 20px;
-    }
+    height: 100%;
+`;
+
+const StyledCard = styled(Card)`
+    flex: 1;
+    max-width: none;
 `;
 
 const BenefitCardsLayout = styled('div')`
     display: flex;
-    padding: 56px 0;
+    padding: ${size.xlarge} 0;
     margin: 0 auto;
     max-width: 1200px;
     justify-content: space-between;
 `;
 
-const CTAText = styled(P)`
+const GradientText = styled(P)`
     background: ${({ theme }) => theme.gradientMap.greenTealOffset};
     background-clip: text;
     -webkit-background-clip: text;
@@ -35,22 +44,33 @@ const CTAText = styled(P)`
     }
 `;
 
-const BenefitTypeCard = ({ bullets, image, href, to, isStudents = true }) => (
-    <Card maxWidth="50%" href={href} to={to} collapseImage>
-        <BenefitCardLayout>
-            <img width="110px" height="92px" alt="" src={image} />
-            <div>
-                <H5>For {isStudents ? 'Students' : 'Educators'}</H5>
-                <GreenBulletedList children={bullets} />
-                <CTAText bold>
-                    {isStudents
-                        ? 'Get Student Benefits'
-                        : 'Start teaching MongoDB'}
-                </CTAText>
-            </div>
-        </BenefitCardLayout>
-    </Card>
-);
+const CardRightSideContent = styled('div')`
+    grid-row: span 2;
+`;
+
+const BenefitTypeCard = ({ bullets, image, href, to, isStudents = true }) => {
+    const forAudienceText = isStudents ? 'For Students' : 'For Educators';
+    const ctaText = isStudents
+        ? 'Get Student Benefits'
+        : 'Start teaching MongoDB';
+    return (
+        <StyledCard href={href} to={to} collapseImage>
+            <BenefitCardLayout>
+                <img
+                    height={IMAGE_HEIGHT}
+                    width={IMAGE_WIDTH}
+                    alt=""
+                    src={image}
+                />
+                <CardRightSideContent>
+                    <H5>{forAudienceText}</H5>
+                    <GreenBulletedList children={bullets} />
+                    <GradientText bold>{ctaText}</GradientText>
+                </CardRightSideContent>
+            </BenefitCardLayout>
+        </StyledCard>
+    );
+};
 
 const StudentsEducatorsDetails = () => (
     <BenefitCardsLayout>

--- a/src/components/pages/academia/students-educators-details.js
+++ b/src/components/pages/academia/students-educators-details.js
@@ -8,17 +8,25 @@ import { H5 } from '~components/dev-hub/text';
 const BenefitCardLayout = styled('div')`
     display: flex;
     flex: 1;
+    max-width: 588px;
+    > img {
+        margin-right: 20px;
+    }
 `;
 
 const BenefitCardsLayout = styled('div')`
     display: flex;
+    padding: 56px 0;
+    margin: 0 20px;
+    max-width: 1200px;
+    justify-content: center;
 `;
 
-const BenefitTypeCard = ({ bullets, image }) => (
+const BenefitTypeCard = ({ bullets, image, isStudents = true }) => (
     <BenefitCardLayout>
         <img width="110px" height="92px" alt="" src={image} />
         <div>
-            <H5>For Students</H5>
+            <H5>For {isStudents ? 'Students' : 'Educators'}</H5>
             <GreenBulletedList children={bullets} />
         </div>
     </BenefitCardLayout>
@@ -35,6 +43,7 @@ const StudentsEducatorsDetails = () => (
             ]}
         />
         <BenefitTypeCard
+            isStudents={false}
             image={HeroBannerImage}
             bullets={[
                 'Access MongoDB course material & content support',

--- a/src/components/pages/academia/students-educators-details.js
+++ b/src/components/pages/academia/students-educators-details.js
@@ -10,7 +10,15 @@ import { size } from '~components/dev-hub/theme';
 const IMAGE_HEIGHT = '98px';
 const IMAGE_WIDTH = '130px';
 
-const BenefitCardLayout = styled('div')`
+const BenefitsLayout = styled('div')`
+    display: grid;
+    grid-template-columns: repeat(2, 50%);
+    margin: 0 auto;
+    max-width: ${({ maxwidth }) => maxwidth};
+    padding: ${size.xlarge} 0;
+`;
+
+const SingleBenefitLayout = styled('div')`
     column-gap: ${size.medium};
     display: grid;
     grid-template-columns: ${IMAGE_WIDTH} auto;
@@ -18,17 +26,13 @@ const BenefitCardLayout = styled('div')`
     height: 100%;
 `;
 
+const CardRightSideContent = styled('div')`
+    grid-row: span 2;
+`;
+
 const NoMaxWidthCard = styled(Card)`
     /* TODO: Update Card component to take any max width setting then use as prop */
     max-width: none;
-`;
-
-const BenefitCardsLayout = styled('div')`
-    display: grid;
-    grid-template-columns: repeat(2, 50%);
-    margin: 0 auto;
-    max-width: ${({ maxwidth }) => maxwidth};
-    padding: ${size.xlarge} 0;
 `;
 
 const GradientText = styled(P)`
@@ -43,10 +47,6 @@ const GradientText = styled(P)`
     }
 `;
 
-const CardRightSideContent = styled('div')`
-    grid-row: span 2;
-`;
-
 const BenefitTypeCard = ({ bullets, image, href, to, isStudents = true }) => {
     const forAudienceText = isStudents ? 'For Students' : 'For Educators';
     const ctaText = isStudents
@@ -54,7 +54,7 @@ const BenefitTypeCard = ({ bullets, image, href, to, isStudents = true }) => {
         : 'Start teaching MongoDB';
     return (
         <NoMaxWidthCard href={href} to={to} collapseImage>
-            <BenefitCardLayout>
+            <SingleBenefitLayout>
                 <img
                     height={IMAGE_HEIGHT}
                     width={IMAGE_WIDTH}
@@ -66,13 +66,13 @@ const BenefitTypeCard = ({ bullets, image, href, to, isStudents = true }) => {
                     <GreenBulletedList children={bullets} />
                     <GradientText bold>{ctaText}</GradientText>
                 </CardRightSideContent>
-            </BenefitCardLayout>
+            </SingleBenefitLayout>
         </NoMaxWidthCard>
     );
 };
 
 const StudentsEducatorsDetails = ({ maxWidth = '1200px' }) => (
-    <BenefitCardsLayout maxwidth={maxWidth}>
+    <BenefitsLayout maxwidth={maxWidth}>
         <BenefitTypeCard
             href="https://www.mongodb.com/students"
             image={HeroBannerImage}
@@ -92,7 +92,7 @@ const StudentsEducatorsDetails = ({ maxWidth = '1200px' }) => (
                 'Access our MongoDB for Academia community to collaborate, share tips and get inspired',
             ]}
         />
-    </BenefitCardsLayout>
+    </BenefitsLayout>
 );
 
 export default StudentsEducatorsDetails;

--- a/src/components/pages/academia/students-educators-details.js
+++ b/src/components/pages/academia/students-educators-details.js
@@ -11,25 +11,24 @@ const IMAGE_HEIGHT = '98px';
 const IMAGE_WIDTH = '130px';
 
 const BenefitCardLayout = styled('div')`
-    column-gap: 20px;
+    column-gap: ${size.medium};
     display: grid;
     grid-template-columns: ${IMAGE_WIDTH} auto;
     grid-template-rows: ${IMAGE_HEIGHT} auto;
-    flex: 1;
     height: 100%;
 `;
 
-const StyledCard = styled(Card)`
-    flex: 1;
+const NoMaxWidthCard = styled(Card)`
+    /* TODO: Update Card component to take any max width setting then use as prop */
     max-width: none;
 `;
 
 const BenefitCardsLayout = styled('div')`
-    display: flex;
-    padding: ${size.xlarge} 0;
+    display: grid;
+    grid-template-columns: repeat(2, 50%);
     margin: 0 auto;
-    max-width: 1200px;
-    justify-content: space-between;
+    max-width: ${({ maxwidth }) => maxwidth};
+    padding: ${size.xlarge} 0;
 `;
 
 const GradientText = styled(P)`
@@ -54,7 +53,7 @@ const BenefitTypeCard = ({ bullets, image, href, to, isStudents = true }) => {
         ? 'Get Student Benefits'
         : 'Start teaching MongoDB';
     return (
-        <StyledCard href={href} to={to} collapseImage>
+        <NoMaxWidthCard href={href} to={to} collapseImage>
             <BenefitCardLayout>
                 <img
                     height={IMAGE_HEIGHT}
@@ -68,12 +67,12 @@ const BenefitTypeCard = ({ bullets, image, href, to, isStudents = true }) => {
                     <GradientText bold>{ctaText}</GradientText>
                 </CardRightSideContent>
             </BenefitCardLayout>
-        </StyledCard>
+        </NoMaxWidthCard>
     );
 };
 
-const StudentsEducatorsDetails = () => (
-    <BenefitCardsLayout>
+const StudentsEducatorsDetails = ({ maxWidth = '1200px' }) => (
+    <BenefitCardsLayout maxwidth={maxWidth}>
         <BenefitTypeCard
             href="https://www.mongodb.com/students"
             image={HeroBannerImage}

--- a/src/components/pages/academia/students-educators-details.js
+++ b/src/components/pages/academia/students-educators-details.js
@@ -3,7 +3,8 @@ import styled from '@emotion/styled';
 import GreenBulletedList from '../educators/green-bulleted-list';
 //TODO: Replace image with Visual Design asset once available
 import HeroBannerImage from '~images/1x/Academia.svg';
-import { H5 } from '~components/dev-hub/text';
+import Card from '~components/dev-hub/card';
+import { H5, P } from '~components/dev-hub/text';
 
 const BenefitCardLayout = styled('div')`
     display: flex;
@@ -17,24 +18,44 @@ const BenefitCardLayout = styled('div')`
 const BenefitCardsLayout = styled('div')`
     display: flex;
     padding: 56px 0;
-    margin: 0 20px;
+    margin: 0 auto;
     max-width: 1200px;
-    justify-content: center;
+    justify-content: space-between;
 `;
 
-const BenefitTypeCard = ({ bullets, image, isStudents = true }) => (
-    <BenefitCardLayout>
-        <img width="110px" height="92px" alt="" src={image} />
-        <div>
-            <H5>For {isStudents ? 'Students' : 'Educators'}</H5>
-            <GreenBulletedList children={bullets} />
-        </div>
-    </BenefitCardLayout>
+const CTAText = styled(P)`
+    background: ${({ theme }) => theme.gradientMap.greenTealOffset};
+    background-clip: text;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+
+    &:after {
+        /* 2192 is "RIGHTWARDS ARROW" */
+        content: ' \u2192';
+    }
+`;
+
+const BenefitTypeCard = ({ bullets, image, href, to, isStudents = true }) => (
+    <Card maxWidth="50%" href={href} to={to} collapseImage>
+        <BenefitCardLayout>
+            <img width="110px" height="92px" alt="" src={image} />
+            <div>
+                <H5>For {isStudents ? 'Students' : 'Educators'}</H5>
+                <GreenBulletedList children={bullets} />
+                <CTAText bold>
+                    {isStudents
+                        ? 'Get Student Benefits'
+                        : 'Start teaching MongoDB'}
+                </CTAText>
+            </div>
+        </BenefitCardLayout>
+    </Card>
 );
 
 const StudentsEducatorsDetails = () => (
     <BenefitCardsLayout>
         <BenefitTypeCard
+            href="https://www.mongodb.com/students"
             image={HeroBannerImage}
             bullets={[
                 'Join our GitHub Student Developer Pack offer',
@@ -45,6 +66,7 @@ const StudentsEducatorsDetails = () => (
         <BenefitTypeCard
             isStudents={false}
             image={HeroBannerImage}
+            to="/academia/educators/"
             bullets={[
                 'Access MongoDB course material & content support',
                 'On-demand access to MongoDB University, cohort tracking and usage analytics',

--- a/src/pages/academia/index.js
+++ b/src/pages/academia/index.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import Layout from '~components/dev-hub/layout';
-import { ProjectGrid, TopBanner } from '~components/pages/academia';
+import {
+    ProjectGrid,
+    TopBanner,
+    StudentsEducatorsDetails,
+} from '~components/pages/academia';
 import { useSiteMetadata } from '~hooks/use-site-metadata';
 import { Helmet } from 'react-helmet';
 
@@ -12,6 +16,7 @@ const AcademiaLandingPage = () => {
                 <title>MongoDB for Academia - {title}</title>
             </Helmet>
             <TopBanner />
+            <StudentsEducatorsDetails />
             <ProjectGrid />
         </Layout>
     );


### PR DESCRIPTION
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-300-body-content/academia/)

This PR adds the rest of the content to the academia entry page and finishes setting up the desktop layout (mobile design is WIP).

I opted to not put this content as Strapi fields for two main reasons:

1. Copy changes seem relatively unlikely
2. Don't want to bloat Strapi fields, that way our internal partners can better find what they actually will update frequently.

Of course should we want to migrate these fields into Strapi that would be easy given this component structure.