### PR TITLE
DEVHUB-478 [Part 4]

### DIFF
--- a/src/components/dev-hub/blog-tag-list.js
+++ b/src/components/dev-hub/blog-tag-list.js
@@ -61,8 +61,13 @@ const BlogTag = ({ children, enableHoverState = true, ...props }) => {
     );
 };
 
-const BlogTagList = ({ className, navigates = true, tags = [] }) => {
-    const canExpand = tags.length >= MINIMUM_EXPANDABLE_SIZE;
+const BlogTagList = ({
+    className,
+    expanded = false,
+    navigates = true,
+    tags = [],
+}) => {
+    const canExpand = tags.length >= MINIMUM_EXPANDABLE_SIZE && !expanded;
     // By default any list of blog tags under the minimum expandable size is already expanded
     const [isExpanded, setIsExpanded] = useState(!canExpand);
     const expandList = useCallback(() => setIsExpanded(true), []);

--- a/src/components/dev-hub/image-gallery.js
+++ b/src/components/dev-hub/image-gallery.js
@@ -18,12 +18,16 @@ const hoverThumbnailBorder = theme => css`
 
 const CurrentImage = styled('img')`
     border-radius: ${size.xsmall};
+    display: block;
+    margin-bottom: ${size.xsmall};
     object-fit: contain;
 `;
 
 const ThumbnailWrapper = styled('div')`
     cursor: pointer;
-    margin-right: 8px;
+    margin-right: ${size.xsmall};
+    height: ${THUMBNAIL_SIZE};
+    width: ${THUMBNAIL_SIZE};
     :last-of-type {
         margin-right: 0;
     }

--- a/src/components/dev-hub/image-gallery.js
+++ b/src/components/dev-hub/image-gallery.js
@@ -12,6 +12,10 @@ const activeThumbnailBorder = theme => css`
     border: 2px solid ${theme.colorMap.darkGreen};
 `;
 
+const hoverThumbnailBorder = theme => css`
+    border: 2px solid ${theme.colorMap.greyLightTwo};
+`;
+
 const CurrentImage = styled('img')`
     border-radius: ${size.xsmall};
     object-fit: contain;
@@ -19,6 +23,10 @@ const CurrentImage = styled('img')`
 
 const ThumbnailWrapper = styled('div')`
     cursor: pointer;
+    margin-right: 8px;
+    :last-of-type {
+        margin-right: 0;
+    }
 `;
 
 const ImageThumbnail = styled('img')`
@@ -28,6 +36,11 @@ const ImageThumbnail = styled('img')`
     height: ${THUMBNAIL_SIZE};
     object-fit: cover;
     width: ${THUMBNAIL_SIZE};
+    &:hover,
+    &:active,
+    &:focus {
+        ${({ theme }) => hoverThumbnailBorder(theme)};
+    }
     ${({ isActive, theme }) => isActive && activeThumbnailBorder(theme)};
 `;
 

--- a/src/components/dev-hub/image-gallery.js
+++ b/src/components/dev-hub/image-gallery.js
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import { P } from './text';
 import { size } from './theme';
 
-const DESKTOP_GALLERY_HEIGHT = '500px';
+const DESKTOP_GALLERY_HEIGHT = '450px';
 const DESKTOP_GALLERY_WIDTH = '1200px';
 const THUMBNAIL_SIZE = '56px';
 

--- a/src/components/dev-hub/image-gallery.js
+++ b/src/components/dev-hub/image-gallery.js
@@ -14,9 +14,7 @@ const activeThumbnailBorder = theme => css`
 
 const CurrentImage = styled('img')`
     border-radius: ${size.xsmall};
-    height: ${DESKTOP_GALLERY_HEIGHT};
     object-fit: contain;
-    width: ${DESKTOP_GALLERY_WIDTH};
 `;
 
 const ThumbnailWrapper = styled('div')`
@@ -51,7 +49,11 @@ const ImageGallery = ({ description, images }) => {
     const updateCurrentImage = img => setCurrentImage(img);
     return (
         <div>
-            <CurrentImage src={currentImage.src} />
+            <CurrentImage
+                height={DESKTOP_GALLERY_HEIGHT}
+                src={currentImage.src}
+                width={DESKTOP_GALLERY_WIDTH}
+            />
             <GalleryItemsContainer>
                 <P>{description}</P>
                 <ThumbnailContainer>

--- a/src/components/dev-hub/image-gallery.js
+++ b/src/components/dev-hub/image-gallery.js
@@ -4,7 +4,8 @@ import styled from '@emotion/styled';
 import { P } from './text';
 import { size } from './theme';
 
-const DESKTOP_GALLERY_MAX_HEIGHT = '600px';
+const DESKTOP_GALLERY_HEIGHT = '500px';
+const DESKTOP_GALLERY_WIDTH = '1200px';
 const THUMBNAIL_SIZE = '56px';
 
 const activeThumbnailBorder = theme => css`
@@ -13,9 +14,9 @@ const activeThumbnailBorder = theme => css`
 
 const CurrentImage = styled('img')`
     border-radius: ${size.xsmall};
-    max-height: ${DESKTOP_GALLERY_MAX_HEIGHT};
-    object-fit: cover;
-    width: 100%;
+    height: ${DESKTOP_GALLERY_HEIGHT};
+    object-fit: contain;
+    width: ${DESKTOP_GALLERY_WIDTH};
 `;
 
 const ThumbnailWrapper = styled('div')`
@@ -27,6 +28,7 @@ const ImageThumbnail = styled('img')`
     border: 2px solid transparent;
     border-radius: ${size.xsmall};
     height: ${THUMBNAIL_SIZE};
+    object-fit: cover;
     width: ${THUMBNAIL_SIZE};
     ${({ isActive, theme }) => isActive && activeThumbnailBorder(theme)};
 `;

--- a/src/components/dev-hub/project-title-area.js
+++ b/src/components/dev-hub/project-title-area.js
@@ -21,7 +21,6 @@ const IncreasedMarginHeroBanner = styled(HeroBanner)`
 `;
 
 const IncreasedMarginH2 = styled(H2)`
-    margin-bottom: ${size.medium};
     @media ${screenSize.upToMedium} {
         margin-bottom: ${size.xsmall};
     }
@@ -47,7 +46,7 @@ const ProjectTitleArea = ({ description, images, title, url }) => {
             fullWidth
         >
             <TopRow>
-                <BlogTitle>{title}</BlogTitle>
+                <BlogTitle collapse>{title}</BlogTitle>
                 <ShareMenu
                     position={isMobile ? 'right' : 'left'}
                     title={title}

--- a/src/components/dev-hub/project-title-area.js
+++ b/src/components/dev-hub/project-title-area.js
@@ -46,7 +46,7 @@ const ProjectTitleArea = ({ description, images, title, url }) => {
             fullWidth
         >
             <TopRow>
-                <BlogTitle collapse>{title}</BlogTitle>
+                <BlogTitle>{title}</BlogTitle>
                 <ShareMenu
                     position={isMobile ? 'right' : 'left'}
                     title={title}

--- a/src/components/pages/project/sidebar-content.js
+++ b/src/components/pages/project/sidebar-content.js
@@ -23,9 +23,9 @@ const ToolsUsedWithPadding = styled(ToolsUsed)`
     padding-bottom: ${size.large};
 `;
 
-const LinkIfExists = ({ label, to }) =>
+const LinkIfExists = ({ label, to, ...props }) =>
     to ? (
-        <ProjectLink tertiary to={to}>
+        <ProjectLink tertiary to={to} {...props}>
             {label}
         </ProjectLink>
     ) : null;
@@ -36,7 +36,11 @@ const Links = ({ github_url, project_link }) => {
         return (
             <LinksContainer>
                 <LinkIfExists to={github_url} label="View Code" />
-                <LinkIfExists to={project_link} label="Live Demo" />
+                <LinkIfExists
+                    target="_blank"
+                    to={project_link}
+                    label="Live Demo"
+                />
             </LinksContainer>
         );
     }

--- a/src/components/pages/project/sidebar-content.js
+++ b/src/components/pages/project/sidebar-content.js
@@ -25,7 +25,7 @@ const ToolsUsedWithPadding = styled(ToolsUsed)`
 
 const LinkIfExists = ({ label, to, ...props }) =>
     to ? (
-        <ProjectLink tertiary to={to} {...props}>
+        <ProjectLink target="_blank" tertiary to={to} {...props}>
             {label}
         </ProjectLink>
     ) : null;
@@ -36,11 +36,7 @@ const Links = ({ github_url, project_link }) => {
         return (
             <LinksContainer>
                 <LinkIfExists to={github_url} label="View Code" />
-                <LinkIfExists
-                    target="_blank"
-                    to={project_link}
-                    label="Live Demo"
-                />
+                <LinkIfExists to={project_link} label="Live Demo" />
             </LinksContainer>
         );
     }

--- a/src/components/pages/project/students.js
+++ b/src/components/pages/project/students.js
@@ -39,10 +39,6 @@ const StudentToggle = styled(Button)`
         }
     }
 `;
-const InvisibleLink = styled(Link)`
-    margin-bottom: 10px;
-    text-decoration: none;
-`;
 const StudentLi = styled('li')`
     border-bottom: 1px solid ${({ theme }) => theme.colorMap.greyDarkThree};
     display: flex;
@@ -74,11 +70,22 @@ const LinkText = styled(P3)`
     text-overflow: ellipsis;
     white-space: nowrap;
 `;
+const InvisibleLink = styled(Link)`
+    margin-bottom: 10px;
+    text-decoration: none;
+    &:active,
+    &:focus,
+    &:hover {
+        ${LinkText} {
+            color: ${({ theme }) => theme.colorMap.lightGreen};
+        }
+    }
+`;
 
 const SocialMediaEntry = ({ Icon, url }) => {
     const theme = useTheme();
     return url ? (
-        <InvisibleLink to={url}>
+        <InvisibleLink target="_blank" to={url}>
             <LinkContainer>
                 <Icon color={theme.colorMap.darkGreen} width={ICON_SIZE} />
                 <LinkText collapse>{url}</LinkText>

--- a/src/components/pages/project/tools-used.js
+++ b/src/components/pages/project/tools-used.js
@@ -5,7 +5,7 @@ import { H5 } from '~components/dev-hub/text';
 const ToolsUsed = ({ tags, ...props }) => (
     <div {...props}>
         <H5>Tools Used</H5>
-        <BlogTagList navigates={false} tags={tags} />
+        <BlogTagList expanded={true} navigates={false} tags={tags} />
     </div>
 );
 


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-478-part-4/)

This PR continues work on cosmetic design tweaks for Student Spotlight. Here we:
- Shrink the Hero section on projects to move content above the fold on most machines
- Fix image resolution issues on the image gallery and fix the size of the current image
- Exposes a prop to remove the condensed view of the blog tag list
- Adds `target="blank"` to several links