### PR TITLE
Increase Direct Link Target Area

### DIFF
--- a/src/components/dev-hub/nav-item.js
+++ b/src/components/dev-hub/nav-item.js
@@ -63,10 +63,6 @@ const navTopItemStyling = css`
     ${linkTextStyles};
 `;
 
-const NavLink = styled(Link)`
-    ${navTopItemStyling};
-`;
-
 const NavListHeader = styled('div')`
     ${navTopItemStyling};
     display: flex;
@@ -80,6 +76,8 @@ const NavListHeader = styled('div')`
         box-shadow: 0px 1px 0px ${({ theme }) => theme.colorMap.greyDarkTwo};
     }
 `;
+
+const NavLink = NavListHeader.withComponent(Link);
 
 /**
  * Expandable sub-list containers
@@ -180,11 +178,7 @@ export const MobileNavItem = ({ item, onLinkClick }) => {
             </NavItemMenu>
         );
     }
-    return (
-        <NavListHeader>
-            <NavLink to={item.url}>{item.name}</NavLink>
-        </NavListHeader>
-    );
+    return <NavLink to={item.url}>{item.name}</NavLink>;
 };
 
 const NavItemSubItem = ({ subitem, onLinkClick }) => (
@@ -239,11 +233,7 @@ const NavItem = ({ item }) => {
             </NavItemMenu>
         );
     }
-    return (
-        <NavListHeader>
-            <NavLink to={item.url}>{item.name}</NavLink>
-        </NavListHeader>
-    );
+    return <NavLink to={item.url}>{item.name}</NavLink>;
 };
 
 export default NavItem;


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/link-full-width/)

This PR fixes a UX issue with the forthcoming nav where "Direct links" (or links that went to external sites) at the top level had a smaller target area than dropdowns. This was because we didn't give the `Link` the full size available.

The solution was to clean up the tree a bit so these links just used the same exact styling as other headers, but instead used the `Link` component as opposed to a `div`.