### PR TITLE
DEVHUB-444 [Part 1]: Begin Implementing Grid

### DIFF
--- a/src/components/dev-hub/article-share-footer.js
+++ b/src/components/dev-hub/article-share-footer.js
@@ -30,7 +30,7 @@ const BlogShareLinks = styled('div')`
     }
 `;
 
-const ArticleShareFooter = ({ tags, title, url }) => {
+const ArticleShareFooter = ({ tags, title, url, ...props }) => {
     const {
         articleUrl,
         facebookUrl,
@@ -41,7 +41,7 @@ const ArticleShareFooter = ({ tags, title, url }) => {
         copy(articleUrl);
     }, [articleUrl]);
     return (
-        <ArticleShareArea>
+        <ArticleShareArea {...props}>
             <BlogTagList tags={tags} />
             <BlogShareLinks data-test="article-share-links">
                 <Tooltip

--- a/src/components/dev-hub/grid.js
+++ b/src/components/dev-hub/grid.js
@@ -1,5 +1,4 @@
 import React, { useMemo } from 'react';
-import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { GridLayout } from '../../utils/grid-layout';
 import { size } from './theme';

--- a/src/components/dev-hub/project-title-area.js
+++ b/src/components/dev-hub/project-title-area.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import useMedia from '~hooks/use-media';
 import HeroBanner from './hero-banner';
 import ImageGallery from './image-gallery';
 import Link from './link';
@@ -38,7 +39,7 @@ const TopRow = styled('div')`
 
 const ProjectTitleArea = ({ description, images, title, url }) => {
     const BlogTitle = IncreasedMarginH2.withComponent('h1');
-
+    const isMobile = useMedia(screenSize.upToMedium);
     return (
         <IncreasedMarginHeroBanner
             showImageOnMobile={false}
@@ -48,7 +49,7 @@ const ProjectTitleArea = ({ description, images, title, url }) => {
             <TopRow>
                 <BlogTitle>{title}</BlogTitle>
                 <ShareMenu
-                    position="left"
+                    position={isMobile ? 'right' : 'left'}
                     title={title}
                     Trigger={<Link>Share</Link>}
                     url={url}

--- a/src/components/dev-hub/project-title-area.js
+++ b/src/components/dev-hub/project-title-area.js
@@ -5,7 +5,7 @@ import ImageGallery from './image-gallery';
 import Link from './link';
 import ShareMenu from './share-menu';
 import { H2 } from './text';
-import { size } from './theme';
+import { screenSize, size } from './theme';
 
 const STUDENT_SPOTLIGHT_BREADCRUMBS = [
     { label: 'Home', target: '/' },
@@ -15,19 +15,30 @@ const STUDENT_SPOTLIGHT_BREADCRUMBS = [
 
 const IncreasedMarginH2 = styled(H2)`
     margin-bottom: ${size.medium};
+    @media ${screenSize.upToMedium} {
+        margin-bottom: ${size.xsmall};
+    }
 `;
 
 const TopRow = styled('div')`
     align-items: baseline;
     display: flex;
     justify-content: space-between;
+    @media ${screenSize.upToMedium} {
+        flex-direction: column;
+        margin-bottom: ${size.medium};
+    }
 `;
 
 const ProjectTitleArea = ({ description, images, title, url }) => {
     const BlogTitle = IncreasedMarginH2.withComponent('h1');
 
     return (
-        <HeroBanner breadcrumb={STUDENT_SPOTLIGHT_BREADCRUMBS} fullWidth>
+        <HeroBanner
+            showImageOnMobile={false}
+            breadcrumb={STUDENT_SPOTLIGHT_BREADCRUMBS}
+            fullWidth
+        >
             <TopRow>
                 <BlogTitle>{title}</BlogTitle>
                 <ShareMenu

--- a/src/components/dev-hub/project-title-area.js
+++ b/src/components/dev-hub/project-title-area.js
@@ -13,6 +13,12 @@ const STUDENT_SPOTLIGHT_BREADCRUMBS = [
     { label: 'Student Spotlights', target: '/academia/students' },
 ];
 
+const IncreasedMarginHeroBanner = styled(HeroBanner)`
+    @media ${screenSize.upToLarge} {
+        margin-bottom: 30px;
+    }
+`;
+
 const IncreasedMarginH2 = styled(H2)`
     margin-bottom: ${size.medium};
     @media ${screenSize.upToMedium} {
@@ -34,7 +40,7 @@ const ProjectTitleArea = ({ description, images, title, url }) => {
     const BlogTitle = IncreasedMarginH2.withComponent('h1');
 
     return (
-        <HeroBanner
+        <IncreasedMarginHeroBanner
             showImageOnMobile={false}
             breadcrumb={STUDENT_SPOTLIGHT_BREADCRUMBS}
             fullWidth
@@ -49,7 +55,7 @@ const ProjectTitleArea = ({ description, images, title, url }) => {
                 />
             </TopRow>
             <ImageGallery description={description} images={images} />
-        </HeroBanner>
+        </IncreasedMarginHeroBanner>
     );
 };
 

--- a/src/components/dev-hub/student-spotlight/github-student-pack.js
+++ b/src/components/dev-hub/student-spotlight/github-student-pack.js
@@ -3,12 +3,15 @@ import styled from '@emotion/styled';
 import githubStudentPackPng from '../../../images/github-backpack-mongo.png';
 import Link from '../link';
 import MediaBlock from '../media-block';
-import { H4, P } from '../text';
+import { H4, P, P2 } from '../text';
 import { screenSize, size } from '../theme';
 
 const StyledMediaBlock = styled(MediaBlock)`
     background-color: ${({ theme }) => theme.colorMap.devBlack};
     padding: ${size.xlarge} ${size.xxlarge};
+    @media ${screenSize.upToMedium} {
+        padding: ${size.large} ${size.default} 48px;
+    }
 `;
 
 const LightText = styled(P)`
@@ -33,9 +36,11 @@ const Centered = styled('div')`
     }
 `;
 
-const StyledLink = styled(Link)`
+const WhiteLink = styled(Link)`
     color: ${({ theme }) => theme.colorMap.devWhite};
 `;
+
+const StyledLink = P2.withComponent(WhiteLink);
 
 const GithubBackpackImg = () => (
     <ImageContainer>

--- a/src/components/dev-hub/theme.js
+++ b/src/components/dev-hub/theme.js
@@ -54,18 +54,6 @@ const size = {
         return parseInt(unit, 10);
     },
 };
-const gridLayout = {
-    columnGap: '24px',
-    numCols: 12,
-    sideMargin: size.xxlarge,
-};
-
-const grid = css`
-    display: grid;
-    grid-template-columns: repeat(${gridLayout.numCols}, 1fr);
-    column-gap: ${gridLayout.columnGap};
-    margin: 0 ${gridLayout.sideMargin};
-`;
 
 const colorMap = {
     darkGreen: '#13AA52',
@@ -196,6 +184,41 @@ const screenSize = {
     upToXlarge: `only screen and (max-width: ${size.maxWidth})`,
     xlargeAndUp: `not all and (max-width: ${size.maxWidth})`,
 };
+
+const gridLayout = {
+    desktop: {
+        columnGap: '24px',
+        numCols: 12,
+        sideMargin: size.xxlarge,
+    },
+    mobile: {
+        columnGap: size.default,
+        numCols: 4,
+        sideMargin: size.default,
+    },
+    tablet: {
+        columnGap: size.default,
+        numCols: 8,
+        sideMargin: size.xlarge,
+    },
+};
+
+const grid = css`
+    display: grid;
+    grid-template-columns: repeat(${gridLayout.desktop.numCols}, 1fr);
+    column-gap: ${gridLayout.desktop.columnGap};
+    margin: 0 ${gridLayout.desktop.sideMargin};
+    @media ${screenSize.upToLarge} {
+        grid-template-columns: repeat(${gridLayout.tablet.numCols}, 1fr);
+        column-gap: ${gridLayout.tablet.columnGap};
+        margin: 0 ${gridLayout.tablet.sideMargin};
+    }
+    @media ${screenSize.upToMedium} {
+        grid-template-columns: repeat(${gridLayout.mobile.numCols}, 1fr);
+        column-gap: ${gridLayout.mobile.columnGap};
+        margin: 0 ${gridLayout.mobile.sideMargin};
+    }
+`;
 
 /**
  * z-index values in ranges of 10. This should give enough leeway to incremement in components as needed.

--- a/src/components/pages/project/tools-used.js
+++ b/src/components/pages/project/tools-used.js
@@ -4,7 +4,7 @@ import { H5 } from '~components/dev-hub/text';
 
 const ToolsUsed = ({ tags, ...props }) => (
     <div {...props}>
-        <H5 collapse>Tools Used</H5>
+        <H5>Tools Used</H5>
         <BlogTagList navigates={false} tags={tags} />
     </div>
 );

--- a/src/components/pages/students/gallery-hero-banner.js
+++ b/src/components/pages/students/gallery-hero-banner.js
@@ -3,10 +3,18 @@ import styled from '@emotion/styled';
 import Button from '~components/dev-hub/button';
 import HeroBanner from '~components/dev-hub/hero-banner';
 import { H2, P } from '~components/dev-hub/text';
+import { screenSize, size } from '~components/dev-hub/theme';
 
 const BannerContentLayout = styled('div')`
     display: flex;
     justify-content: space-between;
+    @media ${screenSize.upToMedium} {
+        display: block;
+    }
+`;
+
+const MobileMarginBottom = styled('div')`
+    margin-bottom: ${size.medium};
 `;
 
 const ShowOffButton = styled(Button)`
@@ -19,12 +27,16 @@ const GalleryHeroBanner = () => {
         { label: 'MongoDB for Academia', target: '/academia' },
     ];
     return (
-        <HeroBanner fullWidth breadcrumb={academiaBreadcrumbs}>
+        <HeroBanner
+            showImageOnMobile={false}
+            fullWidth
+            breadcrumb={academiaBreadcrumbs}
+        >
             <BannerContentLayout>
-                <div>
+                <MobileMarginBottom>
                     <H2>Student Spotlights</H2>
-                    <P>Projects created by students, for students</P>
-                </div>
+                    <P collapse>Projects created by students, for students</P>
+                </MobileMarginBottom>
                 <ShowOffButton primary to="/academia/students/submit">
                     Show off your project
                 </ShowOffButton>

--- a/src/templates/project.js
+++ b/src/templates/project.js
@@ -35,9 +35,24 @@ const ArticleContent = styled('article')`
     padding-left: ${size.small};
     padding-right: ${size.small};
     @media ${screenSize.upToLarge} {
+        grid-column: 1 / 6;
         margin: 0 auto;
     }
+    @media ${screenSize.upToMedium} {
+        grid-column: 1 / 5;
+    }
 `;
+
+const ArticleShareFooterFull = styled(ArticleShareFooter)`
+    grid-column: 2 / 12;
+    @media ${screenSize.upToLarge} {
+        grid-column: 1 / 9;
+    }
+    @media ${screenSize.upToMedium} {
+        grid-column: 1 / 5;
+    }
+`;
+
 const Container = styled('div')`
     ${grid};
     justify-content: center;
@@ -45,6 +60,12 @@ const Container = styled('div')`
 
 const InfoSidebar = styled('div')`
     grid-column: 9 / 12;
+    @media ${screenSize.upToLarge} {
+        grid-column: 7 / 9;
+    }
+    @media ${screenSize.upToMedium} {
+        grid-column: 1 / 5;
+    }
 `;
 
 const TopPaddedShareProjectCTA = styled(ShareProjectCTA)`
@@ -88,11 +109,6 @@ const Project = props => {
                         slug={slug}
                         {...props}
                     />
-                    <ArticleShareFooter
-                        title={name}
-                        url={projectUrl}
-                        tags={[]}
-                    />
                 </ArticleContent>
                 <InfoSidebar>
                     <SidebarContent
@@ -102,6 +118,11 @@ const Project = props => {
                         tags={tags}
                     />
                 </InfoSidebar>
+                <ArticleShareFooterFull
+                    title={name}
+                    url={projectUrl}
+                    tags={[]}
+                />
             </Container>
             <AdditionalProjects excludedProjectName={name} />
             <TopPaddedShareProjectCTA />


### PR DESCRIPTION
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-444-grid/)

This PR begins to work on mobile-responsiveness for student spotlights by using the given `grid` and adding new tablet/mobile values to it. This is a checkpoint as there is still more work to be done, but here is a list of changes:
- Uses new tablet/mobile grids on the project pages
- Swaps layout of top elements on project pages
- Removes extreme padding from GH student pack component on mobile
- Drops GH student pack link sizing to P2
- Moves ArticleShareFooter into new slot on grid