### PR TITLE
DEVHUB-307: Add Explore More Projects (Desktop)

### DIFF
--- a/src/components/pages/project/additional-projects.js
+++ b/src/components/pages/project/additional-projects.js
@@ -1,5 +1,48 @@
-import React from 'react';
+import React, { useMemo } from 'react';
+import dlv from 'dlv';
+import { useStaticQuery, graphql } from 'gatsby';
+import Grid from '~components/dev-hub/grid';
+import ProjectCard from '~components/dev-hub/project-card';
+import { transformProjectStrapiData } from '~utils/transform-project-strapi-data';
 
-const AdditionalProjects = () => <div></div>;
+const allProjects = graphql`
+    query AllProjects {
+        allStrapiProjects {
+            nodes {
+                ...ProjectFragment
+            }
+        }
+    }
+`;
+const GRID_ROW_HEIGHT = '282px';
+const AdditionalProjects = ({ excludedProjectName, ...props }) => {
+    const data = useStaticQuery(allProjects);
+    const projects = dlv(data, ['allStrapiProjects', 'nodes'], []);
+    const mappedProjects = useMemo(
+        () =>
+            projects
+                .filter(p => p.name !== excludedProjectName)
+                .slice(0, 4)
+                .map(transformProjectStrapiData),
+        [projects, excludedProjectName]
+    );
+    const gridLayout = useMemo(() => ({ rowSpan: [1], colSpan: [1] }), []);
+    const gridProps = {
+        gridGap: '48px',
+        rowHeight: GRID_ROW_HEIGHT,
+        numCols: 4,
+        layout: gridLayout,
+    };
+    return (
+        <div {...props}>
+            <p collapse>All Projects</p>
+            <Grid {...gridProps}>
+                {mappedProjects.map(project => (
+                    <ProjectCard key={project.name} project={project} />
+                ))}
+            </Grid>
+        </div>
+    );
+};
 
 export default AdditionalProjects;

--- a/src/components/pages/project/additional-projects.js
+++ b/src/components/pages/project/additional-projects.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const AdditionalProjects = () => <div></div>;
+
+export default AdditionalProjects;

--- a/src/components/pages/project/additional-projects.js
+++ b/src/components/pages/project/additional-projects.js
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import dlv from 'dlv';
 import { useStaticQuery, graphql } from 'gatsby';
@@ -9,68 +10,86 @@ import { grid, size } from '~components/dev-hub/theme';
 import { transformProjectStrapiData } from '~utils/transform-project-strapi-data';
 import Button from '~components/dev-hub/button';
 
+const GRID_COL_GAP = '24px';
+const GRID_LAYOUT = { rowSpan: [1], colSpan: [1] };
+const GRID_ROW_HEIGHT = '282px';
+const NUM_ADDITIONAL_PROJECTS = 4;
+
+// Limit is NUM_ADDITIONAL_PROJECTS + 1, but no interpolation in gql queries
 const allProjects = graphql`
     query AllProjects {
-        allStrapiProjects {
+        allStrapiProjects(limit: 5) {
             nodes {
                 ...ProjectFragment
             }
         }
     }
 `;
-const TitleWithBottomPadding = styled(H4)`
-    padding-bottom: ${size.large};
+const fullLength = css`
+    grid-column: span 12;
 `;
-const GRID_ROW_HEIGHT = '282px';
+
 const AdditionalProjectsContainer = styled('div')`
     background-color: ${({ theme }) => theme.colorMap.devBlack};
     padding-top: 42px;
 `;
-const GridContainer = styled('div')`
-    ${grid};
-    > * {
-        grid-column: span 12;
-    }
+
+const ButtonWithMargin = styled(Button)`
+    margin: 48px 0px;
 `;
+
 const Centered = styled('div')`
     display: flex;
     justify-content: center;
-    padding: 48px 0px;
 `;
