### PR TITLE
DEVHUB-308: Correctly validate at the fieldset level

### DIFF
--- a/src/components/pages/student-submit/form/index.js
+++ b/src/components/pages/student-submit/form/index.js
@@ -19,9 +19,15 @@ const Form = () => {
 
     const onFormPartCompletion = useCallback((e, initialRef, nextRef) => {
         e.preventDefault();
-        // Below checks entire form, should just check fieldset ideally
-        const fieldsetForm = initialRef.current.form;
-        const isValid = fieldsetForm.checkValidity();
+        const currentFieldset = initialRef.current;
+        const fieldsetElements = Array.from(currentFieldset.elements);
+        // Last entry of fieldset is the button to move on to the next fieldset
+        // We do not need to consider it when checking validity
+        fieldsetElements.pop();
+        const isValid = fieldsetElements.reduce(
+            (p, c) => p && c.checkValidity(),
+            true
+        );
         if (isValid) {
             if (nextRef) {
                 scrollToRef(nextRef);
@@ -30,7 +36,8 @@ const Form = () => {
                 return;
             }
         } else {
-            fieldsetForm.reportValidity();
+            // Browser method to show validity messages
+            currentFieldset.form.reportValidity();
         }
     }, []);
 


### PR DESCRIPTION
No staging (since state is not enabled yet for field elements)

This PR updates the logic for validating the student spotlight submit form. Now, we validate a single fieldset before moving onto the next one (instead of incorrectly trying to validate the entire form. We use a `reduce` on the `input`s within the form to check validity since the `FieldSet.checkValidity()` method only returns true.