### PR TITLE
DEVHUB-312 [Part 2]: Properly track form expand states

### DIFF
--- a/src/components/pages/student-submit/form/index.js
+++ b/src/components/pages/student-submit/form/index.js
@@ -25,8 +25,15 @@ const Form = () => {
         [dispatch]
     );
 
-    const onStudentChange = i => e =>
-        dispatch({ field: e.target.name, student: i, value: e.target.value });
+    const onStudentChange = useCallback(
+        i => e =>
+            dispatch({
+                field: e.target.name,
+                student: i,
+                value: e.target.value,
+            }),
+        [dispatch]
+    );
 
     const onFormPartCompletion = useCallback(
         (e, i, ref, isFinalPart = false) => {

--- a/src/components/pages/student-submit/form/index.js
+++ b/src/components/pages/student-submit/form/index.js
@@ -29,27 +29,24 @@ const Form = () => {
         dispatch({ field: e.target.name, student: i, value: e.target.value });
 
     const onFormPartCompletion = useCallback(
-        (e, i, initialRef, nextRef) => {
+        (e, i, ref, isFinalPart = false) => {
             e.preventDefault();
-            const currentFieldset = initialRef.current;
+            const currentFieldset = ref.current;
             const fieldsetElements = Array.from(currentFieldset.elements);
-            // Last entry of fieldset is the button to move on to the next fieldset
-            // We do not need to consider it when checking validity
-            fieldsetElements.pop();
             const isValid = fieldsetElements.reduce(
                 (p, c) => p && c.checkValidity(),
                 true
             );
             if (isValid) {
-                if (nextRef) {
+                if (isFinalPart) {
+                    // TODO: this is the last part, submit form
+                    return;
+                } else {
                     const newOpen = [...fieldsetsOpen];
                     newOpen[i] = false;
                     newOpen[i + 1] = true;
                     setFieldsetsOpen(newOpen);
-                    scrollToRef(nextRef);
-                } else {
-                    // TODO: this is the last part, submit form
-                    return;
+                    scrollToRef(ref);
                 }
             } else {
                 // Browser method to show validity messages
@@ -60,15 +57,15 @@ const Form = () => {
     );
 
     const onFirstPartComplete = useCallback(
-        e => onFormPartCompletion(e, 0, fieldsetOneRef, fieldsetTwoRef),
-        [fieldsetOneRef, fieldsetTwoRef, onFormPartCompletion]
+        e => onFormPartCompletion(e, 0, fieldsetOneRef),
+        [fieldsetOneRef, onFormPartCompletion]
     );
     const onSecondPartComplete = useCallback(
-        e => onFormPartCompletion(e, 1, fieldsetTwoRef, fieldsetThreeRef),
-        [fieldsetThreeRef, fieldsetTwoRef, onFormPartCompletion]
+        e => onFormPartCompletion(e, 1, fieldsetTwoRef),
+        [fieldsetTwoRef, onFormPartCompletion]
     );
     const onFinalPartComplete = useCallback(
-        e => onFormPartCompletion(e, 2, fieldsetThreeRef),
+        e => onFormPartCompletion(e, 2, fieldsetThreeRef, true),
         [fieldsetThreeRef, onFormPartCompletion]
     );
 

--- a/src/components/pages/student-submit/form/new-student-fieldset.js
+++ b/src/components/pages/student-submit/form/new-student-fieldset.js
@@ -59,7 +59,6 @@ const FormInput = ({ required = true, ...props }) => (
 
 const NewStudentFieldset = ({
     authorImage,
-    onAddTeamMember,
     onChange,
     setActivePicture,
     state,
@@ -82,10 +81,6 @@ const NewStudentFieldset = ({
         },
         [setActivePicture]
     );
-    const addAnotherTeamMemberIfValid = useCallback(() => {
-        // Validate
-        onAddTeamMember();
-    }, [onAddTeamMember]);
     return (
         <>
             <LinksSection>
@@ -179,9 +174,6 @@ const NewStudentFieldset = ({
                 required={false}
                 placeholder="Personal Website"
             />
-            <Button onClick={addAnotherTeamMemberIfValid}>
-                + Add another team member
-            </Button>
         </>
     );
 };

--- a/src/components/pages/student-submit/form/promote-yourself.js
+++ b/src/components/pages/student-submit/form/promote-yourself.js
@@ -83,7 +83,7 @@ const PromoteYourself = ({
             }
             const result = newStudents.map((s, idx) => ({
                 ...s,
-                isExpanded: i === idx ? true : false,
+                isExpanded: i === idx,
             }));
             updateStudents(result);
             // else validate then open at i

--- a/src/components/pages/student-submit/form/promote-yourself.js
+++ b/src/components/pages/student-submit/form/promote-yourself.js
@@ -1,49 +1,24 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useState } from 'react';
+import { STUDENT_DEFAULT_KEYS } from '~utils/student-spotlight-reducer';
+import styled from '@emotion/styled';
 import Button from '~components/dev-hub/button';
+import SingleStudentFieldset from './single-student-fieldset';
 import SubmitFormFieldset from './submit-form-fieldset';
-import CondensedStudentEntry from './condensed-student-entry';
-import NewStudentFieldset from './new-student-fieldset';
 
-const SingleStudentFieldset = ({
-    isExpanded,
-    onChange,
-    onEdit,
-    onRemove,
-    state,
-}) => {
-    const [activePicture, setActivePicture] = useState(null);
-    const hasActivePicture = !!activePicture;
-
-    const authorImage = useMemo(
-        () => hasActivePicture && URL.createObjectURL(activePicture),
-        [activePicture, hasActivePicture]
-    );
-
-    return isExpanded ? (
-        <NewStudentFieldset
-            authorImage={authorImage}
-            setActivePicture={setActivePicture}
-            onChange={onChange}
-            state={state}
-        />
-    ) : (
-        <CondensedStudentEntry
-            authorImage={authorImage}
-            state={state}
-            onEdit={onEdit}
-            onRemove={onRemove}
-        />
-    );
-};
+const RightAligned = styled('div')`
+    display: flex;
+    justify-content: flex-end;
+`;
 
 const isEmpty = student => {
     const keys = Object.keys(student);
-    const searchKeys = keys.filter(k => !['key', 'isExpanded'].includes(k));
+    const searchKeys = keys.filter(k => !STUDENT_DEFAULT_KEYS.includes(k));
     return searchKeys.reduce((p, c) => p && !student[c], true);
 };
 
 const PromoteYourself = ({
     dispatch,
+    newRef,
     onComplete,
     onStudentChange,
     state,
@@ -58,8 +33,17 @@ const PromoteYourself = ({
         value => dispatch({ field: 'students', value }),
         [dispatch]
     );
+    const removeLastStudentIfEmpty = useCallback(() => {
+        const lastStudent = state.students[state.students.length - 1];
+        const newStudents = [...state.students];
+        if (isEmpty(lastStudent)) {
+            newStudents.splice(-1);
+        }
+        return newStudents;
+    }, [state.students]);
     const addNewStudent = useCallback(() => {
-        if (props.newRef.current.form.checkValidity()) {
+        const form = newRef.current.form;
+        if (form.checkValidity()) {
             // Whenever we add a student, increment the total to ensure a unique key
             setNumStudents(numStudents + 1);
             const newStudents = state.students.map(s => ({
@@ -70,25 +54,20 @@ const PromoteYourself = ({
             newStudents.push({ key: numStudents, isExpanded: true });
             updateStudents(newStudents);
         } else {
-            props.newRef.current.form.reportValidity();
+            form.reportValidity();
         }
-    }, [props.newRef, numStudents, state, updateStudents]);
+    }, [newRef, numStudents, state.students, updateStudents]);
     const editStudent = useCallback(
         i => () => {
-            // if last student is empty, remove
-            const lastStudent = state.students[state.students.length - 1];
-            const newStudents = [...state.students];
-            if (isEmpty(lastStudent)) {
-                newStudents.splice(-1);
-            }
+            const newStudents = removeLastStudentIfEmpty();
+            // Close all entries except this one
             const result = newStudents.map((s, idx) => ({
                 ...s,
                 isExpanded: i === idx,
             }));
             updateStudents(result);
-            // else validate then open at i
         },
-        [state.students, updateStudents]
+        [removeLastStudentIfEmpty, updateStudents]
     );
     const removeStudent = useCallback(
         i => () => {
@@ -101,26 +80,22 @@ const PromoteYourself = ({
 
     const onStudentFormComplete = useCallback(
         e => {
-            const lastStudent = state.students[state.students.length - 1];
-            if (isEmpty(lastStudent)) {
-                const newStudents = [...state.students];
-                newStudents.splice(-1);
-                updateStudents(newStudents);
-            }
+            const newStudents = removeLastStudentIfEmpty();
+            updateStudents(newStudents);
             onComplete(e);
         },
-        [onComplete, state.students, updateStudents]
+        [onComplete, removeLastStudentIfEmpty, updateStudents]
     );
     return (
         <SubmitFormFieldset
             buttonText="Submit"
             legendText="Promote Yourself"
+            newRef={newRef}
             onComplete={onStudentFormComplete}
             {...props}
         >
             {state.students.map((s, i) => (
                 <SingleStudentFieldset
-                    addNewStudent={addNewStudent}
                     onEdit={editStudent(i)}
                     isExpanded={s.isExpanded}
                     key={s.key}
@@ -129,7 +104,11 @@ const PromoteYourself = ({
                     state={s}
                 />
             ))}
-            <Button onClick={addNewStudent}>+ Add another team member</Button>
+            <RightAligned>
+                <Button onClick={addNewStudent}>
+                    + Add another team member
+                </Button>
+            </RightAligned>
         </SubmitFormFieldset>
     );
 };

--- a/src/components/pages/student-submit/form/promote-yourself.js
+++ b/src/components/pages/student-submit/form/promote-yourself.js
@@ -34,6 +34,10 @@ const PromoteYourself = ({
         [dispatch]
     );
     const removeLastStudentIfEmpty = useCallback(() => {
+        // Don't allow an empty submission
+        if (state.students.length === 1) {
+            return [...state.students];
+        }
         const lastStudent = state.students[state.students.length - 1];
         const newStudents = [...state.students];
         if (isEmpty(lastStudent)) {

--- a/src/components/pages/student-submit/form/promote-yourself.js
+++ b/src/components/pages/student-submit/form/promote-yourself.js
@@ -5,9 +5,9 @@ import CondensedStudentEntry from './condensed-student-entry';
 import NewStudentFieldset from './new-student-fieldset';
 
 const SingleStudentFieldset = ({
-    onEdit,
     isExpanded,
     onChange,
+    onEdit,
     onRemove,
     state,
 }) => {
@@ -34,6 +34,12 @@ const SingleStudentFieldset = ({
             onRemove={onRemove}
         />
     );
+};
+
+const isEmpty = student => {
+    const keys = Object.keys(student);
+    const searchKeys = keys.filter(k => !['key', 'isExpanded'].includes(k));
+    return searchKeys.reduce((p, c) => p && !student[c], true);
 };
 
 const PromoteYourself = ({
@@ -72,7 +78,7 @@ const PromoteYourself = ({
             // if last student is empty, remove
             const lastStudent = state.students[state.students.length - 1];
             const newStudents = [...state.students];
-            if (Object.keys(lastStudent).length === 2) {
+            if (isEmpty(lastStudent)) {
                 newStudents.splice(-1);
             }
             const result = newStudents.map((s, idx) => ({
@@ -96,8 +102,7 @@ const PromoteYourself = ({
     const onStudentFormComplete = useCallback(
         e => {
             const lastStudent = state.students[state.students.length - 1];
-            // Also need to check nulls
-            if (Object.keys(lastStudent).length === 2) {
+            if (isEmpty(lastStudent)) {
                 const newStudents = [...state.students];
                 newStudents.splice(-1);
                 updateStudents(newStudents);

--- a/src/components/pages/student-submit/form/single-student-fieldset.js
+++ b/src/components/pages/student-submit/form/single-student-fieldset.js
@@ -1,0 +1,37 @@
+import React, { useMemo, useState } from 'react';
+import CondensedStudentEntry from './condensed-student-entry';
+import NewStudentFieldset from './new-student-fieldset';
+
+const SingleStudentFieldset = ({
+    isExpanded,
+    onChange,
+    onEdit,
+    onRemove,
+    state,
+}) => {
+    const [activePicture, setActivePicture] = useState(null);
+    const hasActivePicture = !!activePicture;
+
+    const authorImage = useMemo(
+        () => hasActivePicture && URL.createObjectURL(activePicture),
+        [activePicture, hasActivePicture]
+    );
+
+    return isExpanded ? (
+        <NewStudentFieldset
+            authorImage={authorImage}
+            setActivePicture={setActivePicture}
+            onChange={onChange}
+            state={state}
+        />
+    ) : (
+        <CondensedStudentEntry
+            authorImage={authorImage}
+            state={state}
+            onEdit={onEdit}
+            onRemove={onRemove}
+        />
+    );
+};
+
+export default SingleStudentFieldset;

--- a/src/utils/student-spotlight-reducer.js
+++ b/src/utils/student-spotlight-reducer.js
@@ -2,6 +2,10 @@ export const initialStudentSpotlightState = () => ({
     students: [{ key: 0, isExpanded: true }],
 });
 
+export const STUDENT_DEFAULT_KEYS = Object.keys(
+    initialStudentSpotlightState()['students'][0]
+);
+
 const isUpdatingStudents = studentIndex => Number.isInteger(studentIndex);
 
 export const studentSpotlightReducer = (state, { field, student, value }) => {

--- a/src/utils/student-spotlight-reducer.js
+++ b/src/utils/student-spotlight-reducer.js
@@ -1,5 +1,5 @@
 export const initialStudentSpotlightState = () => ({
-    students: [{ key: 0 }],
+    students: [{ key: 0, isExpanded: true }],
 });
 
 const isUpdatingStudents = studentIndex => Number.isInteger(studentIndex);


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-312-multiple-edit/academia/students/submit/)

This PR addresses the need to manage when elements in the form expand/collapse between sections as well as working with multiple students. I went for the array approach since it is scalable and straight forward to understand, although with all the spreads I am sure somewhere we can improve performance slightly.

The key for students is in our representation if the last student is "empty" (meaning any field that isn't a default one for state is null), we remove it which helps keep our state in order.