### PR TITLE
DEVHUB-442: [Part 1] - Render Unordered Lists, Links, Images from Strapi

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -96,6 +96,7 @@ export default class ComponentFactory extends Component {
             include: Include,
             line: Line,
             line_block: LineBlock,
+            link: Reference,
             list: List,
             listItem: ListItem,
             'list-table': ListTable,

--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -166,7 +166,6 @@ export default class ComponentFactory extends Component {
             console.warn(`${name} (${type}) not yet implemented)`);
             return null;
         }
-
         return <ComponentType {...this.props} />;
     }
 

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -68,7 +68,9 @@ export default class Image extends Component {
     render() {
         const { alt, className, captioned, nodeData = {}, src } = this.props;
         const imgSrc =
-            src || getNestedValue(['argument', 0, 'value'], nodeData);
+            src ||
+            nodeData.url ||
+            getNestedValue(['argument', 0, 'value'], nodeData);
         const altText =
             alt || getNestedValue(['options', 'alt'], nodeData) || imgSrc;
         const customAlign = getNestedValue(['options', 'align'], nodeData);

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -30,8 +30,15 @@ const UnorderedList = styled('ul')`
     }
 `;
 
-const List = ({ nodeData: { children, enumtype, startat }, ...rest }) => {
-    const ListTag = enumtype === 'unordered' ? UnorderedList : 'ol';
+const List = ({
+    nodeData: { children, enumtype, ordered, startat },
+    ...rest
+}) => {
+    const isUnorderedInSnooty = enumtype === 'unordered';
+    // Specifically check === false since Snooty articles would be null
+    const isUnorderedInStrapi = ordered === false;
+    const isUnordered = isUnorderedInSnooty || isUnorderedInStrapi;
+    const ListTag = isUnordered ? UnorderedList : 'ol';
     const attributes = {};
     if (enumtype in enumtypeMap) {
         attributes.type = enumtypeMap[enumtype];

--- a/src/components/Reference.js
+++ b/src/components/Reference.js
@@ -4,7 +4,11 @@ import Link from './Link';
 import { getNestedValue } from '../utils/get-nested-value';
 
 const Reference = ({ nodeData }) => (
-    <Link className="reference" to={nodeData.refuri} target="_blank">
+    <Link
+        className="reference"
+        to={nodeData.refuri || nodeData.url}
+        target="_blank"
+    >
         {getNestedValue(['children', 0, 'value'], nodeData)}
     </Link>
 );

--- a/src/templates/project.js
+++ b/src/templates/project.js
@@ -63,7 +63,6 @@ const Project = props => {
         students,
         tags,
     } = props.pageContext;
-    console.log(content);
     const childNodes = getContent(dlv(content, 'children', []));
     const { siteUrl } = useSiteMetadata();
     const articleUrl = `${siteUrl}${props.pageContext.slug}`;

--- a/src/templates/project.js
+++ b/src/templates/project.js
@@ -63,6 +63,7 @@ const Project = props => {
         students,
         tags,
     } = props.pageContext;
+    console.log(content);
     const childNodes = getContent(dlv(content, 'children', []));
     const { siteUrl } = useSiteMetadata();
     const articleUrl = `${siteUrl}${props.pageContext.slug}`;


### PR DESCRIPTION
[Staging (Project with images, link, list)](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-442/project/EHRS-Peru)

This PR adds support for rendering three items coming from Strapi by augmenting our existing parsing implementation from the component factory:
- Images (needed to support `url` on `nodeData`)
- Unordered Lists (needed to support `ordered` on `nodeData`)
- Links (Needed to add `link` type to component factory and support `url` on `nodeType`).

An alternative approach could have been to distinguish the type to be specific to Strapi, but these changes are small enough to just integrate into our existing components.