### PR TITLE
DEVHUB-483: Swap learn page heading text

### DIFF
--- a/cypress/integration/learn.js
+++ b/cypress/integration/learn.js
@@ -7,7 +7,7 @@ describe('Learn Page', () => {
     it('should properly render the learn page', () => {
         cy.visitWithoutFetch('/learn/');
         // Make sure something renders on the page
-        cy.contains('Make better, faster applications');
+        cy.contains('Make better apps, faster');
     });
     it('should have a proper canonical url', () => {
         cy.checkCanonicalUrlValue(CANONICAL_URL);

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -332,7 +332,7 @@ export default ({
             </Helmet>
             <Header>
                 <HeaderContent>
-                    <H2>Make better, faster applications</H2>
+                    <H2>Make better apps, faster</H2>
                     <FeaturedArticles articles={featuredArticles} />
                 </HeaderContent>
             </Header>


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-483/learn/)
[JIRA](https://jira.mongodb.org/browse/DEVHUB-483)

This PR makes a quick switch of the text shown on the learn page from "Make better, faster applications" to "Make better apps, faster" by request.