### PR TITLE
Use transform instead of negative margin for logo

### DIFF
--- a/src/components/dev-hub/global-nav.js
+++ b/src/components/dev-hub/global-nav.js
@@ -82,8 +82,10 @@ const HomeLink = styled(NavLink)`
     &[aria-current='page'] {
         background-color: unset;
     }
+    /* The SVG is slightly un-centered. This will move up 2px without impacting
+    overall size */
     svg {
-        margin-top: -2px;
+        transform: translate(0, -1px);
     }
     @media ${screenSize.upToXlarge} {
         padding: ${LINK_VERTICAL_PADDING} ${size.medium};


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/fix-logo-padding/)

This PR fixes a bug where using negative margin consequentially changed the nav height on desktop. Using `transform` removes this issue.