### PR TITLE
DEVHUB-478: Make GitHub URL not required

### DIFF
--- a/src/components/pages/student-submit/form/project-info.js
+++ b/src/components/pages/student-submit/form/project-info.js
@@ -61,6 +61,7 @@ const ProjectInfo = ({ state, onChange, ...props }) => {
             />
             <LinksSection>
                 <FormInput
+                    required={false}
                     name="github_url"
                     onChange={onChange}
                     placeholder="GitHub Link"


### PR DESCRIPTION
[Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-478/academia/students/submit/)
[JIRA](https://jira.mongodb.org/browse/DEVHUB-478)

This PR removes client-side requirement of the GitHub URL on the student spotlight form. This already is not required by the CMS so removing this validation is all we needed to do in order for it to be optional.