### PR TITLE
DEVHUB-444 [Part 5]: Nitpicks

### DIFF
--- a/src/components/dev-hub/grid.js
+++ b/src/components/dev-hub/grid.js
@@ -15,9 +15,19 @@ const calculateGridRowHeight = (totalWidth, gridGap, layoutCols) => `calc(
 const GridContainer = styled('div')`
     display: grid;
     grid-template-columns: repeat(${({ layoutCols }) => layoutCols}, 1fr);
-    grid-auto-rows: ${({ totalWidth, gridGap, layoutCols }) =>
-        calculateGridRowHeight(totalWidth, gridGap, layoutCols)};
+    grid-auto-rows: ${({ rowHeight, totalWidth, gridGap, layoutCols }) =>
+        rowHeight || calculateGridRowHeight(totalWidth, gridGap, layoutCols)};
     grid-gap: ${({ gridGap }) => gridGap};
+    @media ${screenSize.upToLarge} {
+        grid-auto-rows: ${({
+            mobileRowHeight,
+            totalWidth,
+            gridGap,
+            layoutCols,
+        }) =>
+            mobileRowHeight ||
+            calculateGridRowHeight(totalWidth, gridGap, layoutCols)};
+    }
 `;
 
 const gridSpan = ({ rowSpan, colSpan }) => ({
@@ -38,14 +48,15 @@ const Grid = ({
     mobileLayout,
     mobileGridGap = size.default,
     mobileNumCols,
+    mobileRowHeight,
     numCols,
     gridGap = size.default,
-    rowHeight = '1fr',
+    rowHeight,
     ...props
 }) => {
     const thisGrid = useRef(null);
     const { width } = useRefDimensions(thisGrid);
-    const isMobile = useMedia(screenSize.upToMedium);
+    const isMobile = useMedia(screenSize.upToLarge);
     const activeLayout = useMemo(
         () => (isMobile ? mobileLayout || layout : layout),
         [isMobile, layout, mobileLayout]
@@ -56,7 +67,7 @@ const Grid = ({
     );
     const gridElements = useMemo(
         () =>
-            children.map((child, i) =>
+            React.Children.toArray(children).map((child, i) =>
                 React.cloneElement(child, {
                     style: {
                         ...gridSpan(gridLayout.position(i)),
@@ -71,6 +82,7 @@ const Grid = ({
         <GridContainer
             ref={thisGrid}
             gridGap={isMobile ? mobileGridGap : gridGap}
+            mobileRowHeight={mobileRowHeight}
             rowHeight={rowHeight}
             totalWidth={width}
             layoutCols={isMobile ? mobileNumCols || numCols : numCols}

--- a/src/components/dev-hub/project-card.js
+++ b/src/components/dev-hub/project-card.js
@@ -2,7 +2,14 @@ import React from 'react';
 import styled from '@emotion/styled';
 import HoverCard from './hover-card';
 import { H5, P2 } from './text';
+import { screenSize } from './theme';
 import AuthorImageList from './author-image-list';
+
+const HideOnMobile = styled('div')`
+    @media ${screenSize.upToMedium} {
+        display: none;
+    }
+`;
 
 const CenteredAuthorImageList = styled(AuthorImageList)`
     justify-content: center;
@@ -11,8 +18,10 @@ const CenteredAuthorImageList = styled(AuthorImageList)`
 const ProjectCard = ({ project, ...props }) => (
     <HoverCard to={project.slug} image={project.image_url} {...props}>
         <H5>{project.name}</H5>
-        <P2>{project.description}</P2>
-        <CenteredAuthorImageList students={project.students} />
+        <HideOnMobile>
+            <P2>{project.description}</P2>
+            <CenteredAuthorImageList students={project.students} />
+        </HideOnMobile>
     </HoverCard>
 );
 

--- a/src/components/dev-hub/student-spotlight/github-student-pack.js
+++ b/src/components/dev-hub/student-spotlight/github-student-pack.js
@@ -22,6 +22,7 @@ const LightText = styled(P)`
 const ImageContainer = styled('div')`
     display: flex;
     justify-content: flex-end;
+    object-fit: contain;
 `;
 
 // We want this content centered and, on mobile, the text centered as well