+
+const FullLengthGrid = styled(Grid)`
+    ${fullLength};
+`;
+
+const GridContainer = styled('div')`
+    ${grid};
+`;
+
+const TitleWithBottomPadding = styled(H4)`
+    padding-bottom: ${size.large};
+    ${fullLength};
+`;
+
 const AdditionalProjects = ({ excludedProjectName, ...props }) => {
     const data = useStaticQuery(allProjects);
     const projects = dlv(data, ['allStrapiProjects', 'nodes'], []);
     const mappedProjects = useMemo(
         () =>
             projects
+                // Don't include the current project in the related ones
                 .filter(p => p.name !== excludedProjectName)
-                .slice(0, 4)
+                // Be sure to only have 4 projects total
+                .slice(0, NUM_ADDITIONAL_PROJECTS)
                 .map(transformProjectStrapiData),
         [projects, excludedProjectName]
     );
-    const gridLayout = useMemo(() => ({ rowSpan: [1], colSpan: [1] }), []);
-    const gridProps = {
-        gridGap: '48px',
-        rowHeight: GRID_ROW_HEIGHT,
-        numCols: 4,
-        layout: gridLayout,
-    };
     return (
         <AdditionalProjectsContainer {...props}>
             <GridContainer>
                 <TitleWithBottomPadding collapse>
                     Explore more Student Spotlights
                 </TitleWithBottomPadding>
-                <Grid {...gridProps}>
+                <FullLengthGrid
+                    gridGap={GRID_COL_GAP}
+                    layout={GRID_LAYOUT}
+                    numCols={NUM_ADDITIONAL_PROJECTS}
+                    rowHeight={GRID_ROW_HEIGHT}
+                >
                     {mappedProjects.map(project => (
                         <ProjectCard key={project.name} project={project} />
                     ))}
-                </Grid>
+                </FullLengthGrid>
             </GridContainer>
             <Centered>
-                <Button secondary to="/academia/students">
+                <ButtonWithMargin secondary to="/academia/students">
                     See All
-                </Button>
+                </ButtonWithMargin>
             </Centered>
         </AdditionalProjectsContainer>
     );

--- a/src/components/pages/project/additional-projects.js
+++ b/src/components/pages/project/additional-projects.js
@@ -1,9 +1,13 @@
 import React, { useMemo } from 'react';
+import styled from '@emotion/styled';
 import dlv from 'dlv';
 import { useStaticQuery, graphql } from 'gatsby';
 import Grid from '~components/dev-hub/grid';
 import ProjectCard from '~components/dev-hub/project-card';
+import { H4 } from '~components/dev-hub/text';
+import { grid, size } from '~components/dev-hub/theme';
 import { transformProjectStrapiData } from '~utils/transform-project-strapi-data';
+import Button from '~components/dev-hub/button';
 
 const allProjects = graphql`
     query AllProjects {
@@ -14,7 +18,25 @@ const allProjects = graphql`
         }
     }
 `;
+const TitleWithBottomPadding = styled(H4)`
+    padding-bottom: ${size.large};
+`;
 const GRID_ROW_HEIGHT = '282px';
+const AdditionalProjectsContainer = styled('div')`
+    background-color: ${({ theme }) => theme.colorMap.devBlack};
+    padding-top: 42px;
+`;
+const GridContainer = styled('div')`
+    ${grid};
+    > * {
+        grid-column: span 12;
+    }
+`;
+const Centered = styled('div')`
+    display: flex;
+    justify-content: center;
+    padding: 48px 0px;
+`;
 const AdditionalProjects = ({ excludedProjectName, ...props }) => {
     const data = useStaticQuery(allProjects);
     const projects = dlv(data, ['allStrapiProjects', 'nodes'], []);
@@ -34,14 +56,23 @@ const AdditionalProjects = ({ excludedProjectName, ...props }) => {
         layout: gridLayout,
     };
     return (
-        <div {...props}>
-            <p collapse>All Projects</p>
-            <Grid {...gridProps}>
-                {mappedProjects.map(project => (
-                    <ProjectCard key={project.name} project={project} />
-                ))}
-            </Grid>
-        </div>
+        <AdditionalProjectsContainer {...props}>
+            <GridContainer>
+                <TitleWithBottomPadding collapse>
+                    Explore more Student Spotlights
+                </TitleWithBottomPadding>
+                <Grid {...gridProps}>
+                    {mappedProjects.map(project => (
+                        <ProjectCard key={project.name} project={project} />
+                    ))}
+                </Grid>
+            </GridContainer>
+            <Centered>
+                <Button secondary to="/academia/students">
+                    See All
+                </Button>
+            </Centered>
+        </AdditionalProjectsContainer>
     );
 };
 

--- a/src/components/pages/project/additional-projects.js
+++ b/src/components/pages/project/additional-projects.js
@@ -56,7 +56,7 @@ const TitleWithBottomPadding = styled(H4)`
     ${fullLength};
 `;
 
-const AdditionalProjects = ({ excludedProjectName, ...props }) => {
+const AdditionalProjects = ({ excludedProjectName }) => {
     const data = useStaticQuery(allProjects);
     const projects = dlv(data, ['allStrapiProjects', 'nodes'], []);
     const mappedProjects = useMemo(
@@ -70,7 +70,7 @@ const AdditionalProjects = ({ excludedProjectName, ...props }) => {
         [projects, excludedProjectName]
     );
     return (
-        <AdditionalProjectsContainer {...props}>
+        <AdditionalProjectsContainer>
             <GridContainer>
                 <TitleWithBottomPadding collapse>
                     Explore more Student Spotlights

--- a/src/components/pages/project/index.js
+++ b/src/components/pages/project/index.js
@@ -1,3 +1,4 @@
+import AdditionalProjects from './additional-projects';
 import Students from './students';
 
-export { Students };
+export { AdditionalProjects, Students };

--- a/src/templates/project.js
+++ b/src/templates/project.js
@@ -2,7 +2,7 @@ import React from 'react';
 import dlv from 'dlv';
 import styled from '@emotion/styled';
 import DocumentBody from '~components/DocumentBody';
-import { Students } from '~components/pages/project';
+import { AdditionalProjects, Students } from '~components/pages/project';
 import ArticleShareFooter from '~components/dev-hub/article-share-footer';
 import Layout from '~components/dev-hub/layout';
 import { grid, screenSize, size } from '~components/dev-hub/theme';
@@ -79,7 +79,7 @@ const Project = props => {
                     <Students students={students} />
                 </InfoSidebar>
             </Container>
-
+            <AdditionalProjects />
             <TopPaddedShareProjectCTA />
             <GithubStudentPack />
         </Layout>

--- a/src/templates/project.js
+++ b/src/templates/project.js
@@ -79,10 +79,7 @@ const Project = props => {
                     <Students students={students} />
                 </InfoSidebar>
             </Container>
-            <AdditionalProjects
-                excludedProjectName={name}
-                style={{ gridColumn: 'span 12' }}
-            />
+            <AdditionalProjects excludedProjectName={name} />
             <TopPaddedShareProjectCTA />
             <GithubStudentPack />
         </Layout>

--- a/src/templates/project.js
+++ b/src/templates/project.js
@@ -78,11 +78,11 @@ const Project = props => {
                 <InfoSidebar>
                     <Students students={students} />
                 </InfoSidebar>
-                <AdditionalProjects
-                    excludedProjectName={name}
-                    style={{ gridColumn: 'span 12' }}
-                />
             </Container>
+            <AdditionalProjects
+                excludedProjectName={name}
+                style={{ gridColumn: 'span 12' }}
+            />
             <TopPaddedShareProjectCTA />
             <GithubStudentPack />
         </Layout>

--- a/src/templates/project.js
+++ b/src/templates/project.js
@@ -78,8 +78,11 @@ const Project = props => {
                 <InfoSidebar>
                     <Students students={students} />
                 </InfoSidebar>
+                <AdditionalProjects
+                    excludedProjectName={name}
+                    style={{ gridColumn: 'span 12' }}
+                />
             </Container>
-            <AdditionalProjects />
             <TopPaddedShareProjectCTA />
             <GithubStudentPack />
         </Layout>


### PR DESCRIPTION
[Staging (single project)](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-307/project/go-fifa)

This PR adds the "explore more student spotlights" section to the project pages. The algorithm for determining which to feature is naive and is as follows:
- Pull all projects (limit to 5)
- Filter out any with the same name
- Limit to 4 and map to the correct interface

Ideally, we would randomize these to get more exposure to all projects, but would like to confirm with product how this should behave exactly. The algorithm can be updated separately of the design.