### PR TITLE
DEVHUB-384: Build, Link to Pages with Trailing Slashes

### DIFF
--- a/cypress/integration/author.js
+++ b/cypress/integration/author.js
@@ -1,5 +1,5 @@
 const AUTHOR_NAME = 'Maxime Beugnet';
-const AUTHOR_URL = '/author/maxime-beugnet';
+const AUTHOR_URL = '/author/maxime-beugnet/';
 
 describe('Author Page', () => {
     it('should show an image for the author', () => {

--- a/cypress/integration/community.js
+++ b/cypress/integration/community.js
@@ -1,7 +1,7 @@
 describe('Community Page', () => {
     it('should have some events', () => {
         cy.mockEventsApi();
-        cy.visitWithoutFetch('/community');
+        cy.visitWithoutFetch('/community/');
         cy.wait(['@getEvents', '@getLiveEvents']);
         cy.get('[data-test="event"]').should('have.length', 2);
     });

--- a/cypress/integration/home.js
+++ b/cypress/integration/home.js
@@ -10,7 +10,7 @@ describe('Home Page', () => {
         cy.get(FEATURED_ARTICLES).within(() => {
             cy.contains('Learn MongoDB')
                 .should('have.prop', 'href')
-                .should('include', '/learn');
+                .should('include', '/learn/');
         });
     });
     it('should properly render some featured articles', () => {
@@ -59,7 +59,7 @@ describe('Home Page', () => {
         cy.get('[data-test="events"]').within(() => {
             cy.get('a')
                 .should('have.prop', 'href')
-                .should('contain', '/community/events');
+                .should('contain', '/community/events/');
         });
     });
     it('should have relevant SEO tags', () => {

--- a/cypress/integration/learn.js
+++ b/cypress/integration/learn.js
@@ -1,5 +1,5 @@
 const CANONICAL_URL = 'https://developer.mongodb.com/learn/';
-const FIRST_ARTICLE_IN_ORDERING = '/how-to/transactions-c-dotnet';
+const FIRST_ARTICLE_IN_ORDERING = '/how-to/transactions-c-dotnet/';
 const FIRST_ARTICLE_UPDATED_DATE = 'Oct 03, 2020';
 const FIRST_ARTICLE_PUBLISHED_DATE = 'Oct 17, 2018';
 

--- a/cypress/integration/tag.js
+++ b/cypress/integration/tag.js
@@ -1,5 +1,5 @@
-const TAG_ARTICLE_URL = '/article/3-things-to-know-switch-from-sql-mongodb';
-const TAG_PAGE_URL = '/tag/sql';
+const TAG_ARTICLE_URL = '/article/3-things-to-know-switch-from-sql-mongodb/';
+const TAG_PAGE_URL = '/tag/sql/';
 const PROD_TAG_PAGE_URL = `https://developer.mongodb.com${TAG_PAGE_URL}`;
 const TITLE = 'SQL';
 
@@ -52,6 +52,6 @@ describe('Tag page', () => {
         cy.checkMetaContentProperty('name="robots"', 'noindex');
     });
     it('should have a proper canonical URL', () => {
-        cy.checkCanonicalUrlValue(`${PROD_TAG_PAGE_URL}/`);
+        cy.checkCanonicalUrlValue(`${PROD_TAG_PAGE_URL}`);
     });
 });

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -17,6 +17,7 @@ module.exports = {
     plugins: [
         'gatsby-plugin-react-helmet',
         'gatsby-plugin-emotion',
+        'gatsby-plugin-force-trailing-slashes',
         {
             resolve: `gatsby-source-strapi`,
             options: {

--- a/gatsby-config.prod.js
+++ b/gatsby-config.prod.js
@@ -14,6 +14,7 @@ module.exports = {
     plugins: [
         'gatsby-plugin-react-helmet',
         'gatsby-plugin-emotion',
+        'gatsby-plugin-force-trailing-slashes',
         {
             resolve: `gatsby-source-strapi`,
             options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25320,6 +25320,24 @@
         }
       }
     },
+    "gatsby-plugin-force-trailing-slashes": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-force-trailing-slashes/-/gatsby-plugin-force-trailing-slashes-1.0.5.tgz",
+      "integrity": "sha512-RxRdW++bvSHv4Mho999W0LLNdiQX1OMOvY0v1TlafcaYqJ93fYV/Jp3DDD6PKS0PAKNS8Q8DRsD67cipFmZCFA==",
+      "requires": {
+        "@babel/runtime": "7.12.5"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "gatsby-plugin-google-tagmanager": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-google-tagmanager/-/gatsby-plugin-google-tagmanager-2.3.11.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "gatsby-plugin-alias-imports": "^1.0.5",
     "gatsby-plugin-emotion": "^4.3.10",
     "gatsby-plugin-feed": "^2.5.11",
+    "gatsby-plugin-force-trailing-slashes": "^1.0.5",
     "gatsby-plugin-google-tagmanager": "^2.3.11",
     "gatsby-plugin-meta-redirect": "^1.1.1",
     "gatsby-plugin-react-helmet": "^3.3.10",

--- a/src/components/dev-hub/link.js
+++ b/src/components/dev-hub/link.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { Link as RouterLink } from 'gatsby';
+import { addTrailingSlashBeforeParams } from '../../utils/add-trailing-slash-if-missing';
 import { animationSpeed, fontSize } from './theme';
 
 // Takes an event handler, and wraps it to call preventDefault.
@@ -64,6 +65,7 @@ const StyledLink = styled('a')`
     ${({ tertiary, theme }) =>
         tertiary ? tertiaryLinkStyling(theme) : linkStyling(theme)}
 `;
+
 /**
  * @param {Object<string, any>} props
  * @property {node} props.children
@@ -77,10 +79,13 @@ const Link = ({ href, onClick, target, tertiary, to, ...rest }) => {
     if (to) {
         const AsInternalLink = StyledLink.withComponent(RouterLink);
         const absoluteLink = to.startsWith('/') ? to : `/${to}`;
+        const linkWithTrailingSlash = addTrailingSlashBeforeParams(
+            absoluteLink
+        );
         return (
             <AsInternalLink
                 onClick={onClick}
-                to={absoluteLink}
+                to={linkWithTrailingSlash}
                 tertiary={tertiary}
                 {...rest}
             />

--- a/src/utils/add-trailing-slash-if-missing.js
+++ b/src/utils/add-trailing-slash-if-missing.js
@@ -10,12 +10,12 @@ export const addTrailingSlashIfMissing = url => {
 export const addTrailingSlashBeforeParams = path => {
     if (path.includes('?')) {
         // Query params
-        const pieces = path.split('?');
-        return addTrailingSlashIfMissing(pieces[0]) + `?${pieces[1]}`;
+        const [slug, suffix] = path.split('?');
+        return addTrailingSlashIfMissing(slug) + `?${suffix}`;
     } else if (path.includes('#')) {
         // Anchor without query params
-        const pieces = path.split('#');
-        return addTrailingSlashIfMissing(pieces[0]) + `#${pieces[1]}`;
+        const [slug, suffix] = path.split('#');
+        return addTrailingSlashIfMissing(slug) + `#${suffix}`;
     }
     return addTrailingSlashIfMissing(path);
 };

--- a/src/utils/add-trailing-slash-if-missing.js
+++ b/src/utils/add-trailing-slash-if-missing.js
@@ -4,3 +4,18 @@ export const addTrailingSlashIfMissing = url => {
     }
     return `${url}/`;
 };
+
+// More complicated function to add a trailing slash but before any query params
+// or anchor links
+export const addTrailingSlashBeforeParams = path => {
+    if (path.includes('?')) {
+        // Query params
+        const pieces = path.split('?');
+        return addTrailingSlashIfMissing(pieces[0]) + `?${pieces[1]}`;
+    } else if (path.includes('#')) {
+        // Anchor without query params
+        const pieces = path.split('#');
+        return addTrailingSlashIfMissing(pieces[0]) + `#${pieces[1]}`;
+    }
+    return addTrailingSlashIfMissing(path);
+};

--- a/src/utils/get-article-share-links.js
+++ b/src/utils/get-article-share-links.js
@@ -1,15 +1,17 @@
+import { addTrailingSlashIfMissing } from './add-trailing-slash-if-missing';
 import { removeTrailingSlash } from './remove-trailing-slash';
 
 export const getArticleShareLinks = (title, url) => {
+    const urlWithTrailingSlash = addTrailingSlashIfMissing(url);
     const urlWithoutTrailingSlash = removeTrailingSlash(url);
     const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=${urlWithoutTrailingSlash}`;
     const twitterUrl = `https://twitter.com/intent/tweet?url=${urlWithoutTrailingSlash}&text=${encodeURIComponent(
         title
     )}`;
     // LinkedIn throws redirects to the same exact URL without a trailing slash
-    const linkedInUrl = `https://www.linkedin.com/shareArticle?url=${urlWithoutTrailingSlash}/`;
+    const linkedInUrl = `https://www.linkedin.com/shareArticle?url=${urlWithTrailingSlash}`;
     return {
-        articleUrl: urlWithoutTrailingSlash,
+        articleUrl: urlWithTrailingSlash,
         facebookUrl,
         linkedInUrl,
         twitterUrl,

--- a/tests/unit/Reference.test.js
+++ b/tests/unit/Reference.test.js
@@ -2,12 +2,16 @@ import React from 'react';
 import { render } from 'enzyme';
 import Reference from '../../src/components/Reference';
 import { ThemeProvider } from 'emotion-theming';
-import { darkTheme} from '../../src/components/dev-hub/theme';
+import { darkTheme } from '../../src/components/dev-hub/theme';
 
 // data for this component
 import mockData from './data/Reference.test.json';
 
 it('renders correctly', () => {
-    const tree = render(<ThemeProvider theme={darkTheme}><Reference nodeData={mockData}/></ThemeProvider>);
+    const tree = render(
+        <ThemeProvider theme={darkTheme}>
+            <Reference nodeData={mockData} />
+        </ThemeProvider>
+    );
     expect(tree).toMatchSnapshot();
 });

--- a/tests/unit/__snapshots__/Heading.test.js.snap
+++ b/tests/unit/__snapshots__/Heading.test.js.snap
@@ -6,7 +6,7 @@ exports[`renders correctly 1`] = `
   id="create-an-administrative-username-and-password"
 >
   <a
-    class="e1hiqreu0 css-136ng4v-StyledLink-PermaLink eygprlc0"
+    class="e1hiqreu0 css-9zuzlw-StyledLink-PermaLink eygprlc0"
     href="#create-an-administrative-username-and-password"
     title="Permalink to this headline"
   >

--- a/tests/unit/__snapshots__/Link.test.js.snap
+++ b/tests/unit/__snapshots__/Link.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Link component renders a variety of strings correctly empty string 1`] = `
 <a
-  class="css-1ksu4pk-StyledLink eygprlc0"
+  class="css-4pi1z-StyledLink eygprlc0"
   href=""
 >
   Empty string
@@ -11,7 +11,7 @@ exports[`Link component renders a variety of strings correctly empty string 1`] 
 
 exports[`Link component renders a variety of strings correctly external URL 1`] = `
 <a
-  class="css-1ksu4pk-StyledLink eygprlc0"
+  class="css-4pi1z-StyledLink eygprlc0"
   href="http://mongodb.com"
 >
   MongoDB Company
@@ -20,8 +20,8 @@ exports[`Link component renders a variety of strings correctly external URL 1`] 
 
 exports[`Link component renders a variety of strings correctly internal link 1`] = `
 <a
-  class="test-class css-uq6oqa-AsInternalLink-StyledLink eygprlc1"
-  href="/drivers/c"
+  class="test-class css-1m971tq-AsInternalLink-StyledLink eygprlc1"
+  href="/drivers/c/"
 >
   C Driver
 </a>

--- a/tests/unit/__snapshots__/Reference.test.js.snap
+++ b/tests/unit/__snapshots__/Reference.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders correctly 1`] = `
 <a
-  class="reference css-1ksu4pk-StyledLink eygprlc0"
+  class="reference css-4pi1z-StyledLink eygprlc0"
   href="https://docs.mlab.com/subscriptions/#change-plans-using-rnr"
   rel="noreferrer noopener"
   target="_blank"

--- a/tests/utils/add-trailing-slash-if-missing.test.js
+++ b/tests/utils/add-trailing-slash-if-missing.test.js
@@ -1,4 +1,7 @@
-import { addTrailingSlashIfMissing } from '../../src/utils/add-trailing-slash-if-missing';
+import {
+    addTrailingSlashBeforeParams,
+    addTrailingSlashIfMissing,
+} from '../../src/utils/add-trailing-slash-if-missing';
 
 it('should add trailing slashes to links if they are missing', () => {
     const linkWithoutSlash = 'foo.bar';
@@ -10,4 +13,26 @@ it('should add trailing slashes to links if they are missing', () => {
 
     // Should handle null/empty inputs
     expect(addTrailingSlashIfMissing('')).toBe('/');
+});
+
+it('should add trailing slashes to URLs which have additional params appropriately', () => {
+    const link = 'foo.bar';
+    const linkWithTrailingSlash = `${link}/`;
+    const linkWithQueryParams = `${link}?content=true`;
+    const linkWithQueryParamsSlash = `${linkWithTrailingSlash}?content=true`;
+    const linkWithQueryParamsAndAnchor = `${link}?content=true#main`;
+    const linkWithQueryParamsAndAnchorSlash = `${linkWithTrailingSlash}?content=true#main`;
+    const linkWithAnchor = `${link}#main`;
+    const linkWithAnchorSlash = `${linkWithTrailingSlash}#main`;
+
+    expect(addTrailingSlashBeforeParams(link)).toBe(linkWithTrailingSlash);
+    expect(addTrailingSlashBeforeParams(linkWithQueryParams)).toBe(
+        linkWithQueryParamsSlash
+    );
+    expect(addTrailingSlashBeforeParams(linkWithQueryParamsAndAnchor)).toBe(
+        linkWithQueryParamsAndAnchorSlash
+    );
+    expect(addTrailingSlashBeforeParams(linkWithAnchor)).toBe(
+        linkWithAnchorSlash
+    );
 });


### PR DESCRIPTION
[Staging Link](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-384/)
[JIRA](https://jira.mongodb.org/browse/DEVHUB-384)

This PR fixes an SEO issue regarding additional 308 redirects. Here, we build pages with trailing slashes using the [force-trailing-slashes](https://github.com/jon-sully/gatsby-plugin-force-trailing-slashes) plugin. In addition:
- Any internal `Link`s should have a trailing slash
- Any internal `Link`s should respect query params or anchor links when navigating and keep those on the end
- The article share copy button should copy a link with a trailing slash

Some of these features are more about DEVHUB-423 which deals with internal links, but I also felt it was appropriate ti lay some groundwork here