--- a/src/components/dev-hub/student-spotlight/github-student-pack.js
+++ b/src/components/dev-hub/student-spotlight/github-student-pack.js
@@ -22,6 +22,9 @@ const LightText = styled(P)`
 const ImageContainer = styled('div')`
     display: flex;
     justify-content: flex-end;
+`;
+
+const ImgWithContain = styled('img')`
     object-fit: contain;
 `;
 
@@ -45,7 +48,7 @@ const StyledLink = P2.withComponent(WhiteLink);
 
 const GithubBackpackImg = () => (
     <ImageContainer>
-        <img
+        <ImgWithContain
             alt="Backpack with GitHub logo plus MongoDB leaf"
             height="240"
             src={githubStudentPackPng}

--- a/src/components/pages/academia/project-grid.js
+++ b/src/components/pages/academia/project-grid.js
@@ -14,6 +14,9 @@ const SECTION_VERTICAL_PADDING = '60px';
 
 const GridCopy = styled(P)`
     color: ${({ theme }) => theme.colorMap.greyLightTwo};
+    @media ${screenSize.upToLarge} {
+        display: none;
+    }
 `;
 
 const CenterButtonContainer = styled('div')`

--- a/src/components/pages/academia/students-educators-details.js
+++ b/src/components/pages/academia/students-educators-details.js
@@ -50,6 +50,9 @@ const NoMaxWidthCard = styled(Card)`
     max-width: none;
     ${BulletText} {
         color: ${({ theme }) => theme.colorMap.greyLightTwo};
+        @media ${screenSize.upToLarge} {
+            color: ${({ theme }) => theme.colorMap.devWhite};
+        }
     }
     &:hover {
         ${BulletText} {

--- a/src/components/pages/educators/how-to-join.js
+++ b/src/components/pages/educators/how-to-join.js
@@ -2,7 +2,8 @@ import React from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import EducatorsJoin from '~images/student-spotlight/educators-join.svg';
-import { screenSize } from '../../dev-hub/theme';
+import useMedia from '~hooks/use-media';
+import { screenSize, size } from '../../dev-hub/theme';
 import { H4, P, P2 } from '../../dev-hub/text';
 import MediaBlock from '../../dev-hub/media-block';
 import SignUpModal from './sign-up-modal';
@@ -11,13 +12,6 @@ import GreenBulletedList from './green-bulleted-list';
 const CUSTOM_BULLET_SIZE = '24px';
 const SECTION_HORIZONTAL_PADDING = '120px';
 const SECTION_VERTICAL_PADDING = '60px';
-
-const centerContentOnMobile = css`
-    @media ${screenSize.upToLarge} {
-        justify-content: center;
-        text-align: center;
-    }
-`;
 
 // Custom counter so we can apply custom styles after disabling list-style
 const customOrderedListCounter = css`
@@ -46,7 +40,7 @@ const gradientBullet = theme => css`
 `;
 const reducePaddingOnMobile = css`
     @media ${screenSize.upToLarge} {
-        padding: 16px 20px;
+        padding: ${size.large} ${size.medium} 48px;
     }
 `;
 
@@ -70,21 +64,13 @@ const CustomGradientOrderedList = styled('ol')`
 const EligibilitySection = styled('div')`
     background-color: ${({ theme }) => theme.colorMap.devBlack};
     padding: ${SECTION_VERTICAL_PADDING} ${SECTION_HORIZONTAL_PADDING};
