### PR TITLE
2nd Deploy: Feb 10th 2021

### DIFF
--- a/src/components/dev-hub/card.js
+++ b/src/components/dev-hub/card.js
@@ -64,6 +64,12 @@ const Wrapper = styled('div')`
     ${({ highlight }) => highlight && `background: rgba(255, 255, 255, 0.3);`};
     ${({ isclickable, theme }) => isclickable && hoverStyles(theme)}
 `;
+const truncate = maxLines => css`
+    display: -webkit-box;
+    -webkit-line-clamp: ${maxLines}; /* supported cross browser */
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+`;
 const DescriptionText = styled(P)`
     color: ${({ theme }) => theme.colorMap.greyLightTwo};
     font-size: ${fontSize.small};
@@ -89,6 +95,8 @@ const Card = ({
     description,
     href,
     image,
+    maxDescriptionLines = 4,
+    maxTitleLines = 4,
     onClick,
     badge,
     to,
@@ -136,10 +144,17 @@ const Card = ({
                     </ImageWrapper>
                 )}
                 {title && (
-                    <CardTitle collapse={!description}>{title}</CardTitle>
+                    <CardTitle
+                        css={truncate(maxTitleLines)}
+                        collapse={!description}
+                    >
+                        {title}
+                    </CardTitle>
                 )}
                 {description && (
-                    <DescriptionText>{description}</DescriptionText>
+                    <DescriptionText css={truncate(maxDescriptionLines)}>
+                        {description}
+                    </DescriptionText>
                 )}
             </div>
             {children}

--- a/src/components/dev-hub/card.js
+++ b/src/components/dev-hub/card.js
@@ -64,12 +64,6 @@ const Wrapper = styled('div')`
     ${({ highlight }) => highlight && `background: rgba(255, 255, 255, 0.3);`};
     ${({ isclickable, theme }) => isclickable && hoverStyles(theme)}
 `;
-const truncate = maxLines => css`
-    display: -webkit-box;
-    -webkit-line-clamp: ${maxLines}; /* supported cross browser */
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-`;
 const DescriptionText = styled(P)`
     color: ${({ theme }) => theme.colorMap.greyLightTwo};
     font-size: ${fontSize.small};
