### PR TITLE
DEVHUB-389 [Part 3]: Full-height Mobile Nav Experience

### DIFF
--- a/src/components/dev-hub/global-nav.js
+++ b/src/components/dev-hub/global-nav.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import dlv from 'dlv';
 import styled from '@emotion/styled';
 import { graphql, useStaticQuery } from 'gatsby';
@@ -11,6 +11,8 @@ import NavItem, { MobileNavItem } from './nav-item';
 import MenuToggle from './menu-toggle';
 
 const GREEN_BORDER_SIZE = '2px';
+// Account for bottom bar on mobile browsers
+const MOBILE_MENU_ADDITIONAL_PADDING = '256px';
 const MOBILE_NAV_BREAK = screenSize.upToLarge;
 // nav height is 58px: 24px line height + 2 * 17px vertical padding
 const LINK_VERTICAL_PADDING = '17px';
@@ -35,6 +37,12 @@ const MobileNavMenu = styled('div')`
     top: calc(100% + ${GREEN_BORDER_SIZE});
     width: 100%;
     z-index: ${layer.front};
+    @media ${MOBILE_NAV_BREAK} {
+        /* 100% would not work since the nav itself does not have 100% height */
+        height: 100vh;
+        padding-bottom: ${MOBILE_MENU_ADDITIONAL_PADDING};
+        overflow: scroll;
+    }
 `;
 
 const NavContent = styled('div')`
@@ -97,6 +105,17 @@ const topNavItems = graphql`
 const MobileItems = ({ items }) => {
     const [isOpen, setIsOpen] = useState(false);
     const toggleIsOpen = useCallback(() => setIsOpen(!isOpen), [isOpen]);
+    useEffect(() => {
+        // This effect prevents scrolling outside the opened nav
+        // We restore normal scrolling when the nav is closed
+        if (document) {
+            if (isOpen) {
+                document.body.style.overflow = 'hidden';
+            } else {
+                document.body.style.overflow = 'auto';
+            }
+        }
+    }, [isOpen]);
     return (
         <>
             <MenuToggle isOpen={isOpen} toggleIsOpen={toggleIsOpen} />

--- a/src/components/dev-hub/nav-item.js
+++ b/src/components/dev-hub/nav-item.js
@@ -129,6 +129,10 @@ const SubItemContents = styled('div')`
 
 const SubItemDescriptionText = styled(P3)`
     color: ${({ theme }) => theme.colorMap.greyLightTwo};
+    @media ${MOBILE_NAV_BREAK} {
+        font-size: ${fontSize.tiny};
+        line-height: ${lineHeight.tiny};
+    }
 `;
 
 const SubItemLink = styled(Link)`

--- a/src/components/dev-hub/nav-item.js
+++ b/src/components/dev-hub/nav-item.js
@@ -231,7 +231,11 @@ const NavItem = ({ item }) => {
             </NavItemMenu>
         );
     }
-    return <NavLink to={item.url}>{item.name}</NavLink>;
+    return (
+        <NavListHeader>
+            <NavLink to={item.url}>{item.name}</NavLink>
+        </NavListHeader>
+    );
 };
 
 export default NavItem;


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-389-full/)

This PR updates the mobile nav behavior when expanded to do the following:
- Expand at least the full height remaining (below the initial nav bar)
- Disable parent scrolling while the nav is open
- Allow the user to scroll if needed
- Restore normal scrolling when closed

I also fixed a desktop bug opened by moving spacing logic out of some shared CSS