-    ${centerContentOnMobile};
     ${reducePaddingOnMobile};
 `;
 
-const HowToJoin = () => (
-    <EligibilitySection>
-        <MediaBlock
-            mediaComponent={
-                <img
-                    src={EducatorsJoin}
-                    alt="person with book and browser window looking over six other people"
-                />
-            }
-            reverse
-        >
+const HowToJoin = () => {
+    const isMobile = useMedia(screenSize.upToLarge);
+    const Requirements = () => (
+        <>
             <H4>How to join MongoDB for Academia</H4>
             <P>You're eligible for this program if you teach:</P>
             <GreenBulletedList
@@ -92,24 +78,44 @@ const HowToJoin = () => (
                     'Higher Education, College and University programs',
                     'Bootcamps and Online Courses',
                 ]}
-            ></GreenBulletedList>
-            <CustomGradientOrderedList>
-                <li>
-                    <P2 collapse>Fill out a form with teaching details</P2>
-                </li>
-                <li>
-                    <P2 collapse>Our team will verify your details</P2>
-                </li>
-                <li>
-                    <P2 collapse>You'll get an email within 5 business days</P2>
-                </li>
-                <li>
-                    <P2 collapse>Bring your students on board</P2>
-                </li>
-            </CustomGradientOrderedList>
-            <SignUpModal />
-        </MediaBlock>
-    </EligibilitySection>
-);
+            />
+        </>
+    );
+    return (
+        <EligibilitySection>
+            <MediaBlock
+                mediaComponent={
+                    <>
+                        {isMobile && <Requirements />}
+                        <img
+                            src={EducatorsJoin}
+                            alt="person with book and browser window looking over six other people"
+                        />
+                    </>
+                }
+                reverse
+            >
+                {!isMobile && <Requirements />}
+                <CustomGradientOrderedList>
+                    <li>
+                        <P2 collapse>Fill out a form with teaching details</P2>
+                    </li>
+                    <li>
+                        <P2 collapse>Our team will verify your details</P2>
+                    </li>
+                    <li>
+                        <P2 collapse>
+                            You'll get an email within 5 business days
+                        </P2>
+                    </li>
+                    <li>
+                        <P2 collapse>Bring your students on board</P2>
+                    </li>
+                </CustomGradientOrderedList>
+                <SignUpModal />
+            </MediaBlock>
+        </EligibilitySection>
+    );
+};
 
 export default HowToJoin;

--- a/src/components/pages/educators/program-benefits.js
+++ b/src/components/pages/educators/program-benefits.js
@@ -16,13 +16,6 @@ const FeaturedBenefitMaxWidthContainer = styled('div')`
     max-width: ${MAX_FEATURED_BENEFIT_WIDTH};
 `;
 
-const centerContentOnMobile = css`
-    @media ${screenSize.upToLarge} {
-        justify-content: center;
-        text-align: center;
-    }
-`;
-
 const reducePaddingOnMobile = css`
     @media ${screenSize.upToLarge} {
         padding: 16px 20px;
@@ -38,6 +31,7 @@ const BenefitsLayout = styled('div')`
         align-items: center;
         justify-content: unset;
         flex-direction: column;
+        margin-top: ${size.large};
     }
 `;
 
@@ -46,7 +40,6 @@ const BodyContent = styled('div')`
     display: flex;
     flex-direction: column;
     padding: ${SECTION_VERTICAL_PADDING} ${SECTION_HORIZONTAL_PADDING};
-    ${centerContentOnMobile};
     ${reducePaddingOnMobile};
 `;
 
@@ -66,7 +59,7 @@ const FeaturedBenefit = ({ bullets, image, title }) => (
 
 const ProgramBenefits = () => (
     <BodyContent>
-        <H3>Teach MongoDB with confidence</H3>
+        <H3 collapse>Teach MongoDB with confidence</H3>
         <BenefitsLayout>
             <FeaturedBenefit
                 bullets={[

--- a/src/components/pages/project/additional-projects.js
+++ b/src/components/pages/project/additional-projects.js
@@ -10,9 +10,8 @@ import { grid, size } from '~components/dev-hub/theme';
 import { transformProjectStrapiData } from '~utils/transform-project-strapi-data';
 import Button from '~components/dev-hub/button';
 
-const GRID_COL_GAP = '24px';
+const GRID_COL_GAP = size.mediumLarge;
 const GRID_LAYOUT = { rowSpan: [1], colSpan: [1] };
-const GRID_ROW_HEIGHT = '282px';
 const MOBILE_GRID_LAYOUT = { rowSpan: [1], colSpan: [1] };
 const NUM_ADDITIONAL_PROJECTS = 4;
 
@@ -82,7 +81,6 @@ const AdditionalProjects = ({ excludedProjectName }) => {
                     mobileLayout={MOBILE_GRID_LAYOUT}
                     mobileNumCols={2}
                     numCols={NUM_ADDITIONAL_PROJECTS}
-                    rowHeight={GRID_ROW_HEIGHT}
                 >
                     {mappedProjects.map(project => (
                         <ProjectCard key={project.name} project={project} />

--- a/src/components/pages/students/all-projects.js
+++ b/src/components/pages/students/all-projects.js
@@ -6,10 +6,9 @@ import Grid from '~components/dev-hub/grid';
 import Paginate from '~components/dev-hub/paginate';
 import ProjectCard from '~components/dev-hub/project-card';
 import { H3 } from '~components/dev-hub/text';
-import { size } from '~components/dev-hub/theme';
+import { screenSize, size } from '~components/dev-hub/theme';
 import { transformProjectStrapiData } from '~utils/transform-project-strapi-data';
 
-const GRID_ROW_HEIGHT = '360px';
 const PAGINATION_LIMIT = 7;
 
 const allGalleryProjects = graphql`
@@ -26,10 +25,17 @@ const AllProjectsContainer = styled('div')`
     border-bottom: 1px solid ${({ theme }) => theme.colorMap.greyDarkTwo};
     padding-top: 48px;
     padding-bottom: ${size.xlarge};
+    @media ${screenSize.upToLarge} {
+        padding-bottom: ${size.large};
+        padding-top: ${size.large};
+    }
 `;
 
 const TitleWithBottomPadding = styled(H3)`
     padding-bottom: ${size.large};
+    @media ${screenSize.upToLarge} {
+        padding-bottom: ${size.mediumLarge};
+    }
 `;
 
 const AllProjects = () => {
@@ -49,7 +55,6 @@ const AllProjects = () => {
     );
     const gridProps = {
         gridGap: '48px',
-        rowHeight: GRID_ROW_HEIGHT,
         mobileNumCols: 2,
         numCols: 3,
         layout: gridLayout,

--- a/src/components/pages/students/featured-project.js
+++ b/src/components/pages/students/featured-project.js
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import dlv from 'dlv';
 import { useStaticQuery, graphql } from 'gatsby';
+import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import BlogTagList from '~components/dev-hub/blog-tag-list';
 import Link from '~components/dev-hub/link';
@@ -8,16 +9,34 @@ import AuthorImageList from '~components/dev-hub/author-image-list';
 import Badge from '~components/dev-hub/badge';
 import Grid from '~components/dev-hub/grid';
 import { H5, P } from '~components/dev-hub/text';
-import { size } from '~components/dev-hub/theme';
+import { screenSize, size } from '~components/dev-hub/theme';
 import { transformProjectStrapiData } from '~utils/transform-project-strapi-data';
+import useMedia from '~src/hooks/use-media';
+
+const bottomBorder = theme => css`
+    border-bottom: 1px solid ${theme.colorMap.greyDarkTwo};
+`;
 
 const AuthorImageListWithMargin = styled(AuthorImageList)`
     margin-bottom: ${size.large};
+    @media ${screenSize.upToLarge} {
+        margin-bottom: ${size.mediumLarge};
+    }
+`;
+
+const BottomBorderOnMobile = styled('div')`
+    @media ${screenSize.upToLarge} {
+        ${({ theme }) => bottomBorder(theme)};
+        padding-bottom: ${size.large};
+    }
 `;
 
 const DescriptionText = styled(P)`
     color: ${({ theme }) => theme.colorMap.greyLightTwo};
     margin-bottom: 48px;
+    @media ${screenSize.upToLarge} {
+        margin-bottom: ${size.mediumLarge};
+    }
 `;
 
 const FeaturedImage = styled('img')`
@@ -28,14 +47,27 @@ const FeaturedImage = styled('img')`
 `;
 
 const GridWithBottomBorder = styled(Grid)`
-    border-bottom: 1px solid ${({ theme }) => theme.colorMap.greyDarkTwo};
+    ${({ theme }) => bottomBorder(theme)};
     padding-bottom: ${size.xlarge};
+    @media ${screenSize.upToLarge} {
+        border-bottom: none;
+        padding-bottom: ${size.large};
+    }
+`;
+
+const ProjectName = styled(H5)`
+    @media ${screenSize.upToLarge} {
+        margin-bottom: ${size.xsmall};
+    }
 `;
 
 const RelativePositionedBadge = styled(Badge)`
     margin-left: 0;
     position: relative;
     width: fit-content;
+    @media ${screenSize.upToLarge} {
+        margin-bottom: ${size.small};
+    }
 `;
 
 const StyledLink = styled(Link)`
@@ -46,6 +78,9 @@ const StyledLink = styled(Link)`
 
 const TagListWithMargin = styled(BlogTagList)`
     margin-bottom: 48px;
+    @media ${screenSize.upToLarge} {
+        margin-bottom: ${size.mediumLarge};
+    }
 `;
 
 const galleryFeaturedProject = graphql`
@@ -72,25 +107,35 @@ const FeaturedProject = () => {
         students,
         tags,
     } = transformProjectStrapiData(project);
+    const isMobile = useMedia(screenSize.upToLarge);
+    const ProjectDetails = () => (
+        <div>
+            <RelativePositionedBadge contentType="featured" />
+            <ProjectName>{name}</ProjectName>
+            <DescriptionText>{description}</DescriptionText>
+            <AuthorImageListWithMargin size={30} students={students} />
+            <TagListWithMargin navigates={false} tags={tags} />
+            <StyledLink tertiary to={slug}>
+                View Project
+            </StyledLink>
+        </div>
+    );
     return (
-        <GridWithBottomBorder
-            layout={gridLayout}
-            gridGap="48px"
-            rowHeight="460px"
-            numCols={3}
-        >
-            <FeaturedImage src={image_url} />
-            <div>
-                <RelativePositionedBadge contentType="featured" />
-                <H5>{name}</H5>
-                <DescriptionText>{description}</DescriptionText>
-                <AuthorImageListWithMargin size={30} students={students} />
-                <TagListWithMargin navigates={false} tags={tags} />
-                <StyledLink tertiary to={slug}>
-                    View Project
-                </StyledLink>
-            </div>
-        </GridWithBottomBorder>
+        <BottomBorderOnMobile>
+            <GridWithBottomBorder
+                mobileLayout={{ rowSpan: [1], colSpan: [1] }}
+                layout={gridLayout}
+                gridGap="48px"
+                rowHeight="460px"
+                mobileNumCols={1}
+                mobileGridGap={size.default}
+                numCols={3}
+            >
+                <FeaturedImage src={image_url} />
+                {!isMobile && <ProjectDetails />}
+            </GridWithBottomBorder>
+            {isMobile && <ProjectDetails />}
+        </BottomBorderOnMobile>
     );
 };
 

--- a/src/pages/academia/students/index.js
+++ b/src/pages/academia/students/index.js
@@ -25,6 +25,10 @@ const ContentContainer = styled('div')`
 const TopPaddedShareProjectCTA = styled(ShareProjectCTA)`
     padding-top: ${size.xlarge};
     padding-bottom: 88px;
+    @media ${screenSize.upToLarge} {
+        padding-bottom: ${size.large};
+        padding-top: ${size.large};
+    }
 `;
 
 const Students = ({ path }) => {


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-444-nitpicks/)
[Figma](https://www.figma.com/file/QuUf86imwSoPNYoxZX3az2/Academia---Student-Spotlights?node-id=1231%3A2529)

This PR clean up mobile-responsive behavior and sticks to our Figma for mobile styling. Here is what was updated in this PR:

Academia entry page:
- Swapped text color to more white on mobile since hover state is less prevalent on mobile

Educators Page:
- Fixed padding throughout
- Removed centering of text
- Fixed margins throughout
- Swapped ordering of bottom section on mobile

Gallery page:
- Made the featured project responsive
- Adjusted padding throughout

Misc:
- Removed extra content on project cards on mobile
- Let the GitHub image scale appropriately
- Fixed issues with the grid for one child
- 