### PR TITLE
DEVHUB-478 part 1

### DIFF
--- a/src/components/dev-hub/academia-sign-up-form.js
+++ b/src/components/dev-hub/academia-sign-up-form.js
@@ -8,7 +8,6 @@ import Button from './button';
 import Select from './select';
 import Checkbox from '@leafygreen-ui/checkbox';
 import SectionHeader from './section-header';
-import SuccessState from './success-state';
 
 const INPUT_BOX_WIDTH = '100%';
 
@@ -42,11 +41,6 @@ const StyledSectionText = styled(ArticleH3)`
     font-weight: normal;
 `;
 
-const StyledSuccessState = styled(SuccessState)`
-    margin-bottom: ${size.xlarge};
-    margin-top: ${size.xlarge};
-`;
-
 const InstructorSection = styled('div')`
     display: grid;
     grid-template-columns: ${INPUT_BOX_WIDTH};
@@ -68,7 +62,7 @@ const InstitutionSection = styled('div')`
     }
 `;
 
-const Form = React.memo(({ setSuccess, success, ...props }) => {
+const AcademiaSignUpForm = React.memo(({ setSuccess, success, ...props }) => {
     const [firstName, setFirstName] = useState('');
     const [lastName, setLastName] = useState('');
     const [email, setEmail] = useState('');
@@ -218,13 +212,5 @@ const Form = React.memo(({ setSuccess, success, ...props }) => {
         </form>
     );
 });
-
-const AcademiaSignUpForm = ({ ...props }) => {
-    const [success, setSuccess] = useState(null);
-    if (success) {
-        return <StyledSuccessState>Thank you for joining!</StyledSuccessState>;
-    }
-    return <Form setSuccess={setSuccess} success={success} {...props} />;
-};
 
 export default AcademiaSignUpForm;

--- a/src/components/pages/academia/project-grid.js
+++ b/src/components/pages/academia/project-grid.js
@@ -12,6 +12,10 @@ import { transformProjectStrapiData } from '~utils/transform-project-strapi-data
 const SECTION_HORIZONTAL_PADDING = '120px';
 const SECTION_VERTICAL_PADDING = '60px';
 
+const GridCopy = styled(P)`
+    color: ${({ theme }) => theme.colorMap.greyLightTwo};
+`;
+
 const CenterButtonContainer = styled('div')`
     display: flex;
     justify-content: center;
