### PR TITLE
DEVHUB-313: Clear Image Dropzone State for Validation

### DIFF
--- a/src/components/pages/student-submit/form/image-dropzone.js
+++ b/src/components/pages/student-submit/form/image-dropzone.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { useDropzone } from 'react-dropzone';
@@ -67,9 +67,9 @@ const FullInput = styled('input')`
 `;
 
 // Adopted from https://react-dropzone.js.org/#section-previews
-const ImageDropzone = ({ maxFiles = 6 }) => {
+const ImageDropzone = ({ onChange, maxFiles = 6 }) => {
     const [files, setFiles] = useState([null, null, null, null, null, null]);
-    const { getRootProps, getInputProps } = useDropzone({
+    const { getRootProps, getInputProps, inputRef } = useDropzone({
         accept: 'image/*',
         onDrop: acceptedFiles => {
             const newFiles = [
@@ -80,6 +80,12 @@ const ImageDropzone = ({ maxFiles = 6 }) => {
                 ),
                 ...files,
             ].slice(0, maxFiles);
+            onChange({
+                target: {
+                    name: 'project_images',
+                    value: newFiles.filter(f => !!f),
+                },
+            });
             setFiles(newFiles);
         },
     });
@@ -91,6 +97,17 @@ const ImageDropzone = ({ maxFiles = 6 }) => {
             removeImage={() => {
                 const newFiles = [...files];
                 newFiles[index] = null;
+                const actualImages = newFiles.filter(f => !!f);
+                const hasNoImages = !actualImages.length;
+                onChange({
+                    target: {
+                        name: 'project_images',
+                        value: actualImages,
+                    },
+                });
+                if (hasNoImages) {
+                    inputRef.current.value = '';
+                }
                 setFiles(newFiles);
             }}
         />

--- a/src/components/pages/student-submit/form/image-dropzone.js
+++ b/src/components/pages/student-submit/form/image-dropzone.js
@@ -78,12 +78,7 @@ const ImageDropzone = ({ onChange, maxFiles = 6 }) => {
             ),
             ...files,
         ].slice(0, maxFiles);
-        onChange({
-            target: {
-                name: 'project_images',
-                value: newFiles.filter(f => !!f),
-            },
-        });
+        onChange(newFiles.filter(f => !!f));
         setFiles(newFiles);
     };
     const { getRootProps, getInputProps, inputRef } = useDropzone({
@@ -97,12 +92,7 @@ const ImageDropzone = ({ onChange, maxFiles = 6 }) => {
             newFiles[i] = null;
             const actualImages = newFiles.filter(f => !!f);
             const hasNoImages = !actualImages.length;
-            onChange({
-                target: {
-                    name: 'project_images',
-                    value: actualImages,
-                },
-            });
+            onChange(actualImages);
             if (hasNoImages) {
                 inputRef.current.value = '';
             }

--- a/src/components/pages/student-submit/form/index.js
+++ b/src/components/pages/student-submit/form/index.js
@@ -19,8 +19,10 @@ const Form = () => {
     const scrollToRef = ref =>
         window.scrollTo({ behavior: 'smooth', top: ref.current.offsetTop });
 
-    const onChange = e =>
-        dispatch({ field: e.target.name, value: e.target.value });
+    const onChange = useCallback(
+        e => dispatch({ field: e.target.name, value: e.target.value }),
+        [dispatch]
+    );
 
     const onStudentChange = i => e =>
         dispatch({ field: e.target.name, student: i, value: e.target.value });

--- a/src/components/pages/student-submit/form/project-info.js
+++ b/src/components/pages/student-submit/form/project-info.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import styled from '@emotion/styled';
 import Input from '~components/dev-hub/input';
 import ImageDropzone from './image-dropzone';
@@ -23,54 +23,71 @@ const FormInput = ({ required = true, ...props }) => (
     <Input narrow required={required} {...props} />
 );
 
-const ProjectInfo = ({ state, onChange, ...props }) => (
-    <SubmitFormFieldset buttonText="Next" legendText="Project Info" {...props}>
-        <FormInput
-            name="project_name"
-            onChange={onChange}
-            placeholder="Project Name"
-            value={state.project_name}
-        />
-        <FormInput
-            name="short_description"
-            onChange={onChange}
-            placeholder="Short description of project"
-            value={state.short_description}
-        />
-        <FormInput
-            name="tools_used"
-            onChange={onChange}
-            placeholder="Tools used (separate each tool with a comma)"
-            value={state.tools_used}
-        />
-        <LinksSection>
+const ProjectInfo = ({ state, onChange, ...props }) => {
+    const onImageDropzoneChange = useCallback(
+        images => {
+            onChange({
+                target: {
+                    name: 'project_images',
+                    value: images,
+                },
+            });
+        },
+        [onChange]
+    );
+    return (
+        <SubmitFormFieldset
+            buttonText="Next"
+            legendText="Project Info"
+            {...props}
+        >
             <FormInput
-                name="github_link"
+                name="project_name"
                 onChange={onChange}
-                placeholder="GitHub Link"
-                type="url"
-                value={state.github_link}
+                placeholder="Project Name"
+                value={state.project_name}
             />
+            <FormInput
+                name="short_description"
+                onChange={onChange}
+                placeholder="Short description of project"
+                value={state.short_description}
+            />
+            <FormInput
+                name="tools_used"
+                onChange={onChange}
+                placeholder="Tools used (separate each tool with a comma)"
+                value={state.tools_used}
+            />
+            <LinksSection>
+                <FormInput
+                    name="github_link"
+                    onChange={onChange}
+                    placeholder="GitHub Link"
+                    type="url"
+                    value={state.github_link}
+                />
+                <FormInput
+                    required={false}
+                    name="project_link"
+                    onChange={onChange}
+                    placeholder="Other Project Link"
+                    type="url"
+                    value={state.project_link}
+                />
+            </LinksSection>
+            <H5>Show off with images and video</H5>
+            <ImageDropzone onChange={onImageDropzoneChange} />
             <FormInput
                 required={false}
-                name="project_link"
+                name="youtube_link"
                 onChange={onChange}
-                placeholder="Other Project Link"
+                placeholder="YouTube Video Demo Link"
                 type="url"
-                value={state.project_link}
+                value={state.youtube_link}
             />
-        </LinksSection>
-        <H5>Show off with images and video</H5>
-        <ImageDropzone onChange={onChange} />
-        <FormInput
-            required={false}
-            name="youtube_link"
-            onChange={onChange}
-            placeholder="YouTube Video Demo Link"
-            type="url"
-            value={state.youtube_link}
-        />
-    </SubmitFormFieldset>
-);
+        </SubmitFormFieldset>
+    );
+};
 
 export default ProjectInfo;

--- a/src/components/pages/student-submit/form/project-info.js
+++ b/src/components/pages/student-submit/form/project-info.js
@@ -61,7 +61,7 @@ const ProjectInfo = ({ state, onChange, ...props }) => (
             />
         </LinksSection>
         <H5>Show off with images and video</H5>
-        <ImageDropzone />
+        <ImageDropzone onChange={onChange} />
         <FormInput
             required={false}
             name="youtube_link"


### PR DESCRIPTION
[Staging Link](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-313-images/academia/students/submit/)

This PR adds in the state of the image dropzone properly into our reducer and also allows for proper validation when all images are removed. Using the available ref on the dropzone, we can hook into the `input` and clear the value if there are no more images we are tracking. The only programatic value that can be used for an `input type="file"` is the empty string, so that is why we chose it here.