### PR TITLE
Add page titles, basic SEO to gallery and projects

### DIFF
--- a/src/pages/academia/students/index.js
+++ b/src/pages/academia/students/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Helmet } from 'react-helmet';
 import styled from '@emotion/styled';
 import Layout from '~components/dev-hub/layout';
 import {
@@ -9,6 +10,7 @@ import FeaturedProject from '~components/pages/students/featured-project';
 import AllProjects from '~components/pages/students/all-projects';
 import GalleryHeroBanner from '~components/pages/students/gallery-hero-banner';
 import { screenSize, size } from '~components/dev-hub/theme';
+import { useSiteMetadata } from '~hooks/use-site-metadata';
 
 const ContentContainer = styled('div')`
     padding-left: ${size.xxlarge};
@@ -25,16 +27,22 @@ const TopPaddedShareProjectCTA = styled(ShareProjectCTA)`
     padding-bottom: 88px;
 `;
 
-const Students = () => (
-    <Layout>
-        <GalleryHeroBanner />
-        <ContentContainer>
-            <FeaturedProject />
-            <AllProjects />
-            <TopPaddedShareProjectCTA />
-        </ContentContainer>
-        <GithubStudentPack />
-    </Layout>
-);
+const Students = () => {
+    const metadata = useSiteMetadata();
+    return (
+        <Layout>
+            <Helmet>
+                <title>Student Spotlights - {metadata.title}</title>
+            </Helmet>
+            <GalleryHeroBanner />
+            <ContentContainer>
+                <FeaturedProject />
+                <AllProjects />
+                <TopPaddedShareProjectCTA />
+            </ContentContainer>
+            <GithubStudentPack />
+        </Layout>
+    );
+};
 
 export default Students;

--- a/src/templates/project.js
+++ b/src/templates/project.js
@@ -8,6 +8,7 @@ import Layout from '~components/dev-hub/layout';
 import { grid, screenSize, size } from '~components/dev-hub/theme';
 import { useSiteMetadata } from '~hooks/use-site-metadata';
 import ProjectTitleArea from '~components/dev-hub/project-title-area';
+import SEO from '~components/dev-hub/SEO';
 import {
     GithubStudentPack,
     ShareProjectCTA,
@@ -67,6 +68,7 @@ const Project = props => {
     const articleUrl = `${siteUrl}${props.pageContext.slug}`;
     return (
         <Layout>
+            <SEO articleTitle={name} />
             <ProjectTitleArea
                 images={[{ src: image.url, caption: name }]}
                 title={name}


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/titles/)

This PR adds page `title` tags, as well as some of the basic SEO skeleton for the project template pages. I imagine we will fill these in more later, but missing page `title`s was a glaring need.