@@ -53,7 +57,7 @@ const ProjectGrid = () => {
         <FullWidthBackground>
             <GridContainer>
                 <H5 collapse>See what students are creating with MongoDB.</H5>
-                <P>Projects created by students, for students.</P>
+                <GridCopy>Projects created by students, for students.</GridCopy>
                 <Grid
                     numCols={4}
                     layout={{

--- a/src/components/pages/academia/top-banner.js
+++ b/src/components/pages/academia/top-banner.js
@@ -11,6 +11,11 @@ const defaultLineHeight = css`
     line-height: ${lineHeight.default};
 `;
 
+const HeadingCopy = styled(P)`
+    color: ${({ theme }) => theme.colorMap.greyLightTwo};
+    ${defaultLineHeight};
+`;
+
 const Header = styled('header')`
     padding-top: ${size.large};
     @media ${screenSize.upToLarge} {
@@ -30,12 +35,12 @@ const TopBanner = () => (
         <Header>
             <H2>MongoDB for Academia</H2>
 
-            <P css={defaultLineHeight}>
+            <HeadingCopy>
                 MongoDB for Academia is your home for resources, tools, and
                 community support while you learn or teach MongoDB! Wherever you
                 are in your journey -- beginner or advanced developer -- we’re
                 here to equip you for success.
-            </P>
+            </HeadingCopy>
         </Header>
     </ReducedMarginBanner>
 );

--- a/src/components/pages/educators/how-to-join.js
+++ b/src/components/pages/educators/how-to-join.js
@@ -3,7 +3,7 @@ import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import EducatorsJoin from '~images/student-spotlight/educators-join.svg';
 import { screenSize } from '../../dev-hub/theme';
-import { H4, P } from '../../dev-hub/text';
+import { H4, P, P2 } from '../../dev-hub/text';
 import MediaBlock from '../../dev-hub/media-block';
 import SignUpModal from './sign-up-modal';
 import GreenBulletedList from './green-bulleted-list';
@@ -41,8 +41,7 @@ const gradientBullet = theme => css`
     line-height: ${CUSTOM_BULLET_SIZE};
     position: absolute;
     text-align: center;
-    /* line-height is 32px. (32px - 24px) / 2 gives a 4px veritcal offset to center */
-    top: 4px;
+    top: 0;
     width: ${CUSTOM_BULLET_SIZE};
 `;
 const reducePaddingOnMobile = css`
@@ -95,10 +94,18 @@ const HowToJoin = () => (
                 ]}
             ></GreenBulletedList>
             <CustomGradientOrderedList>
-                <li>Fill out a form with teaching details</li>
-                <li>Our team will verify your details</li>
-                <li>You'll get an email within 5 business days</li>
-                <li>Bring your students on board</li>
+                <li>
+                    <P2 collapse>Fill out a form with teaching details</P2>
+                </li>
+                <li>
+                    <P2 collapse>Our team will verify your details</P2>
+                </li>
+                <li>
+                    <P2 collapse>You'll get an email within 5 business days</P2>
+                </li>
+                <li>
+                    <P2 collapse>Bring your students on board</P2>
+                </li>
             </CustomGradientOrderedList>
             <SignUpModal />
         </MediaBlock>

--- a/src/components/pages/educators/sign-up-modal.js
+++ b/src/components/pages/educators/sign-up-modal.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { size, lineHeight } from '../../dev-hub/theme';
 import { H5, P } from '../../dev-hub/text';
 import styled from '@emotion/styled';
@@ -6,6 +6,7 @@ import { css } from '@emotion/core';
 import Button from '../../dev-hub/button';
 import AcademiaSignUpForm from '../../dev-hub/academia-sign-up-form';
 import Modal from '../../dev-hub/modal';
+import SuccessState from '~components/dev-hub/success-state';
 
 const MAX_SIGN_UP_WIDTH = '600px';
 
@@ -22,24 +23,38 @@ const StyledAcademiaSignUpForm = styled(AcademiaSignUpForm)`
     margin-top: ${size.large};
 `;
 
-const SignUpModal = () => (
-    <Modal
-        triggerComponent={
-            <ButtonWithAdditionalTopMargin primary hasArrow={false}>
-                Join MongoDB for Academia
-            </ButtonWithAdditionalTopMargin>
-        }
-        dialogContainerStyle={{ maxWidth: MAX_SIGN_UP_WIDTH }}
-    >
-        <H5>Join MongoDB for Academia</H5>
-        <P css={defaultLineHeight}>
-            If you’re interested in receiving MongoDB course materials or if you
-            like us to review your current content, please let us know by
-            submitting the form and we’ll get back to you within five business
-            days.
-        </P>
-        <StyledAcademiaSignUpForm />
-    </Modal>
-);
+const StyledSuccessState = styled(SuccessState)`
+    margin-bottom: ${size.xlarge};
+    margin-top: ${size.xlarge};
+`;
+
+const SignUpModal = () => {
+    const [success, setSuccess] = useState(null);
+    if (success) {
+        return <StyledSuccessState>Thank you for joining!</StyledSuccessState>;
+    }
+    return (
+        <Modal
+            triggerComponent={
+                <ButtonWithAdditionalTopMargin primary hasArrow={false}>
+                    Join MongoDB for Academia
+                </ButtonWithAdditionalTopMargin>
+            }
+            dialogContainerStyle={{ maxWidth: MAX_SIGN_UP_WIDTH }}
+        >
+            <H5>Join MongoDB for Academia</H5>
+            <P css={defaultLineHeight}>
+                If you’re interested in receiving MongoDB course materials or if
+                you like us to review your current content, please let us know
+                by submitting the form and we’ll get back to you within five
+                business days.
+            </P>
+            <StyledAcademiaSignUpForm
+                setSuccess={setSuccess}
+                success={success}
+            />
+        </Modal>
+    );
+};
 
 export default SignUpModal;

--- a/src/components/pages/educators/top-banner.js
+++ b/src/components/pages/educators/top-banner.js
@@ -17,6 +17,11 @@ const defaultLineHeight = css`
     line-height: ${lineHeight.default};
 `;
 
+const HeadingCopy = styled(P)`
+    color: ${({ theme }) => theme.colorMap.greyLightTwo};
+    ${defaultLineHeight};
+`;
+
 const Header = styled('header')`
     padding-top: ${size.large};
     @media ${screenSize.upToLarge} {
@@ -39,11 +44,11 @@ const TopBanner = () => (
         <Header>
             <H2>MongoDB Academia for Educators</H2>
 
-            <P css={defaultLineHeight}>
+            <HeadingCopy>
                 MongoDB for Academia is for educators who want to prepare
                 students for careers that require in-demand database skills that
                 power modern applications.
-            </P>
+            </HeadingCopy>
             <SignUpModal />
         </Header>
     </ReducedMarginBanner>

--- a/src/components/pages/students/gallery-hero-banner.js
+++ b/src/components/pages/students/gallery-hero-banner.js
@@ -5,6 +5,10 @@ import HeroBanner from '~components/dev-hub/hero-banner';
 import { H2, P } from '~components/dev-hub/text';
 import { screenSize, size } from '~components/dev-hub/theme';
 
+const HeadingCopy = styled(P)`
+    color: ${({ theme }) => theme.colorMap.greyLightTwo};
+`;
+
 const BannerContentLayout = styled('div')`
     display: flex;
     justify-content: space-between;
@@ -35,7 +39,9 @@ const GalleryHeroBanner = () => {
             <BannerContentLayout>
                 <MobileMarginBottom>
                     <H2>Student Spotlights</H2>
-                    <P collapse>Projects created by students, for students</P>
+                    <HeadingCopy collapse>
+                        Projects created by students, for students
+                    </HeadingCopy>
                 </MobileMarginBottom>
                 <ShowOffButton primary to="/academia/students/submit">
                     Show off your project


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-478-part-1/)
[UAT Sheet](https://docs.google.com/spreadsheets/d/10bDBzs-QnbaF5vdo19a1JRw-ALdaNZLOcS4Bil92joQ/edit#gid=0)

This PR begins addressing cosmetic concerns on Student Spotlight. Namely, this PR:
- Swaps the link tertiary hover state to green and removes the transition used
- Fixes a bug where the academia educators form submission kept the additional top copy
- Swapped copy to greyLightTwo in several headers
- Cleaned up text sizes in the bulleted list of how to join on the educators page