### PR TITLE
DEVHUB-397: Add Learn Page Anchor to All Content

### DIFF
--- a/src/components/dev-hub/tab.js
+++ b/src/components/dev-hub/tab.js
@@ -60,13 +60,13 @@ const mapTabTextToButton = (textList, activeItem, handleClick) => (
     </div>
 );
 
-const Tabs = ({ activeItem, className, handleClick, leftTabs, rightTabs }) => {
+const Tabs = ({ activeItem, handleClick, leftTabs, rightTabs, ...props }) => {
     const LeftTabs = () =>
         mapTabTextToButton(leftTabs, activeItem, handleClick);
     const RightTabs = () =>
         mapTabTextToButton(rightTabs, activeItem, handleClick);
     return (
-        <Tab data-test="tabs" className={className}>
+        <Tab data-test="tabs" {...props}>
             <LeftTabs />
             <RightTabs />
         </Tab>

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -333,6 +333,8 @@ export default ({
             </Header>
 
             <TabBar
+                // ID used specifically for anchor links
+                id="skip-featured"
                 handleClick={updateActiveFilter}
                 leftTabs={leftTabs}
                 rightTabs={rightTabs}


### PR DESCRIPTION
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-397/)

This PR adds support for anchoring to the section below featured content on the learn page by adding an html `id` attribute. We are still playing around with what best represents this section, but `skip-featured` is where we are at for now.

I also updated Nav data in Strapi so this staging link will feature a nav that will directly point to the tab above the content grid.