### PR TITLE
DEVHUB-389 [Part 1]: Initial Mobile Nav Layout

### DIFF
--- a/src/components/dev-hub/global-nav.js
+++ b/src/components/dev-hub/global-nav.js
@@ -5,11 +5,12 @@ import { graphql, useStaticQuery } from 'gatsby';
 import DevLeafDesktop from './icons/mdb-dev-leaf-desktop';
 import DevLeafMobile from './icons/mdb-dev-leaf-mobile';
 import Link from '../Link';
-import { fontSize, lineHeight, screenSize, size } from './theme';
+import { fontSize, layer, lineHeight, screenSize, size } from './theme';
 import useMedia from '~hooks/use-media';
 import NavItem, { MobileNavItem } from './nav-item';
 import MenuToggle from './menu-toggle';
 
+const GREEN_BORDER_SIZE = '2px';
 const MOBILE_NAV_BREAK = screenSize.upToLarge;
 // nav height is 58px: 24px line height + 2 * 17px vertical padding
 const LINK_VERTICAL_PADDING = '17px';
@@ -22,9 +23,18 @@ const GlobalNav = styled('nav')`
     &:after {
         background: radial-gradient(circle, #3ebb8c 0%, #76d3b1 100%);
         content: ' ';
-        height: 2px;
+        height: ${GREEN_BORDER_SIZE};
         width: 100%;
     }
+`;
+
+const MobileNavMenu = styled('div')`
+    background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
+    position: absolute;
+    /* Add 2px for green border to show */
+    top: calc(100% + ${GREEN_BORDER_SIZE});
+    width: 100%;
+    z-index: ${layer.front};
 `;
 
 const NavContent = styled('div')`
@@ -38,7 +48,7 @@ const NavContent = styled('div')`
     width: 100%;
     @media ${MOBILE_NAV_BREAK} {
         justify-content: space-between;
-        padding-right: 20px;
+        padding-right: ${size.medium};
     }
 `;
 
@@ -82,16 +92,6 @@ const topNavItems = graphql`
             }
         }
     }
-`;
-
-const MobileNavMenu = styled('div')`
-    position: absolute;
-    /* Add 2px for green border to show */
-    top: calc(100% + 2px);
-    width: 100%;
-    background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
-    z-index: 10;
-    min-height: 100vh;
 `;
 
 const MobileItems = ({ items }) => {

--- a/src/components/dev-hub/menu-toggle.js
+++ b/src/components/dev-hub/menu-toggle.js
@@ -61,6 +61,8 @@ const AnimatedHamburger = props => (
     </HamburgerToggle>
 );
 
-export const MenuToggle = ({ isOpen, toggleIsOpen }) => (
+const MenuToggle = ({ isOpen, toggleIsOpen }) => (
     <AnimatedHamburger isOpen={isOpen} onClick={toggleIsOpen} />
 );
+
+export default MenuToggle;

--- a/src/components/dev-hub/menu-toggle.js
+++ b/src/components/dev-hub/menu-toggle.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+
+const expanded = css`
+    span:nth-of-type(1) {
+        left: 50%;
+        top: 6px;
+        width: 0%;
+    }
+    span:nth-of-type(2) {
+        transform: rotate(45deg);
+    }
+    span:nth-of-type(3) {
+        transform: rotate(-45deg);
+    }
+    span:nth-of-type(4) {
+        left: 50%;
+        top: 6px;
+        width: 0%;
+    }
+`;
+
+/** Used the third example from https://codepen.io/designcouch/pen/Atyop */
+const HamburgerToggle = styled('div')`
+    cursor: pointer;
+    height: 10px;
+    transform: rotate(0deg);
+    transition: 300ms ease-in-out;
+    width: 20px;
+    ${({ isOpen }) => isOpen && expanded};
+    span {
+        background: ${({ theme }) => theme.colorMap.devWhite};
+        display: block;
+        height: 2px;
+        left: 0;
+        opacity: 1;
+        position: absolute;
+        transform: rotate(0deg);
+        transition: 150ms ease-in-out;
+        width: 100%;
+        :nth-of-type(1) {
+            top: 0px;
+        }
+        :nth-of-type(2),
+        :nth-of-type(3) {
+            top: 5px;
+        }
+        :nth-of-type(4) {
+            top: 10px;
+        }
+    }
+`;
+
+const AnimatedHamburger = props => (
+    <HamburgerToggle {...props}>
+        <span />
+        <span />
+        <span />
+        <span />
+    </HamburgerToggle>
+);
+
+export const MenuToggle = ({ isOpen, toggleIsOpen }) => (
+    <AnimatedHamburger isOpen={isOpen} onClick={toggleIsOpen} />
+);

--- a/src/components/dev-hub/nav-item.js
+++ b/src/components/dev-hub/nav-item.js
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import Link from '../Link';
+import ArrowheadIcon from './icons/arrowhead-icon';
 import { P, P3 } from './text';
 import { fontSize, layer, lineHeight, screenSize, size } from './theme';
 
@@ -87,6 +88,7 @@ const NavItemSublist = styled('ul')`
 
 const NavItemMenu = styled('div')`
     cursor: pointer;
+    position: relative;
     &:active,
     &:hover,
     &:focus,
@@ -128,6 +130,40 @@ const SubItemLink = styled(Link)`
 const SubItemText = styled(P)`
     margin-bottom: 4px;
 `;
+
+export const MobileNavItem = ({ item }) => {
+    const [isExpanded, setIsExpanded] = useState(false);
+    const toggleMenu = useCallback(() => setIsExpanded(!isExpanded), [
+        isExpanded,
+    ]);
+    const hasSubMenu = !!item.subitems.length;
+    if (hasSubMenu) {
+        return (
+            <NavItemMenu
+                onClick={toggleMenu}
+                isExpanded={isExpanded}
+                tabIndex="0"
+            >
+                <NavListHeader isExpanded={isExpanded}>
+                    {item.name}
+                    <ArrowheadIcon down={!isExpanded} />
+                </NavListHeader>
+                <NavItemSublist isExpanded={isExpanded}>
+                    {item.subitems.map(subitem => (
+                        <NavListSubItem key={subitem.name}>
+                            <NavItemSubItem tabIndex="0" subitem={subitem} />
+                        </NavListSubItem>
+                    ))}
+                </NavItemSublist>
+            </NavItemMenu>
+        );
+    }
+    return (
+        <NavListHeader>
+            <NavLink to={item.url}>{item.name}</NavLink>
+        </NavListHeader>
+    );
+};
 
 const NavItemSubItem = ({ subitem }) => (
     <SubItemLink to={subitem.url}>

--- a/src/components/dev-hub/nav-item.js
+++ b/src/components/dev-hub/nav-item.js
@@ -88,7 +88,6 @@ const NavItemSublist = styled('ul')`
 
 const NavItemMenu = styled('div')`
     cursor: pointer;
-    position: relative;
     &:active,
     &:hover,
     &:focus,


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-389-initial-layout/)

This PR just marks a point to check-in the initial layout and behavior of a mobile-friendly version of the new nav, it is by no means ready for production.

This PR adds the following:
- A toggle-able hamburger menu icon lifted from University which open/closes the menu when on mobile
- An absolutely-positioned list of mobile menu options

Next steps:
- Fix padding/spacing on nav items
- Make nav items full width
- Capture focus or make height 100% when menu is open