### PR TITLE
DEVHUB-444 [Part 3]: Add Mobile Options to Grid

### DIFF
--- a/src/components/dev-hub/grid.js
+++ b/src/components/dev-hub/grid.js
@@ -1,7 +1,8 @@
 import React, { useMemo } from 'react';
 import styled from '@emotion/styled';
+import useMedia from '~hooks/use-media';
 import { GridLayout } from '../../utils/grid-layout';
-import { size } from './theme';
+import { screenSize, size } from './theme';
 
 const GridContainer = styled('div')`
     display: grid;
@@ -25,14 +26,21 @@ const gridSpan = ({ rowSpan, colSpan }) => ({
 const Grid = ({
     children,
     layout,
+    mobileLayout,
+    mobileNumCols,
     numCols,
     gridGap = size.default,
     rowHeight = '1fr',
     ...props
 }) => {
+    const isMobile = useMedia(screenSize.upToMedium);
+    const activeLayout = useMemo(
+        () => (isMobile ? mobileLayout || layout : layout),
+        [isMobile, layout, mobileLayout]
+    );
     const gridLayout = useMemo(
-        () => new GridLayout(layout.rowSpan, layout.colSpan),
-        [layout]
+        () => new GridLayout(activeLayout.rowSpan, activeLayout.colSpan),
+        [activeLayout]
     );
     const gridElements = useMemo(
         () =>
@@ -51,7 +59,7 @@ const Grid = ({
         <GridContainer
             gridGap={gridGap}
             rowHeight={rowHeight}
-            layoutCols={numCols}
+            layoutCols={isMobile ? mobileNumCols || numCols : numCols}
             {...props}
         >
             {gridElements}

--- a/src/components/pages/academia/project-grid.js
+++ b/src/components/pages/academia/project-grid.js
@@ -54,6 +54,11 @@ const ProjectGrid = () => {
                         rowSpan: [2, 1, 1, 1],
                         colSpan: [2, 2, 1, 1],
                     }}
+                    mobileNumCols={2}
+                    mobileLayout={{
+                        rowSpan: [2, 1, 1, 1],
+                        colSpan: [2, 2, 1, 1],
+                    }}
                     rowHeight="250px"
                 >
                     {mappedProjects.map(project => (

--- a/src/components/pages/project/additional-projects.js
+++ b/src/components/pages/project/additional-projects.js
@@ -13,6 +13,7 @@ import Button from '~components/dev-hub/button';
 const GRID_COL_GAP = '24px';
 const GRID_LAYOUT = { rowSpan: [1], colSpan: [1] };
 const GRID_ROW_HEIGHT = '282px';
+const MOBILE_GRID_LAYOUT = { rowSpan: [1], colSpan: [2] };
 const NUM_ADDITIONAL_PROJECTS = 4;
 
 // Limit is NUM_ADDITIONAL_PROJECTS + 1, but no interpolation in gql queries
@@ -78,6 +79,7 @@ const AdditionalProjects = ({ excludedProjectName }) => {
                 <FullLengthGrid
                     gridGap={GRID_COL_GAP}
                     layout={GRID_LAYOUT}
+                    mobileLayout={MOBILE_GRID_LAYOUT}
                     numCols={NUM_ADDITIONAL_PROJECTS}
                     rowHeight={GRID_ROW_HEIGHT}
                 >

--- a/src/components/pages/students/all-projects.js
+++ b/src/components/pages/students/all-projects.js
@@ -37,6 +37,10 @@ const AllProjects = () => {
         () => ({ rowSpan: [1], colSpan: [2, 1, 1, 1, 1, 1, 2] }),
         []
     );
+    const mobileGridLayout = useMemo(
+        () => ({ rowSpan: [1], colSpan: [2, 1, 1] }),
+        []
+    );
     const data = useStaticQuery(allGalleryProjects);
     const projects = dlv(data, ['allStrapiProjects', 'nodes'], []);
     const mappedProjects = useMemo(
@@ -46,8 +50,10 @@ const AllProjects = () => {
     const gridProps = {
         gridGap: '48px',
         rowHeight: GRID_ROW_HEIGHT,
+        mobileNumCols: 2,
         numCols: 3,
         layout: gridLayout,
+        mobileLayout: mobileGridLayout,
     };
     return (
         <AllProjectsContainer>


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-444-grid-ratio/)

This PR begins to add some mobile props to the Grid to allow for better-responsive layouts. With this we currently updated the grid on the academia entry page, gallery page, and project pages