### PR TITLE
DEVHUB-397 [Part 3]: Ensure Page Scroll if Anchor Link Exists

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,10 +1,14 @@
+import dlv from 'dlv';
 import { removeTrailingSlash } from './src/utils/remove-trailing-slash';
 
+const isNewPage = (prevLocation, newLocation) => {
+    const prevPathname = removeTrailingSlash(prevLocation.pathname);
+    const newPathname = removeTrailingSlash(newLocation.pathname);
+    return prevPathname !== newPathname;
+};
+
 export const shouldUpdateScroll = ({ prevRouterProps, routerProps }) => {
-    const prevLocation =
-        prevRouterProps &&
-        removeTrailingSlash(prevRouterProps.location.pathname);
-    const newLocation =
-        routerProps && removeTrailingSlash(routerProps.location.pathname);
-    return prevLocation !== newLocation;
+    const prevLocation = dlv(prevRouterProps, ['location'], {});
+    const newLocation = dlv(routerProps, ['location'], {});
+    return isNewPage(prevLocation, newLocation);
 };

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,14 +1,9 @@
 import dlv from 'dlv';
-import { removeTrailingSlash } from './src/utils/remove-trailing-slash';
-
-const isNewPage = (prevLocation, newLocation) => {
-    const prevPathname = removeTrailingSlash(prevLocation.pathname);
-    const newPathname = removeTrailingSlash(newLocation.pathname);
-    return prevPathname !== newPathname;
-};
+import { hasAnchorLink } from '~utils/has-anchor-link';
+import { isNewPage } from '~utils/is-new-page';
 
 export const shouldUpdateScroll = ({ prevRouterProps, routerProps }) => {
     const prevLocation = dlv(prevRouterProps, ['location'], {});
     const newLocation = dlv(routerProps, ['location'], {});
-    return isNewPage(prevLocation, newLocation);
+    return isNewPage(prevLocation, newLocation) || hasAnchorLink(newLocation);
 };

--- a/src/utils/has-anchor-link.js
+++ b/src/utils/has-anchor-link.js
@@ -1,0 +1,1 @@
+export const hasAnchorLink = newLocation => !!newLocation.hash;

--- a/src/utils/is-new-page.js
+++ b/src/utils/is-new-page.js
@@ -1,0 +1,7 @@
+import { removeTrailingSlash } from './remove-trailing-slash';
+
+export const isNewPage = (prevLocation, newLocation) => {
+    const prevPathname = removeTrailingSlash(prevLocation.pathname);
+    const newPathname = removeTrailingSlash(newLocation.pathname);
+    return prevPathname !== newPathname;
+};

--- a/tests/utils/has-anchor-link.test.js
+++ b/tests/utils/has-anchor-link.test.js
@@ -1,0 +1,11 @@
+import { hasAnchorLink } from '../../src/utils/has-anchor-link';
+
+it('should determine whether or not a location object has an anchor link', () => {
+    const hasAnchor = { hash: '#main' };
+    const doesNotHaveAnchor = { hash: '' };
+    const alsoDoesNotHaveAnchor = {};
+
+    expect(hasAnchorLink(hasAnchor)).toBeTruthy();
+    expect(hasAnchorLink(doesNotHaveAnchor)).toBeFalsy();
+    expect(hasAnchorLink(alsoDoesNotHaveAnchor)).toBeFalsy();
+});

--- a/tests/utils/is-new-page.test.js
+++ b/tests/utils/is-new-page.test.js
@@ -1,0 +1,12 @@
+import { isNewPage } from '../../src/utils/is-new-page';
+
+it('should identify when a new page is being navigated to', () => {
+    const prevLocation = { pathname: '/learn' };
+    const newLocationNotMatching = { pathname: '/community' };
+    const newLocationMatching = prevLocation;
+    const newLocationMatchWithSlash = { pathname: '/learn/' };
+
+    expect(isNewPage(prevLocation, newLocationNotMatching)).toBeTruthy();
+    expect(isNewPage(prevLocation, newLocationMatching)).toBeFalsy();
+    expect(isNewPage(prevLocation, newLocationMatchWithSlash)).toBeFalsy();
+});


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-397-scroll-learn/)

This PR fixes a potentially poor UX issue with the incoming nav. If a reader is on the learn page and uses the nav to again navigate to the learn page, nothing would happen. This is because of how loose we are being in `gatsby-browser` in not updating scroll position if a pathname has not changed.

Now, we also check to see if where we are navigating to has an anchor tag and we respect it. I also added testing for this behavior. Here are some places this could impact (and seems to continue to behave consistently):
- On the learn page using the new nav
- On the learn page changing the tab active (New position removes the anchor tag already)
- On the learn page or tag pages when loading more (Again removes the anchor tag already)
- On an article page when using TOC (Again removes the anchor tag already)