### PR TITLE
DEVHUB-309 [Part 1]: Add react-dropzone backed Image Upload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7206,6 +7206,11 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
+    "attr-accept": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
+      "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg=="
+    },
     "autoprefixer": {
       "version": "9.8.6",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
@@ -14230,6 +14235,21 @@
             "ajv": "^6.1.0",
             "ajv-keywords": "^3.1.0"
           }
+        }
+      }
+    },
+    "file-selector": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.2.4.tgz",
+      "integrity": "sha512-ZDsQNbrv6qRi1YTDOEWzf5J2KjZ9KMI1Q2SGeTkCJmNNW25Jg4TW4UMcmoqcg4WrAyKRcpBXdbWRxkfrOzVRbA==",
+      "requires": {
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
         }
       }
     },
@@ -26784,6 +26804,16 @@
       "requires": {
         "classnames": "^2.2.5",
         "prop-types": "^15.6.0"
+      }
+    },
+    "react-dropzone": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-11.3.0.tgz",
+      "integrity": "sha512-5ffIOi5Uf1X52m4fN8QdcRuAX88nQPfmx6HTTIfF9I3W9Ss1SvRDl/ruZmFf53K7+g3TSaIgVw6a9EK7XoDwHw==",
+      "requires": {
+        "attr-accept": "^2.2.1",
+        "file-selector": "^0.2.2",
+        "prop-types": "^15.7.2"
       }
     },
     "react-element-to-jsx-string": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react": "^16.13.1",
     "react-aria-modal": "^4.0.0",
     "react-dom": "^16.13.1",
+    "react-dropzone": "^11.3.0",
     "react-helmet": "^6.1.0",
     "react-loadable": "^5.5.0",
     "react-player": "^2.8.2",

--- a/src/components/pages/student-submit/form/dropzone-thumbnail.js
+++ b/src/components/pages/student-submit/form/dropzone-thumbnail.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { size } from '~components/dev-hub/theme';
+import Icon from '@leafygreen-ui/icon';
+import Button from '~components/dev-hub/button';
+
+export const THUMBNAIL_WIDTH = '96px';
+
+const RemoveButton = styled(Button)`
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 0;
+`;
+
+const ThumbnailWrapper = styled('div')`
+    border-radius: 10px;
+    width: ${THUMBNAIL_WIDTH};
+    height: ${size.xlarge};
+    padding: 4px;
+    margin: 0 ${size.mediumLarge} ${size.xsmall} 0;
+    grid-row-start: 2;
+    border: 1px dashed ${({ theme }) => theme.colorMap.greyLightThree};
+    :last-of-type {
+        margin-right: 0;
+    }
+`;
+
+const ThumbnailContent = styled('div')`
+    display: flex;
+    height: 100%;
+    min-width: 0;
+    overflow: hidden;
+    position: relative;
+`;
+
+const Image = styled('img')`
+    display: block;
+    height: 100%;
+    width: auto;
+`;
+
+const DropzoneThumbnail = ({ file, removeImage }) => {
+    const isFile = !!file;
+    const preview = isFile && file.preview;
+    return (
+        <ThumbnailWrapper>
+            <ThumbnailContent>
+                {preview ? (
+                    <div>
+                        <Image src={preview} />
+                        <RemoveButton onClick={removeImage}>
+                            <Icon
+                                glyph="XWithCircle"
+                                size="small"
+                                fill="#D8D8D8"
+                            />
+                        </RemoveButton>
+                    </div>
+                ) : null}
+            </ThumbnailContent>
+        </ThumbnailWrapper>
+    );
+};
+
+export default DropzoneThumbnail;

