### PR TITLE
Add right arrow option to ArrowheadIcon

### DIFF
--- a/src/components/dev-hub/icons/arrowhead-icon.js
+++ b/src/components/dev-hub/icons/arrowhead-icon.js
@@ -1,24 +1,19 @@
 import React from 'react';
 import { useTheme } from 'emotion-theming';
 
-const ArrowheadIcon = ({ color, down = false }) => {
+const DIRECTION_TO_SVG_PATH = {
+    down: 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z',
+    right: 'M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z',
+    up: 'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z',
+};
+
+const ArrowheadIcon = ({ color, direction = 'up' }) => {
     const theme = useTheme();
     const iconColor = color ? color : theme.colorMap.greyLightTwo;
-    return down ? (
+    return (
         <svg height="24" viewBox="0 0 24 24" width="24">
-            <path
-                d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
-                fill={iconColor}
-            />
+            <path d={DIRECTION_TO_SVG_PATH[direction]} fill={iconColor} />
             <path d="M0 0h24v24H0V0z" fill="none" />
-        </svg>
-    ) : (
-        <svg height="24" viewBox="0 0 24 24" width="24">
-            <path
-                d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"
-                fill={iconColor}
-            />
-            <path d="M0 0h24v24H0z" fill="none" />
         </svg>
     );
 };

--- a/src/components/dev-hub/nav-item.js
+++ b/src/components/dev-hub/nav-item.js
@@ -170,7 +170,7 @@ export const MobileNavItem = ({ item, onLinkClick }) => {
             >
                 <NavListHeader isExpanded={isExpanded}>
                     {item.name}
-                    <ArrowheadIcon down={!isExpanded} />
+                    <ArrowheadIcon direction={isExpanded ? 'up' : 'down'} />
                 </NavListHeader>
                 <NavItemSublist isExpanded={isExpanded}>
                     {item.subitems.map(subitem => (

--- a/src/components/dev-hub/select.js
+++ b/src/components/dev-hub/select.js
@@ -198,7 +198,7 @@ const FormSelect = ({
                 {...extraProps}
             >
                 <P collapse>{selectText}</P>
-                <ArrowheadIcon down={!showOptions} />
+                <ArrowheadIcon direction={showOptions ? 'down' : 'up'} />
             </SelectedOption>
             {showOptions && (
                 <Options narrow={narrow}>


### PR DESCRIPTION
[Staging (Not in use yet)](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/chevron-directions/)

This PR adds a new `right` arrow option for the `ArrowheadIcon` component. We also swap the direction indicator from being a binary to being more scalable.

I also noticed the up/down rendered JSX was essentially identical aside from one path `d` value, so I combined these for clarity.