### PR TITLE
DEVHUB-430 [Desktop]: Add slight SVG-related offset for desktop graphic

### DIFF
--- a/src/components/dev-hub/global-nav.js
+++ b/src/components/dev-hub/global-nav.js
@@ -73,6 +73,7 @@ const NavLink = styled(Link)`
         background-color: #2c3d47;
     }
 `;
+
 const HomeLink = styled(NavLink)`
     align-items: center;
     display: flex;
@@ -82,7 +83,10 @@ const HomeLink = styled(NavLink)`
     &[aria-current='page'] {
         background-color: unset;
     }
-    @media ${screenSize.upToMedium} {
+    svg {
+        margin-top: -1px;
+    }
+    @media ${MOBILE_NAV_BREAK} {
         padding: ${size.default};
         svg {
             /* align svg with other nav links */


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-430-desktop/)

This PR adds a slight offset to the desktop home logo SVG to align it with other text.

Before:
![Screen Shot 2021-01-20 at 4 01 51 PM](https://user-images.githubusercontent.com/9064401/105237145-45127380-5b3a-11eb-95df-b63ef92e3a36.png)

After:
![Screen Shot 2021-01-20 at 4 01 27 PM](https://user-images.githubusercontent.com/9064401/105237081-3f1c9280-5b3a-11eb-9fab-aa18f39f5e2f.png)
