### PR TITLE
DEVHUB-478 [Part 3]

### DIFF
--- a/src/components/dev-hub/blog-tag-list.js
+++ b/src/components/dev-hub/blog-tag-list.js
@@ -1,10 +1,21 @@
 import React, { useCallback, useState } from 'react';
+import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import Link from './link';
 import { fontSize, lineHeight, screenSize, size } from './theme';
 
 const MINIMUM_EXPANDABLE_SIZE = 3;
 const MAX_TAG_LIST_SIZE = 5;
+
+const tagHoverState = theme => css`
+    &:active,
+    &:focus,
+    &:hover {
+        border: 1px solid ${theme.colorMap.lightGreen};
+        cursor: pointer;
+        transition: border 0.15s;
+    }
+`;
 
 const TagLink = styled('div')`
     background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
@@ -21,13 +32,7 @@ const TagLink = styled('div')`
     @media ${screenSize.upToMedium} {
         font-size: ${fontSize.micro};
     }
-    &:active,
-    &:focus,
-    &:hover {
-        border: 1px solid ${({ theme }) => theme.colorMap.lightGreen};
-        cursor: pointer;
-        transition: border 0.15s;
-    }
+    ${({ enableHoverState, theme }) => enableHoverState && tagHoverState(theme)}
     &:visited {
         color: ${({ theme }) => theme.colorMap.greyLightTwo};
     }
@@ -42,14 +47,16 @@ const TagListItem = styled('li')`
     display: inline-block;
 `;
 
-const BlogTag = ({ children, ...props }) => {
+const BlogTag = ({ children, enableHoverState = true, ...props }) => {
     const renderAsLink = !!(props.to || props.onClick);
     const TagLinkComponent = renderAsLink
         ? TagLink.withComponent(Link)
         : TagLink;
     return (
         <TagListItem>
-            <TagLinkComponent {...props}>{children}</TagLinkComponent>
+            <TagLinkComponent enableHoverState={enableHoverState} {...props}>
+                {children}
+            </TagLinkComponent>
         </TagListItem>
     );
 };
@@ -68,7 +75,11 @@ const BlogTagList = ({ className, navigates = true, tags = [] }) => {
         if (navigates) {
             props.to = t.to;
         }
-        return <BlogTag {...props}>{t.label}</BlogTag>;
+        return (
+            <BlogTag enableHoverState={navigates} {...props}>
+                {t.label}
+            </BlogTag>
+        );
     };
 
     return (

--- a/src/components/dev-hub/hero-banner.js
+++ b/src/components/dev-hub/hero-banner.js
@@ -24,7 +24,7 @@ const HeroBannerContainer = styled('div')`
     ${({ background }) =>
         background && `background-image: url(${background});`};
     /* Send background to the right */
-    background-position: 100%;
+    background-position: ${({ backgroundPosition }) => backgroundPosition};
     background-repeat: no-repeat;
     background-size: ${({ shouldContainBackground }) =>
         shouldContainBackground ? 'contain' : 'cover'};
@@ -64,6 +64,7 @@ const HeroBanner = ({
     breadcrumb,
     children,
     collapse,
+    backgroundPosition = '100%',
     // Setting below to false would allow for bleed effect on bg
     shouldContainBackground = true,
     showImageOnMobile = true,
@@ -75,6 +76,7 @@ const HeroBanner = ({
         <Header collapse={collapse} {...props}>
             <HeroBannerContainer
                 background={background}
+                backgroundPosition={backgroundPosition}
                 shouldContainBackground={shouldContainBackground}
             >
                 <ContentContainer fullWidth={fullWidth}>

--- a/src/components/pages/academia/top-banner.js
+++ b/src/components/pages/academia/top-banner.js
@@ -31,7 +31,10 @@ const ReducedMarginBanner = styled(HeroBanner)`
 `;
 
 const TopBanner = () => (
-    <ReducedMarginBanner background={AcademiaHeader}>
+    <ReducedMarginBanner
+        background={AcademiaHeader}
+        backgroundPosition="100% 42px"
+    >
         <Header>
             <H2>MongoDB for Academia</H2>
 

--- a/src/components/pages/educators/program-benefits.js
+++ b/src/components/pages/educators/program-benefits.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
-import { screenSize } from '../../dev-hub/theme';
+import { screenSize, size } from '../../dev-hub/theme';
 import { H3, H5 } from '../../dev-hub/text';
 import ThumbnailConnect from '~images/student-spotlight/thumbnail-connect.svg';
 import ThumbnailCurriculum from '~images/student-spotlight/thumbnail-curriculum.svg';
@@ -50,9 +50,15 @@ const BodyContent = styled('div')`
     ${reducePaddingOnMobile};
 `;
 
+const BenefitGraphic = styled('img')`
+    display: block;
+    max-width: 200px;
+    margin: 0 auto ${size.medium};
+`;
+
 const FeaturedBenefit = ({ bullets, image, title }) => (
     <FeaturedBenefitMaxWidthContainer>
-        <img alt="" src={image} />
+        <BenefitGraphic alt="" src={image} />
         <H5>{title}</H5>
         <GreenBulletedList>{bullets}</GreenBulletedList>
     </FeaturedBenefitMaxWidthContainer>

--- a/src/components/pages/educators/top-banner.js
+++ b/src/components/pages/educators/top-banner.js
@@ -38,8 +38,9 @@ const ReducedMarginBanner = styled(HeroBanner)`
 
 const TopBanner = () => (
     <ReducedMarginBanner
-        breadcrumb={ACADEMIA_BREADCRUMBS}
         background={EducatorsHeader}
+        backgroundPosition="100% 42px"
+        breadcrumb={ACADEMIA_BREADCRUMBS}
     >
         <Header>
             <H2>MongoDB Academia for Educators</H2>

--- a/src/components/pages/project/sidebar-content.js
+++ b/src/components/pages/project/sidebar-content.js
@@ -16,6 +16,7 @@ const LinksContainer = styled('div')`
 
 const ProjectLink = styled(Link)`
     color: ${({ theme }) => theme.colorMap.devWhite};
+    font-weight: bold;
 `;
 
 const ToolsUsedWithPadding = styled(ToolsUsed)`

--- a/src/components/pages/students/featured-project.js
+++ b/src/components/pages/students/featured-project.js
@@ -40,6 +40,8 @@ const RelativePositionedBadge = styled(Badge)`
 
 const StyledLink = styled(Link)`
     color: ${({ theme }) => theme.colorMap.devWhite};
+    font-weight: bold;
+    width: fit-content;
 `;
 
 const TagListWithMargin = styled(BlogTagList)`


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-478-part-3/)
[UAT Sheet](https://docs.google.com/spreadsheets/d/10bDBzs-QnbaF5vdo19a1JRw-ALdaNZLOcS4Bil92joQ/edit#gid=0)

This PR continues with the design alterations for Student Spotlight. Namely:
- Removing the tag hover state if navigation is off
- Exposing the `background-position` on the Hero Banner Image for more fine desktop use
- Restricting the benefit graphics on the educator page to 200px wide max
- Making a few links bold and ensuring clickable areas are appropriate