### PR TITLE
Add missing keys to nav and featured home page items

### DIFF
--- a/src/components/dev-hub/global-nav.js
+++ b/src/components/dev-hub/global-nav.js
@@ -16,7 +16,7 @@ const MOBILE_NAV_BREAK = screenSize.upToLarge;
 // nav height is 58px: 24px line height + 2 * 17px vertical padding
 const LINK_VERTICAL_PADDING = '17px';
 
-const GlobalNav = styled('nav')`
+const Nav = styled('nav')`
     background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
     display: flex;
     flex-direction: column;
@@ -135,12 +135,12 @@ const MobileItems = ({ items }) => {
     );
 };
 
-export default () => {
+const GlobalNav = () => {
     const data = useStaticQuery(topNavItems);
     const items = dlv(data, ['strapiTopNav', 'items'], []);
     const isMobile = useMedia(MOBILE_NAV_BREAK);
     return (
-        <GlobalNav>
+        <Nav>
             <NavContent>
                 <HomeLink aria-label="Home" to="/">
                     <LeafLogo />
@@ -148,9 +148,11 @@ export default () => {
                 {isMobile ? (
                     <MobileItems items={items} />
                 ) : (
-                    items.map(item => <NavItem item={item} />)
+                    items.map(item => <NavItem key={item.name} item={item} />)
                 )}
             </NavContent>
-        </GlobalNav>
+        </Nav>
     );
 };
+
+export default GlobalNav;

--- a/src/components/pages/home/hero.js
+++ b/src/components/pages/home/hero.js
@@ -63,7 +63,7 @@ const Hero = ({ featuredItems }) => (
         <Sub>What will you create today?</Sub>
         <CardGallery>
             {featuredItems.map(item => (
-                <FeaturedHomePageItem item={item} />
+                <FeaturedHomePageItem key={item._id} item={item} />
             ))}
         </CardGallery>
         <div>


### PR DESCRIPTION
[Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/add-missing-keys/)

This PR adds missing `key` fields to two components:
- Top nav items
- Featured items on the home page

We were seeing console errors for these. This PR now resolves those. I also swapped to a named export for the `GlobalNav`