@@ -95,8 +89,6 @@ const Card = ({
     description,
     href,
     image,
-    maxDescriptionLines = 3,
-    maxTitleLines = 2,
     onClick,
     badge,
     to,
@@ -144,17 +136,10 @@ const Card = ({
                     </ImageWrapper>
                 )}
                 {title && (
-                    <CardTitle
-                        css={truncate(maxTitleLines)}
-                        collapse={!description}
-                    >
-                        {title}
-                    </CardTitle>
+                    <CardTitle collapse={!description}>{title}</CardTitle>
                 )}
                 {description && (
-                    <DescriptionText css={truncate(maxDescriptionLines)}>
-                        {description}
-                    </DescriptionText>
+                    <DescriptionText>{description}</DescriptionText>
                 )}
             </div>
             {children}

--- a/src/components/dev-hub/related-articles.js
+++ b/src/components/dev-hub/related-articles.js
@@ -108,7 +108,6 @@ const RelatedArticles = ({ related, slugTitleMapping }) => {
                                 key={`${title}-${i}`}
                                 image={image}
                                 href={target}
-                                maxTitleLines={2}
                                 title={title}
                                 maxWidth={MAX_CARD_WIDTH}
                             />

--- a/src/components/dev-hub/stories/card.stories.mdx
+++ b/src/components/dev-hub/stories/card.stories.mdx
@@ -12,10 +12,11 @@ A card can have a link, image, title, and description.
 
 <Preview>
     <Story name="default card">
-        <div style={{ display: 'flex' }}>
+        <div style={{display: 'flex'}}>
             <Card
                 distinct
                 image={mockCardImage}
+                maxTitleLines={3}
                 title="Title for Card"
                 description="Description for card that has a link."
                 href="#cards"
@@ -23,6 +24,7 @@ A card can have a link, image, title, and description.
             <Card
                 distinct
                 image={mockCardImage}
+                maxTitleLines={3}
                 title="Title for Card"
                 description="Description for card with no link."
             />
@@ -34,11 +36,12 @@ Cards can also have a list of tags associated with them (max 5 tags).
 
 <Preview>
     <Story name="tag-list card">
-        <div style={{ display: 'flex' }}>
+        <div style={{display: 'flex'}}>
             <Card
                 distinct
                 image={mockCardImage}
                 tags={mapTagTypeToUrl(['tag one', 'tag two'], 'tags')}
+                maxTitleLines={3}
                 title="I'm a Card For A Post on the New Devhub Platform! I have 2 tags!"
                 href="#cards"
             />
@@ -56,11 +59,25 @@ Cards can also have a list of tags associated with them (max 5 tags).
     </Story>
 </Preview>
 
-Cards do not need images.
+Cards do not need images and can handle short and long titles. You can configure
+the max number of lines a title can have using the `maxTitleLines` prop.
 
 <Preview>
     <Story name="no-image card">
-        <div style={{ display: 'flex' }}>
+        <div style={{display: 'flex'}}>
+            <Card
+                width="300px"
+                title="I'm a card with a really really really really really really really really really really long title"
+                description="This card has a long title, displaying 2 lines by default."
+                href="#cards"
+            />
+            <Card
+                width="300px"
+                title="I'm a card with a really really really really really really really really really really long title.I'm a card with a really really really really really really really really really really long title"
+                maxTitleLines={4}
+                description="This card has a long title, displaying 4 lines though the 'maxTitleLines' prop."
+                href="#cards"
+            />
             <Card
                 highlight
                 width="300px"

--- a/src/components/dev-hub/stories/card.stories.mdx
+++ b/src/components/dev-hub/stories/card.stories.mdx
@@ -12,11 +12,10 @@ A card can have a link, image, title, and description.
 
 <Preview>
     <Story name="default card">
-        <div style={{display: 'flex'}}>
+        <div style={{ display: 'flex' }}>
             <Card
                 distinct
                 image={mockCardImage}
-                maxTitleLines={3}
                 title="Title for Card"
                 description="Description for card that has a link."
                 href="#cards"
@@ -24,7 +23,6 @@ A card can have a link, image, title, and description.
             <Card
                 distinct
                 image={mockCardImage}
-                maxTitleLines={3}
                 title="Title for Card"
                 description="Description for card with no link."
             />
@@ -36,12 +34,11 @@ Cards can also have a list of tags associated with them (max 5 tags).
 
 <Preview>
     <Story name="tag-list card">
-        <div style={{display: 'flex'}}>
+        <div style={{ display: 'flex' }}>
             <Card
                 distinct
                 image={mockCardImage}
                 tags={mapTagTypeToUrl(['tag one', 'tag two'], 'tags')}
-                maxTitleLines={3}
                 title="I'm a Card For A Post on the New Devhub Platform! I have 2 tags!"
                 href="#cards"
             />
@@ -59,25 +56,11 @@ Cards can also have a list of tags associated with them (max 5 tags).
     </Story>
 </Preview>
 
-Cards do not need images and can handle short and long titles. You can configure
-the max number of lines a title can have using the `maxTitleLines` prop.
+Cards do not need images.
 
 <Preview>
     <Story name="no-image card">
-        <div style={{display: 'flex'}}>
-            <Card
-                width="300px"
-                title="I'm a card with a really really really really really really really really really really long title"
-                description="This card has a long title, displaying 2 lines by default."
-                href="#cards"
-            />
-            <Card
-                width="300px"
-                title="I'm a card with a really really really really really really really really really really long title.I'm a card with a really really really really really really really really really really long title"
-                maxTitleLines={4}
-                description="This card has a long title, displaying 4 lines though the 'maxTitleLines' prop."
-                href="#cards"
-            />
+        <div style={{ display: 'flex' }}>
             <Card
                 highlight
                 width="300px"

--- a/src/components/pages/home/hero.js
+++ b/src/components/pages/home/hero.js
@@ -48,13 +48,7 @@ const FeaturedHomePageItem = ({ item }) => {
     if (item.type === 'article') {
         const { image, slug, title } = getFeaturedCardFields(item);
         return (
-            <StyledTopCard
-                maxTitleLines={3}
-                image={image}
-                to={slug}
-                title={title}
-                key={title}
-            />
+            <StyledTopCard image={image} to={slug} title={title} key={title} />
         );
     }
 };

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -168,7 +168,6 @@ const FeaturedArticles = ({ articles }) => {
                 >
                     <Card
                         collapseImage
-                        maxDescriptionLines={4}
                         to={slug}
                         title={title}
                         description={description}


### PR DESCRIPTION
[Staging Job](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=6022c91dab23346c202a3b7d)
[Staging Link](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/revert-648-DEVHUB-461/)

This PR removes the truncation on cards in production.

```
staging using branch origin/staging
production using branch origin/master

changes in staging but not production:
fc38380 Revert 648 devhub 461 (#651) --> revert with truncate at 4 lines
94f2e6f Remove truncation on all cards (#648)
```