--- a/src/components/pages/student-submit/form/dropzone-thumbnail.js
+++ b/src/components/pages/student-submit/form/dropzone-thumbnail.js
@@ -7,20 +7,20 @@ import Button from '~components/dev-hub/button';
 export const THUMBNAIL_WIDTH = '96px';
 
 const RemoveButton = styled(Button)`
-    position: absolute;
-    top: 0;
-    right: 0;
     padding: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
 `;
 
 const ThumbnailWrapper = styled('div')`
-    border-radius: 10px;
-    width: ${THUMBNAIL_WIDTH};
-    height: ${size.xlarge};
-    padding: 4px;
-    margin: 0 ${size.mediumLarge} ${size.xsmall} 0;
-    grid-row-start: 2;
     border: 1px dashed ${({ theme }) => theme.colorMap.greyLightThree};
+    border-radius: 10px;
+    grid-row-start: 2;
+    height: ${size.xlarge};
+    margin: 0 ${size.mediumLarge} ${size.xsmall} 0;
+    padding: 4px;
+    width: ${THUMBNAIL_WIDTH};
     :last-of-type {
         margin-right: 0;
     }

--- a/src/components/pages/student-submit/form/image-dropzone.js
+++ b/src/components/pages/student-submit/form/image-dropzone.js
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { useDropzone } from 'react-dropzone';
+import Button from '~components/dev-hub/button';
+import CloseIcon from '~components/dev-hub/icons/close-icon';
 import { H5, P, P3 } from '~components/dev-hub/text';
 import { size } from '~components/dev-hub/theme';
 
@@ -25,19 +27,25 @@ const GreyP3 = styled(P3)`
     ${greyText};
 `;
 
-const Dropzone = styled('div')`
-    background: #21313c;
-    /* B&W/Grey 5 */
+const RemoveButton = styled(Button)`
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 0;
+    color: black;
+`;
 
-    border: 1px dashed #9fa1a2;
+const Dropzone = styled('div')`
+    align-items: center;
+    background: ${({ theme }) => theme.colorMap.greyDarkThree};
+    border: 1px dashed ${({ theme }) => theme.colorMap.greyLightThree};
     border-radius: 10px;
     cursor: pointer;
     display: flex;
     flex-direction: column;
-    align-items: center;
+    height: 232px;
     justify-content: center;
     text-align: center;
-    height: 232px;
 `;
 
 const ThumbnailsContainer = styled('aside')`
@@ -53,7 +61,7 @@ const ThumbnailWrapper = styled('div')`
     height: 64px;
     padding: 4px;
     display: inline-flex;
-    border: 1px dashed #9fa1a2;
+    border: 1px dashed ${({ theme }) => theme.colorMap.greyLightThree};
     :last-of-type {
         margin-right: 0;
     }
