### PR TITLE
DEVHUB-480: Don't Remove Fieldset from DOM

### DIFF
--- a/src/components/pages/student-submit/form/dropzone-thumbnail.js
+++ b/src/components/pages/student-submit/form/dropzone-thumbnail.js
@@ -37,6 +37,8 @@ const ThumbnailContent = styled('div')`
 const Image = styled('img')`
     display: block;
     height: 100%;
+    margin: 0 auto;
+    object-fit: contain;
     width: auto;
 `;
 

--- a/src/components/pages/student-submit/form/promote-yourself.js
+++ b/src/components/pages/student-submit/form/promote-yourself.js
@@ -6,6 +6,8 @@ import SingleStudentFieldset from './single-student-fieldset';
 import SubmitFormFieldset from './submit-form-fieldset';
 
 const getRemoveStudentMsg = name => `Remove ${name} from project?`;
+const wantsToRemoveStudent = student =>
+    window.confirm(getRemoveStudentMsg(student.first_name));
 
 const RightAligned = styled('div')`
     display: flex;
@@ -77,11 +79,7 @@ const PromoteYourself = ({
     );
     const removeStudent = useCallback(
         i => () => {
-            if (
-                window.confirm(
-                    getRemoveStudentMsg(state.students[i].first_name)
-                )
-            ) {
+            if (wantsToRemoveStudent(state.students[i])) {
                 const newStudents = [...state.students];
                 newStudents.splice(i, 1);
                 updateStudents(newStudents);

--- a/src/components/pages/student-submit/form/promote-yourself.js
+++ b/src/components/pages/student-submit/form/promote-yourself.js
@@ -5,6 +5,8 @@ import Button from '~components/dev-hub/button';
 import SingleStudentFieldset from './single-student-fieldset';
 import SubmitFormFieldset from './submit-form-fieldset';
 
+const getRemoveStudentMsg = name => `Remove ${name} from project?`;
+
 const RightAligned = styled('div')`
     display: flex;
     justify-content: flex-end;
@@ -75,9 +77,15 @@ const PromoteYourself = ({
     );
     const removeStudent = useCallback(
         i => () => {
-            const newStudents = [...state.students];
-            newStudents.splice(i, 1);
-            updateStudents(newStudents);
+            if (
+                window.confirm(
+                    getRemoveStudentMsg(state.students[i].first_name)
+                )
+            ) {
+                const newStudents = [...state.students];
+                newStudents.splice(i, 1);
+                updateStudents(newStudents);
+            }
         },
         [state.students, updateStudents]
     );

--- a/src/components/pages/student-submit/form/single-student-fieldset.js
+++ b/src/components/pages/student-submit/form/single-student-fieldset.js
@@ -2,19 +2,18 @@ import React, { useMemo, useState } from 'react';
 import styled from '@emotion/styled';
 import CondensedStudentEntry from './condensed-student-entry';
 import NewStudentFieldset from './new-student-fieldset';
-import { size } from '~components/dev-hub/theme';
 
 const ShowOnExpanded = styled('div')`
     display: ${({ isExpanded }) => (isExpanded ? 'contents' : 'none')};
     > * {
-        margin-bottom: ${size.mediumLarge};
+        margin-bottom: inherit;
     }
 `;
 
 const ShowOnCondensed = styled('div')`
     display: ${({ isExpanded }) => (isExpanded ? 'none' : 'contents')};
     > * {
-        margin-bottom: ${size.mediumLarge};
+        margin-bottom: inherit;
     }
 `;
 

--- a/src/components/pages/student-submit/form/single-student-fieldset.js
+++ b/src/components/pages/student-submit/form/single-student-fieldset.js
@@ -1,6 +1,22 @@
 import React, { useMemo, useState } from 'react';
+import styled from '@emotion/styled';
 import CondensedStudentEntry from './condensed-student-entry';
 import NewStudentFieldset from './new-student-fieldset';
+import { size } from '~components/dev-hub/theme';
+
+const ShowOnExpanded = styled('div')`
+    display: ${({ isExpanded }) => (isExpanded ? 'contents' : 'none')};
+    > * {
+        margin-bottom: ${size.mediumLarge};
+    }
+`;
+
+const ShowOnCondensed = styled('div')`
+    display: ${({ isExpanded }) => (isExpanded ? 'none' : 'contents')};
+    > * {
+        margin-bottom: ${size.mediumLarge};
+    }
+`;
 
 const SingleStudentFieldset = ({
     isExpanded,
@@ -17,20 +33,25 @@ const SingleStudentFieldset = ({
         [activePicture, hasActivePicture]
     );
 
-    return isExpanded ? (
-        <NewStudentFieldset
-            authorImage={authorImage}
-            setActivePicture={setActivePicture}
-            onChange={onChange}
-            state={state}
-        />
-    ) : (
-        <CondensedStudentEntry
-            authorImage={authorImage}
-            state={state}
-            onEdit={onEdit}
-            onRemove={onRemove}
-        />
+    return (
+        <>
+            <ShowOnCondensed isExpanded={isExpanded}>
+                <CondensedStudentEntry
+                    authorImage={authorImage}
+                    state={state}
+                    onEdit={onEdit}
+                    onRemove={onRemove}
+                />
+            </ShowOnCondensed>
+            <ShowOnExpanded isExpanded={isExpanded}>
+                <NewStudentFieldset
+                    authorImage={authorImage}
+                    setActivePicture={setActivePicture}
+                    onChange={onChange}
+                    state={state}
+                />
+            </ShowOnExpanded>
+        </>
     );
 };
 

--- a/src/components/pages/student-submit/form/submit-form-fieldset.js
+++ b/src/components/pages/student-submit/form/submit-form-fieldset.js
@@ -35,7 +35,7 @@ const FieldsetContent = styled('div')`
     clear: both;
     display: ${({ isOpen }) => (isOpen ? 'block' : 'none')};
     > * {
-        margin-bottom: 24px;
+        margin-bottom: ${size.mediumLarge};
     }
 `;
 


### PR DESCRIPTION
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-480/academia/students/submit/)

This PR fixes a bug where on collapse we remove student forms from the DOM. This would cause the photo selected to be lost because the file input is uncontrolled.

I also fixed the object-fit for thumbnails above in the form and cleaned that up a bit, as well as added `window.confirm` before removing a student.