### PR TITLE
DEVHUB-304 (Part 2): Add support for additional_images for a project

### DIFF
--- a/src/components/dev-hub/image-gallery.js
+++ b/src/components/dev-hub/image-gallery.js
@@ -36,6 +36,10 @@ const GalleryItemsContainer = styled('div')`
     justify-content: space-between;
 `;
 
+const ThumbnailContainer = styled('div')`
+    display: flex;
+`;
+
 /**
  *
  * @param {[object]} images: A list of img src values/captions
@@ -48,7 +52,7 @@ const ImageGallery = ({ images }) => {
             <CurrentImage src={currentImage.src} />
             <GalleryItemsContainer>
                 <P>{currentImage.caption}</P>
-                <div>
+                <ThumbnailContainer>
                     {images.map(img => (
                         <ThumbnailWrapper
                             key={img.src}
@@ -60,7 +64,7 @@ const ImageGallery = ({ images }) => {
                             />
                         </ThumbnailWrapper>
                     ))}
-                </div>
+                </ThumbnailContainer>
             </GalleryItemsContainer>
         </div>
     );

--- a/src/queries/projects.js
+++ b/src/queries/projects.js
@@ -23,6 +23,10 @@ query Projects {
             youtube_url
           }
         }
+        additional_images {
+          alternativeText
+          url
+        }
         info {
           contents
           languages {

--- a/src/templates/project.js
+++ b/src/templates/project.js
@@ -54,6 +54,7 @@ const TopPaddedShareProjectCTA = styled(ShareProjectCTA)`
 
 const Project = props => {
     const {
+        additional_images = [],
         content,
         github_url,
         image,
@@ -70,7 +71,11 @@ const Project = props => {
         <Layout>
             <SEO articleTitle={name} />
             <ProjectTitleArea
-                images={[{ src: image.url, caption: name }]}
+                // TODO: Clean up src/url difference between Strapi and Snooty
+                images={[
+                    { src: image.url },
+                    ...additional_images.map(i => ({ src: i.url })),
+                ]}
                 title={name}
             />
             <Container>

--- a/src/utils/transform-project-strapi-data.js
+++ b/src/utils/transform-project-strapi-data.js
@@ -1,5 +1,6 @@
 export const transformProjectStrapiData = project => {
     const result = {
+        additional_images: project.additional_images,
         github_url: project.github_url,
         name: project.name,
         project_link: project.project_link,


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DEVHUB-304)
[Staging Link](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-304-additional/project/go-fifa/)

This PR adds support for `additional_images` for a project to show up on the project page. These image thumbnails in the bottom right can be clicked on to open the image in the main view.

![Screen Shot 2021-02-05 at 4 45 56 PM](https://user-images.githubusercontent.com/9064401/107092462-a5a7de80-67d1-11eb-9f21-d51909542c60.png)
