### PR TITLE
DEVHUB-397 [Part 2]: Swap Anchor ID to Main

### DIFF
--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -334,7 +334,7 @@ export default ({
 
             <TabBar
                 // ID used specifically for anchor links
-                id="skip-featured"
+                id="main"
                 handleClick={updateActiveFilter}
                 leftTabs={leftTabs}
                 rightTabs={rightTabs}


### PR DESCRIPTION
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-397-main/)

We decided to change the anchor llink to `#main` from `#skip-featured` as this also better represents where we are anchoring to on the Learn page. The relevant content has also been updated on Strapi.