### PR TITLE
DEVHUB- 463: Fix trailing slash not staying when filtering on learn

### DIFF
--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo, useEffect, useState } from 'react';
 import styled from '@emotion/styled';
+import { withPrefix } from 'gatsby';
 import { Helmet } from 'react-helmet';
 import Layout from '../components/dev-hub/layout';
 import { H2 } from '../components/dev-hub/text';
@@ -239,12 +240,13 @@ export default ({
             const filter = stripAllParam(filterValue);
             const searchParams = buildQueryString(filter);
             const filteredArticles = filterActiveArticles(filter);
-            console.log(searchParams);
             setArticles(filteredArticles);
             if (window.location.search !== searchParams) {
                 // if the search params are empty, push the pathname state in order to remove params
                 navigate(
-                    searchParams === '' ? pathname : `/learn/${searchParams}`,
+                    searchParams === ''
+                        ? pathname
+                        : withPrefix(`/learn/${searchParams}`),
                     {
                         replace: true,
                     }

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -239,12 +239,16 @@ export default ({
             const filter = stripAllParam(filterValue);
             const searchParams = buildQueryString(filter);
             const filteredArticles = filterActiveArticles(filter);
+            console.log(searchParams);
             setArticles(filteredArticles);
             if (window.location.search !== searchParams) {
                 // if the search params are empty, push the pathname state in order to remove params
-                navigate(searchParams === '' ? pathname : searchParams, {
-                    replace: true,
-                });
+                navigate(
+                    searchParams === '' ? pathname : `/learn/${searchParams}`,
+                    {
+                        replace: true,
+                    }
+                );
             }
         },
         // Exclude "navigate" since it constantly changes


### PR DESCRIPTION
[Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/fix-slash-on-filters/)

This PR fixes a bug where the filters on the learn page unintentionally removed the trailing slash off of `/learn/`. We would like to keep this.

To test:
- Go to the learn page
- Turn on a filter (or any combination of filters)
- Verify the url has `/learn/?...`
- Remove filters
- Verify the url has `/learn/...`