### PR TITLE
DEVHUB-444 [Part 4] - Maintain 1:1 Aspect Ratio for Grid

### DIFF
--- a/src/components/dev-hub/author-image-list.js
+++ b/src/components/dev-hub/author-image-list.js
@@ -22,14 +22,14 @@ const AuthorImageList = ({
     ...props
 }) => (
     <AuthorImageContainer {...props}>
-        {students.map(({ name, image_url }) => (
+        {students.map(({ image_url }) => (
             <StyledAuthorImage
                 gradientOffset={4}
                 hideOnMobile={false}
                 height={size}
                 width={size}
                 image={image_url}
-                key={name}
+                key={image_url}
             />
         ))}
     </AuthorImageContainer>

--- a/src/components/dev-hub/grid.js
+++ b/src/components/dev-hub/grid.js
@@ -1,5 +1,4 @@
 import React, { useMemo, useRef } from 'react';
-import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import useMedia from '~hooks/use-media';
 import { GridLayout } from '../../utils/grid-layout';

--- a/src/components/dev-hub/grid.js
+++ b/src/components/dev-hub/grid.js
@@ -1,13 +1,23 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
+import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import useMedia from '~hooks/use-media';
 import { GridLayout } from '../../utils/grid-layout';
 import { screenSize, size } from './theme';
+import { useRefDimensions } from '~hooks/use-ref-dimensions';
+
+const calculateGridRowHeight = (totalWidth, gridGap, layoutCols) => `calc(
+        (
+                ${totalWidth}px -
+                    ${(layoutCols - 1) * size.stripUnit(gridGap)}px
+            ) / ${layoutCols}
+    );`;
 
 const GridContainer = styled('div')`
     display: grid;
     grid-template-columns: repeat(${({ layoutCols }) => layoutCols}, 1fr);
-    grid-auto-rows: ${({ rowHeight }) => rowHeight};
+    grid-auto-rows: ${({ totalWidth, gridGap, layoutCols }) =>
+        calculateGridRowHeight(totalWidth, gridGap, layoutCols)};
     grid-gap: ${({ gridGap }) => gridGap};
 `;
 
@@ -27,12 +37,15 @@ const Grid = ({
     children,
     layout,
     mobileLayout,
+    mobileGridGap = size.default,
     mobileNumCols,
     numCols,
     gridGap = size.default,
     rowHeight = '1fr',
     ...props
 }) => {
+    const thisGrid = useRef(null);
+    const { width } = useRefDimensions(thisGrid);
     const isMobile = useMedia(screenSize.upToMedium);
     const activeLayout = useMemo(
         () => (isMobile ? mobileLayout || layout : layout),
@@ -57,8 +70,10 @@ const Grid = ({
     );
     return (
         <GridContainer
-            gridGap={gridGap}
+            ref={thisGrid}
+            gridGap={isMobile ? mobileGridGap : gridGap}
             rowHeight={rowHeight}
+            totalWidth={width}
             layoutCols={isMobile ? mobileNumCols || numCols : numCols}
             {...props}
         >

--- a/src/components/dev-hub/media-block.js
+++ b/src/components/dev-hub/media-block.js
@@ -56,7 +56,7 @@ const MediaWrapper = styled('div')`
     @media ${screenSize.upToLarge} {
         margin-right: 0;
         ${({ fullWidthContentOnMobile }) =>
-            fullWidthContentOnMobile && 'width: 100%'};
+            fullWidthContentOnMobile && 'max-width: 540px; width: 100%;'};
     }
 `;
 

--- a/src/components/dev-hub/media-block.js
+++ b/src/components/dev-hub/media-block.js
@@ -33,6 +33,7 @@ const gridStructure = ({ reverse, flexible }) => css`
 
 const MediaBlockContainer = styled('div')`
     display: grid;
+    width: 100%;
     ${columnSizes};
     ${gridStructure};
     @media ${screenSize.upToLarge} {
@@ -54,6 +55,8 @@ const MediaWrapper = styled('div')`
     }
     @media ${screenSize.upToLarge} {
         margin-right: 0;
+        ${({ fullWidthContentOnMobile }) =>
+            fullWidthContentOnMobile && 'width: 100%'};
     }
 `;
 
@@ -71,6 +74,7 @@ const MediaBlock = ({
     mediaComponent,
     mediaWidth,
     reverse,
+    fullWidthContentOnMobile,
     flexible = true,
 }) => (
     <MediaBlockContainer
@@ -80,7 +84,12 @@ const MediaBlock = ({
         className={className}
     >
         {mediaComponent && (
-            <MediaWrapper reverse={reverse}>{mediaComponent}</MediaWrapper>
+            <MediaWrapper
+                fullWidthContentOnMobile={fullWidthContentOnMobile}
+                reverse={reverse}
+            >
+                {mediaComponent}
+            </MediaWrapper>
         )}
         <ContentWrapper>{children}</ContentWrapper>
     </MediaBlockContainer>

--- a/src/components/pages/home/academia-feature.js
+++ b/src/components/pages/home/academia-feature.js
@@ -30,6 +30,7 @@ const AcademiaFeature = () => {
                 mediaWidth="550px"
                 mediaComponent={<ProjectCardGrid />}
                 reverse
+                fullWidthContentOnMobile
             >
                 <SectionContent>
                     <H2>

--- a/src/components/pages/project/additional-projects.js
+++ b/src/components/pages/project/additional-projects.js
@@ -13,7 +13,7 @@ import Button from '~components/dev-hub/button';
 const GRID_COL_GAP = '24px';
 const GRID_LAYOUT = { rowSpan: [1], colSpan: [1] };
 const GRID_ROW_HEIGHT = '282px';
-const MOBILE_GRID_LAYOUT = { rowSpan: [1], colSpan: [2] };
+const MOBILE_GRID_LAYOUT = { rowSpan: [1], colSpan: [1] };
 const NUM_ADDITIONAL_PROJECTS = 4;
 
 // Limit is NUM_ADDITIONAL_PROJECTS + 1, but no interpolation in gql queries
@@ -80,6 +80,7 @@ const AdditionalProjects = ({ excludedProjectName }) => {
                     gridGap={GRID_COL_GAP}
                     layout={GRID_LAYOUT}
                     mobileLayout={MOBILE_GRID_LAYOUT}
+                    mobileNumCols={2}
                     numCols={NUM_ADDITIONAL_PROJECTS}
                     rowHeight={GRID_ROW_HEIGHT}
                 >

--- a/src/hooks/use-ref-dimensions.js
+++ b/src/hooks/use-ref-dimensions.js
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+export const useRefDimensions = myRef => {
+    const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+
+    useEffect(() => {
+        const getDimensions = () => ({
+            width: myRef.current.offsetWidth,
+            height: myRef.current.offsetHeight,
+        });
+
+        const handleResize = () => {
+            setDimensions(getDimensions());
+        };
+
+        if (myRef.current) {
+            setDimensions(getDimensions());
+        }
+
+        window.addEventListener('resize', handleResize);
+
+        return () => {
+            window.removeEventListener('resize', handleResize);
+        };
+    }, [myRef]);
+
+    return dimensions;
+};


### PR DESCRIPTION
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-444-responsive-grid/)

This PR adds some JS logic to the Grid to make it properly responsive on various device widths. There was some work that also needed to be done to the MediaBlock since it was giving us a width of 16px for some reason. I noticed modifying this also seemed to impact rendering of other images on the home page which should not happen. This is another bug but will be addressed in future iterations of the home page.