### PR TITLE
DEVHUB-389 [Part 4]: Correctly close menu on internal link

### DIFF
--- a/src/components/dev-hub/global-nav.js
+++ b/src/components/dev-hub/global-nav.js
@@ -108,6 +108,7 @@ const topNavItems = graphql`
 
 const MobileItems = ({ items }) => {
     const [isOpen, setIsOpen] = useState(false);
+    const closeMenu = useCallback(() => setIsOpen(false), []);
     const toggleIsOpen = useCallback(() => setIsOpen(!isOpen), [isOpen]);
     useEffect(() => {
         // This effect prevents scrolling outside the opened nav
@@ -126,7 +127,11 @@ const MobileItems = ({ items }) => {
             {isOpen && (
                 <MobileNavMenu>
                     {items.map(item => (
-                        <MobileNavItem key={item.name} item={item} />
+                        <MobileNavItem
+                            onLinkClick={closeMenu}
+                            key={item.name}
+                            item={item}
+                        />
                     ))}
                 </MobileNavMenu>
             )}

--- a/src/components/dev-hub/nav-item.js
+++ b/src/components/dev-hub/nav-item.js
@@ -149,7 +149,7 @@ const SubItemText = styled(P)`
     margin-bottom: 4px;
 `;
 
-export const MobileNavItem = ({ item }) => {
+export const MobileNavItem = ({ item, onLinkClick }) => {
     const [isExpanded, setIsExpanded] = useState(false);
     const toggleMenu = useCallback(() => setIsExpanded(!isExpanded), [
         isExpanded,
@@ -169,7 +169,11 @@ export const MobileNavItem = ({ item }) => {
                 <NavItemSublist isExpanded={isExpanded}>
                     {item.subitems.map(subitem => (
                         <NavListSubItem key={subitem.name}>
-                            <NavItemSubItem tabIndex="0" subitem={subitem} />
+                            <NavItemSubItem
+                                onLinkClick={onLinkClick}
+                                tabIndex="0"
+                                subitem={subitem}
+                            />
                         </NavListSubItem>
                     ))}
                 </NavItemSublist>
@@ -183,8 +187,8 @@ export const MobileNavItem = ({ item }) => {
     );
 };
 
-const NavItemSubItem = ({ subitem }) => (
-    <SubItemLink to={subitem.url}>
+const NavItemSubItem = ({ subitem, onLinkClick }) => (
+    <SubItemLink onClick={onLinkClick} to={subitem.url}>
         <SubItemContents>
             <SubItemText>{subitem.name}</SubItemText>
             <SubItemDescriptionText collapse>


### PR DESCRIPTION
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/fix-nav-scroll-lock/)

This PR fixes a bug in the overflow scroll logic introduced in #608. The issue was that on an internal navigation, the state of the menu was not properly updating to close the menu and run the needed `useEffect` to restore scrolling behavior. The fix is to add a small piece of code which will run prior to an internal navigation which will update state to close the menu, giving the desired behavior.

I went for this route instead of a context because that way we can re-use our components more effectively.

A/C:
- Scrolling after linking via the nav (in any environment) should work