@@ -63,6 +71,7 @@ const ThumbnailContent = styled('div')`
     display: flex;
     min-width: 0;
     overflow: hidden;
+    position: relative;
 `;
 
 const Image = styled('img')`
@@ -71,13 +80,20 @@ const Image = styled('img')`
     width: auto;
 `;
 
-const Thumbnail = ({ file }) => {
+const Thumbnail = ({ file, removeImage }) => {
     const isFile = !!file;
     const preview = isFile && file.preview;
     return (
         <ThumbnailWrapper>
             <ThumbnailContent>
-                {preview ? <Image src={preview} /> : null}
+                {preview ? (
+                    <div>
+                        <Image src={preview} />
+                        <RemoveButton onClick={removeImage}>
+                            <CloseIcon height="10" width="10" />
+                        </RemoveButton>
+                    </div>
+                ) : null}
             </ThumbnailContent>
         </ThumbnailWrapper>
     );
@@ -102,7 +118,15 @@ const ImageDropzone = ({ maxFiles = 6 }) => {
     });
 
     const thumbs = files.map((file, index) => (
-        <Thumbnail file={file} key={file ? file.name : index} />
+        <Thumbnail
+            file={file}
+            key={file ? file.name : index}
+            removeImage={() => {
+                const newFiles = [...files];
+                newFiles[index] = null;
+                setFiles(newFiles);
+            }}
+        />
     ));
 
     useEffect(

--- a/src/components/pages/student-submit/form/image-dropzone.js
+++ b/src/components/pages/student-submit/form/image-dropzone.js
@@ -48,12 +48,15 @@ const ThumbnailsContainer = styled('aside')`
 
 const ThumbnailWrapper = styled('div')`
     border-radius: 10px;
-    margin: 0 8px 8px 0;
+    margin: 0 24px 8px 0;
     width: 96px;
     height: 64px;
     padding: 4px;
     display: inline-flex;
     border: 1px dashed #9fa1a2;
+    :last-of-type {
+        margin-right: 0;
+    }
 `;
 
 const ThumbnailContent = styled('div')`
@@ -70,10 +73,9 @@ const Image = styled('img')`
 
 const Thumbnail = ({ file }) => {
     const isFile = !!file;
-    const key = isFile && file.name;
     const preview = isFile && file.preview;
     return (
-        <ThumbnailWrapper key={key}>
+        <ThumbnailWrapper>
             <ThumbnailContent>
                 {preview ? <Image src={preview} /> : null}
             </ThumbnailContent>
@@ -82,23 +84,25 @@ const Thumbnail = ({ file }) => {
 };
 
 // Adopted from https://react-dropzone.js.org/#section-previews
-const ImageDropzone = () => {
-    const [files, setFiles] = useState([null]);
+const ImageDropzone = ({ maxFiles = 6 }) => {
+    const [files, setFiles] = useState([null, null, null, null, null, null]);
     const { getRootProps, getInputProps } = useDropzone({
         accept: 'image/*',
         onDrop: acceptedFiles => {
-            setFiles(
-                acceptedFiles.map(file =>
+            const newFiles = [
+                ...acceptedFiles.map(file =>
                     Object.assign(file, {
                         preview: URL.createObjectURL(file),
                     })
-                )
-            );
+                ),
+                ...files,
+            ].slice(0, maxFiles);
+            setFiles(newFiles);
         },
     });
 
-    const thumbs = files.map(file => (
-        <Thumbnail file={file} key={file && file.name} />
+    const thumbs = files.map((file, index) => (
+        <Thumbnail file={file} key={file ? file.name : index} />
     ));
 
     useEffect(
@@ -110,7 +114,7 @@ const ImageDropzone = () => {
     );
 
     return (
-        <section className="container">
+        <section>
             <Dropzone {...getRootProps()}>
                 <input {...getInputProps()} />
                 <GreyH5>Drag and drop images (6 max)</GreyH5>

--- a/src/components/pages/student-submit/form/image-dropzone.js
+++ b/src/components/pages/student-submit/form/image-dropzone.js
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
-import Icon from '@leafygreen-ui/icon';
 import { useDropzone } from 'react-dropzone';
-import Button from '~components/dev-hub/button';
 import { H5, P, P3 } from '~components/dev-hub/text';
 import { size } from '~components/dev-hub/theme';
+import DropzoneThumbnail, { THUMBNAIL_WIDTH } from './dropzone-thumbnail';
+
+const DROPZONE_HEIGHT = '232px';
 
 const greyText = theme => css`
     color: ${theme.colorMap.greyLightTwo};
@@ -27,14 +28,6 @@ const GreyP3 = styled(P3)`
     ${({ theme }) => greyText(theme)};
 `;
 
-const RemoveButton = styled(Button)`
-    position: absolute;
-    top: 0;
-    right: 0;
-    padding: 0;
-    color: black;
-`;
-
 const Dropzone = styled('div')`
     align-items: center;
     background: ${({ theme }) => theme.colorMap.greyDarkThree};
@@ -43,42 +36,15 @@ const Dropzone = styled('div')`
     cursor: pointer;
     display: flex;
     flex-direction: column;
-    height: 232px;
+    height: ${DROPZONE_HEIGHT};
     justify-content: center;
     text-align: center;
-`;
-
-const ThumbnailWrapper = styled('div')`
-    border-radius: 10px;
-    width: 96px;
-    height: ${size.xlarge};
-    padding: 4px;
-    margin: 0 ${size.mediumLarge} ${size.xsmall} 0;
-    grid-row-start: 2;
-    border: 1px dashed ${({ theme }) => theme.colorMap.greyLightThree};
-    :last-of-type {
-        margin-right: 0;
-    }
-`;
-
-const ThumbnailContent = styled('div')`
-    display: flex;
-    height: 100%;
-    min-width: 0;
-    overflow: hidden;
-    position: relative;
-`;
-
-const Image = styled('img')`
-    display: block;
-    height: 100%;
-    width: auto;
 `;
 
 const ThumbnailGrid = styled('div')`
     display: grid;
     grid-template-rows: ${size.medium} ${size.xlarge};
-    grid-template-columns: repeat(6, 96px);
+    grid-template-columns: repeat(6, ${THUMBNAIL_WIDTH});
     text-align: center;
     row-gap: 4px;
     column-gap: ${size.mediumLarge};
@@ -88,29 +54,6 @@ const ThumbnailGrid = styled('div')`
 const ImageLabelText = styled(P3)`
     color: ${({ theme }) => theme.colorMap.greyLightTwo};
 `;
-
-const Thumbnail = ({ file, removeImage }) => {
-    const isFile = !!file;
-    const preview = isFile && file.preview;
-    return (
-        <ThumbnailWrapper>
-            <ThumbnailContent>
-                {preview ? (
-                    <div>
-                        <Image src={preview} />
-                        <RemoveButton onClick={removeImage}>
-                            <Icon
-                                glyph="XWithCircle"
-                                size="small"
-                                fill="#D8D8D8"
-                            />
-                        </RemoveButton>
-                    </div>
-                ) : null}
-            </ThumbnailContent>
-        </ThumbnailWrapper>
-    );
-};
 
 // Adopted from https://react-dropzone.js.org/#section-previews
 const ImageDropzone = ({ maxFiles = 6 }) => {
@@ -131,7 +74,7 @@ const ImageDropzone = ({ maxFiles = 6 }) => {
     });
 
     const thumbs = files.map((file, index) => (
-        <Thumbnail
+        <DropzoneThumbnail
             file={file}
             key={file ? file.name : index}
             removeImage={() => {

--- a/src/components/pages/student-submit/form/image-dropzone.js
+++ b/src/components/pages/student-submit/form/image-dropzone.js
@@ -1,0 +1,129 @@
+import React, { useEffect, useState } from 'react';
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+import { useDropzone } from 'react-dropzone';
+import { H5, P, P3 } from '~components/dev-hub/text';
+import { size } from '~components/dev-hub/theme';
+
+const greyText = css`
+    color: #b8c4c2;
+`;
+
+const Underline = styled('span')`
+    text-decoration: underline;
+`;
+
+const GreyH5 = styled(H5)`
+    ${greyText};
+`;
+
+const GreyP = styled(P)`
+    ${greyText};
+`;
+
+const GreyP3 = styled(P3)`
+    ${greyText};
+`;
+
+const Dropzone = styled('div')`
+    background: #21313c;
+    /* B&W/Grey 5 */
+
+    border: 1px dashed #9fa1a2;
+    border-radius: 10px;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    height: 232px;
+`;
+
+const ThumbnailsContainer = styled('aside')`
+    display: flex;
+    flex-wrap: wrap;
+    margin-top: ${size.default};
+`;
+
+const ThumbnailWrapper = styled('div')`
+    border-radius: 10px;
+    margin: 0 8px 8px 0;
+    width: 96px;
+    height: 64px;
+    padding: 4px;
+    display: inline-flex;
+    border: 1px dashed #9fa1a2;
+`;
+
+const ThumbnailContent = styled('div')`
+    display: flex;
+    min-width: 0;
+    overflow: hidden;
+`;
+
+const Image = styled('img')`
+    display: block;
+    height: 100%;
+    width: auto;
+`;
+
+const Thumbnail = ({ file }) => {
+    const isFile = !!file;
+    const key = isFile && file.name;
+    const preview = isFile && file.preview;
+    return (
+        <ThumbnailWrapper key={key}>
+            <ThumbnailContent>
+                {preview ? <Image src={preview} /> : null}
+            </ThumbnailContent>
+        </ThumbnailWrapper>
+    );
+};
+
+// Adopted from https://react-dropzone.js.org/#section-previews
+const ImageDropzone = () => {
+    const [files, setFiles] = useState([null]);
+    const { getRootProps, getInputProps } = useDropzone({
+        accept: 'image/*',
+        onDrop: acceptedFiles => {
+            setFiles(
+                acceptedFiles.map(file =>
+                    Object.assign(file, {
+                        preview: URL.createObjectURL(file),
+                    })
+                )
+            );
+        },
+    });
+
+    const thumbs = files.map(file => (
+        <Thumbnail file={file} key={file && file.name} />
+    ));
+
+    useEffect(
+        () => () => {
+            // Make sure to revoke the data uris to avoid memory leaks
+            files.forEach(file => file && URL.revokeObjectURL(file.preview));
+        },
+        [files]
+    );
+
+    return (
+        <section className="container">
+            <Dropzone {...getRootProps()}>
+                <input {...getInputProps()} />
+                <GreyH5>Drag and drop images (6 max)</GreyH5>
+                <GreyP collapse>
+                    or <Underline>browse</Underline> to choose a file
+                </GreyP>
+                <GreyP3>
+                    (1600 x 1200 or larger recommended, up to 10MB each)
+                </GreyP3>
+            </Dropzone>
+            <ThumbnailsContainer>{thumbs}</ThumbnailsContainer>
+        </section>
+    );
+};
+
+export default ImageDropzone;

--- a/src/components/pages/student-submit/form/image-dropzone.js
+++ b/src/components/pages/student-submit/form/image-dropzone.js
@@ -42,13 +42,13 @@ const Dropzone = styled('div')`
 `;
 
 const ThumbnailGrid = styled('div')`
-    display: grid;
-    grid-template-rows: ${size.medium} ${size.xlarge};
-    grid-template-columns: repeat(6, ${THUMBNAIL_WIDTH});
-    text-align: center;
-    row-gap: 4px;
     column-gap: ${size.mediumLarge};
+    display: grid;
+    grid-template-columns: repeat(6, ${THUMBNAIL_WIDTH});
+    grid-template-rows: ${size.medium} ${size.xlarge};
     margin-top: ${size.mediumLarge};
+    row-gap: 4px;
+    text-align: center;
 `;
 
 const ImageLabelText = styled(P3)`

--- a/src/components/pages/student-submit/form/image-dropzone.js
+++ b/src/components/pages/student-submit/form/image-dropzone.js
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
+import Icon from '@leafygreen-ui/icon';
 import { useDropzone } from 'react-dropzone';
 import Button from '~components/dev-hub/button';
-import CloseIcon from '~components/dev-hub/icons/close-icon';
 import { H5, P, P3 } from '~components/dev-hub/text';
 import { size } from '~components/dev-hub/theme';
 
@@ -63,6 +63,7 @@ const ThumbnailWrapper = styled('div')`
 
 const ThumbnailContent = styled('div')`
     display: flex;
+    height: 100%;
     min-width: 0;
     overflow: hidden;
     position: relative;
@@ -98,7 +99,11 @@ const Thumbnail = ({ file, removeImage }) => {
                     <div>
                         <Image src={preview} />
                         <RemoveButton onClick={removeImage}>
-                            <CloseIcon height="10" width="10" />
+                            <Icon
+                                glyph="XWithCircle"
+                                size="small"
+                                fill="#D8D8D8"
+                            />
                         </RemoveButton>
                     </div>
                 ) : null}

--- a/src/components/pages/student-submit/form/image-dropzone.js
+++ b/src/components/pages/student-submit/form/image-dropzone.js
@@ -7,8 +7,8 @@ import CloseIcon from '~components/dev-hub/icons/close-icon';
 import { H5, P, P3 } from '~components/dev-hub/text';
 import { size } from '~components/dev-hub/theme';
 
-const greyText = css`
-    color: #b8c4c2;
+const greyText = theme => css`
+    color: ${theme.colorMap.greyLightTwo};
 `;
 
 const Underline = styled('span')`
@@ -16,15 +16,15 @@ const Underline = styled('span')`
 `;
 
 const GreyH5 = styled(H5)`
-    ${greyText};
+    ${({ theme }) => greyText(theme)};
 `;
 
 const GreyP = styled(P)`
-    ${greyText};
+    ${({ theme }) => greyText(theme)};
 `;
 
 const GreyP3 = styled(P3)`
-    ${greyText};
+    ${({ theme }) => greyText(theme)};
 `;
 
 const RemoveButton = styled(Button)`
@@ -48,19 +48,13 @@ const Dropzone = styled('div')`
     text-align: center;
 `;
 
-const ThumbnailsContainer = styled('aside')`
-    display: flex;
-    flex-wrap: wrap;
-    margin-top: ${size.default};
-`;
-
 const ThumbnailWrapper = styled('div')`
     border-radius: 10px;
-    margin: 0 24px 8px 0;
     width: 96px;
-    height: 64px;
+    height: ${size.xlarge};
     padding: 4px;
-    display: inline-flex;
+    margin: 0 ${size.mediumLarge} ${size.xsmall} 0;
+    grid-row-start: 2;
     border: 1px dashed ${({ theme }) => theme.colorMap.greyLightThree};
     :last-of-type {
         margin-right: 0;
@@ -78,6 +72,20 @@ const Image = styled('img')`
     display: block;
     height: 100%;
     width: auto;
+`;
+
+const ThumbnailGrid = styled('div')`
+    display: grid;
+    grid-template-rows: ${size.medium} ${size.xlarge};
+    grid-template-columns: repeat(6, 96px);
+    text-align: center;
+    row-gap: 4px;
+    column-gap: ${size.mediumLarge};
+    margin-top: ${size.mediumLarge};
+`;
+
+const ImageLabelText = styled(P3)`
+    color: ${({ theme }) => theme.colorMap.greyLightTwo};
 `;
 
 const Thumbnail = ({ file, removeImage }) => {
@@ -126,6 +134,7 @@ const ImageDropzone = ({ maxFiles = 6 }) => {
                 newFiles[index] = null;
                 setFiles(newFiles);
             }}
+            label={index === 0 ? 'Main Image' : null}
         />
     ));
 
@@ -149,7 +158,10 @@ const ImageDropzone = ({ maxFiles = 6 }) => {
                     (1600 x 1200 or larger recommended, up to 10MB each)
                 </GreyP3>
             </Dropzone>
-            <ThumbnailsContainer>{thumbs}</ThumbnailsContainer>
+            <ThumbnailGrid>
+                <ImageLabelText collapse>Main Image</ImageLabelText>
+                {thumbs}
+            </ThumbnailGrid>
         </section>
     );
 };

--- a/src/components/pages/student-submit/form/project-info.js
+++ b/src/components/pages/student-submit/form/project-info.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Input from '~components/dev-hub/input';
+import ImageDropzone from './image-dropzone';
 import SubmitFormFieldset from './submit-form-fieldset';
 
 const ProjectInfo = ({ ...props }) => (
@@ -13,6 +14,7 @@ const ProjectInfo = ({ ...props }) => (
         />
         <Input narrow required placeholder="GitHub Link" />
         <Input narrow placeholder="Other project link" />
+        <ImageDropzone />
         <Input narrow placeholder="YouTube Video Demo Link" />
     </SubmitFormFieldset>
 );

--- a/src/components/pages/student-submit/form/submit-form-fieldset.js
+++ b/src/components/pages/student-submit/form/submit-form-fieldset.js
@@ -4,7 +4,7 @@ import Button from '~components/dev-hub/button';
 import { H5 } from '~components/dev-hub/text';
 import { size } from '~components/dev-hub/theme';
 
-const FIELDSET_MAX_WIDTH = '792px';
+const FIELDSET_MAX_WIDTH = '794px';
 
 const Centered = styled('div')`
     display: flex;


### PR DESCRIPTION
[Staging Link](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-309/academia/students/submit/)

This PR uses a lightweight NPM package called `react-dropzone` to construct the project image upload section of the submission form for student spotlights.

The next step will be improving the UX to allow for an easier choice of which image is the main one.

![Screen Shot 2021-02-08 at 11 03 17 AM](https://user-images.githubusercontent.com/9064401/107246215-0451a000-69fe-11eb-8823-d99a4a245fb2.png)
