### PR TITLE
DEVHUB-444 [Part 6]: Form Responsiveness

### DIFF
--- a/src/components/pages/student-submit/form/condensed-student-entry.js
+++ b/src/components/pages/student-submit/form/condensed-student-entry.js
@@ -43,6 +43,7 @@ const RemoveButton = styled(Button)`
 const CondensedStudentEntry = ({ authorImage, onEdit, onRemove, state }) => (
     <CondensedContainer>
         <AuthorImage
+            hideOnMobile={false}
             isInternalReference={false}
             height={IMAGE_PREVIEW_SIZE}
             width={IMAGE_PREVIEW_SIZE}

--- a/src/components/pages/student-submit/form/dropzone-thumbnail.js
+++ b/src/components/pages/student-submit/form/dropzone-thumbnail.js
@@ -48,11 +48,11 @@ const Image = styled('img')`
     width: auto;
 `;
 
-const DropzoneThumbnail = ({ file, removeImage, row }) => {
+const DropzoneThumbnail = ({ file, removeImage }) => {
     const isFile = !!file;
     const preview = isFile && file.preview;
     return (
-        <ThumbnailWrapper row={row}>
+        <ThumbnailWrapper>
             <ThumbnailContent>
                 {preview ? (
                     <div>

--- a/src/components/pages/student-submit/form/dropzone-thumbnail.js
+++ b/src/components/pages/student-submit/form/dropzone-thumbnail.js
@@ -4,6 +4,8 @@ import { screenSize, size } from '~components/dev-hub/theme';
 import Icon from '@leafygreen-ui/icon';
 import Button from '~components/dev-hub/button';
 
+export const THUMBNAIL_MOBILE_HEIGHT = '74px';
+export const THUMBNAIL_MOBILE_WIDTH = '74px';
 export const THUMBNAIL_WIDTH = '96px';
 
 const RemoveButton = styled(Button)`
@@ -26,6 +28,9 @@ const ThumbnailWrapper = styled('div')`
     }
     @media ${screenSize.upToLarge} {
         grid-row-start: ${({ row }) => row};
+        height: ${THUMBNAIL_MOBILE_HEIGHT};
+        margin: 0;
+        width: ${THUMBNAIL_MOBILE_WIDTH};
     }
 `;
 

--- a/src/components/pages/student-submit/form/dropzone-thumbnail.js
+++ b/src/components/pages/student-submit/form/dropzone-thumbnail.js
@@ -18,7 +18,6 @@ const RemoveButton = styled(Button)`
 const ThumbnailWrapper = styled('div')`
     border: 1px dashed ${({ theme }) => theme.colorMap.greyLightThree};
     border-radius: 10px;
-    grid-row-start: 2;
     height: ${size.xlarge};
     margin: 0 ${size.mediumLarge} ${size.xsmall} 0;
     padding: 4px;
@@ -26,8 +25,7 @@ const ThumbnailWrapper = styled('div')`
     :last-of-type {
         margin-right: 0;
     }
-    @media ${screenSize.upToLarge} {
-        grid-row-start: ${({ row }) => row};
+    @media ${screenSize.upToMedium} {
         height: ${THUMBNAIL_MOBILE_HEIGHT};
         margin: 0;
         width: ${THUMBNAIL_MOBILE_WIDTH};

--- a/src/components/pages/student-submit/form/dropzone-thumbnail.js
+++ b/src/components/pages/student-submit/form/dropzone-thumbnail.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { size } from '~components/dev-hub/theme';
+import { screenSize, size } from '~components/dev-hub/theme';
 import Icon from '@leafygreen-ui/icon';
 import Button from '~components/dev-hub/button';
 
@@ -24,6 +24,9 @@ const ThumbnailWrapper = styled('div')`
     :last-of-type {
         margin-right: 0;
     }
+    @media ${screenSize.upToLarge} {
+        grid-row-start: ${({ row }) => row};
+    }
 `;
 
 const ThumbnailContent = styled('div')`
@@ -42,11 +45,11 @@ const Image = styled('img')`
     width: auto;
 `;
 
-const DropzoneThumbnail = ({ file, removeImage }) => {
+const DropzoneThumbnail = ({ file, removeImage, row }) => {
     const isFile = !!file;
     const preview = isFile && file.preview;
     return (
-        <ThumbnailWrapper>
+        <ThumbnailWrapper row={row}>
             <ThumbnailContent>
                 {preview ? (
                     <div>

--- a/src/components/pages/student-submit/form/image-dropzone.js
+++ b/src/components/pages/student-submit/form/image-dropzone.js
@@ -2,11 +2,17 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { useDropzone } from 'react-dropzone';
-import { H5, P, P3 } from '~components/dev-hub/text';
-import { layer, size } from '~components/dev-hub/theme';
+import { H5, P2, P3 } from '~components/dev-hub/text';
+import { layer, screenSize, size } from '~components/dev-hub/theme';
 import DropzoneThumbnail, { THUMBNAIL_WIDTH } from './dropzone-thumbnail';
+import useMedia from '~hooks/use-media';
 
 const DROPZONE_HEIGHT = '232px';
+const DROPZONE_MOBILE_HEIGHT = '48px';
+
+const firaMono = css`
+    font-family: 'Fira Mono';
+`;
 
 const greyText = theme => css`
     color: ${theme.colorMap.greyLightTwo};
@@ -20,7 +26,7 @@ const GreyH5 = styled(H5)`
     ${({ theme }) => greyText(theme)};
 `;
 
-const GreyP = styled(P)`
+const GreyP2 = styled(P2)`
     ${({ theme }) => greyText(theme)};
 `;
 
@@ -40,6 +46,9 @@ const Dropzone = styled('div')`
     justify-content: center;
     position: relative;
     text-align: center;
+    @media ${screenSize.upToLarge} {
+        height: ${DROPZONE_MOBILE_HEIGHT};
+    }
 `;
 
 const ThumbnailGrid = styled('div')`
@@ -50,6 +59,10 @@ const ThumbnailGrid = styled('div')`
     margin-top: ${size.mediumLarge};
     row-gap: 4px;
     text-align: center;
+    @media ${screenSize.upToLarge} {
+        grid-template-columns: repeat(3, 74px);
+        grid-template-rows: ${size.medium} 74px 74px;
+    }
 `;
 
 const ImageLabelText = styled(P3)`
@@ -91,6 +104,7 @@ const removeFileValueFromInput = input => (input.value = '');
 
 // Adopted from https://react-dropzone.js.org/#section-previews
 const ImageDropzone = ({ onChange, maxFiles = 6 }) => {
+    const isMobile = useMedia(screenSize.upToLarge);
     const [files, setFiles] = useState(new Array(maxFiles).fill(null));
     const filesWithoutNulls = useMemo(() => files.filter(f => !!f), [files]);
 
@@ -138,6 +152,7 @@ const ImageDropzone = ({ onChange, maxFiles = 6 }) => {
             file={file}
             key={file ? file.name : index}
             removeImage={removeImage(index)}
+            row={1 + Math.ceil((index + 1) / 3)}
         />
     ));
 
@@ -151,13 +166,21 @@ const ImageDropzone = ({ onChange, maxFiles = 6 }) => {
                     // We want to display for the validation message
                     style={{ display: 'block' }}
                 />
-                <GreyH5>Drag and drop images (6 max)</GreyH5>
-                <GreyP collapse>
-                    or <Underline>browse</Underline> to choose a file
-                </GreyP>
-                <GreyP3>
-                    (1600 x 1200 or larger recommended, up to 10MB each)
-                </GreyP3>
+                {isMobile ? (
+                    <GreyP2 collapse css={firaMono}>
+                        + Add Images
+                    </GreyP2>
+                ) : (
+                    <>
+                        <GreyH5>Drag and drop images (6 max)</GreyH5>
+                        <GreyP2 collapse>
+                            or <Underline>browse</Underline> to choose a file
+                        </GreyP2>
+                        <GreyP3>
+                            (1600 x 1200 or larger recommended, up to 10MB each)
+                        </GreyP3>
+                    </>
+                )}
             </Dropzone>
             <ThumbnailGrid>
                 <ImageLabelText collapse>Main Image</ImageLabelText>

--- a/src/components/pages/student-submit/form/image-dropzone.js
+++ b/src/components/pages/student-submit/form/image-dropzone.js
@@ -60,8 +60,11 @@ const ThumbnailGrid = styled('div')`
     row-gap: 4px;
     text-align: center;
     @media ${screenSize.upToLarge} {
+        grid-gap: ${size.default};
         grid-template-columns: repeat(3, 74px);
         grid-template-rows: ${size.medium} 74px 74px;
+        margin: ${size.xsmall} auto 0;
+        width: fit-content;
     }
 `;
 

--- a/src/components/pages/student-submit/form/image-dropzone.js
+++ b/src/components/pages/student-submit/form/image-dropzone.js
@@ -4,7 +4,11 @@ import styled from '@emotion/styled';
 import { useDropzone } from 'react-dropzone';
 import { H5, P2, P3 } from '~components/dev-hub/text';
 import { layer, screenSize, size } from '~components/dev-hub/theme';
-import DropzoneThumbnail, { THUMBNAIL_WIDTH } from './dropzone-thumbnail';
+import DropzoneThumbnail, {
+    THUMBNAIL_MOBILE_HEIGHT,
+    THUMBNAIL_MOBILE_WIDTH,
+    THUMBNAIL_WIDTH,
+} from './dropzone-thumbnail';
 import useMedia from '~hooks/use-media';
 
 const DROPZONE_HEIGHT = '232px';
@@ -62,9 +66,9 @@ const ThumbnailGrid = styled('div')`
     text-align: center;
     @media ${screenSize.upToMedium} {
         grid-gap: ${size.default};
-        grid-template-columns: repeat(3, 74px);
-        grid-template-rows: 74px 74px;
-        margin: ${size.mediumLarge} auto 0;
+        grid-template-columns: repeat(3, ${THUMBNAIL_MOBILE_WIDTH});
+        grid-template-rows: ${THUMBNAIL_MOBILE_HEIGHT} ${THUMBNAIL_MOBILE_HEIGHT};
+        margin: ${size.large} auto 0;
         width: fit-content;
     }
 `;
@@ -76,7 +80,7 @@ const ImageLabelText = styled(P3)`
     left: 14px;
     @media ${screenSize.upToMedium} {
         top: -20px;
-        left: 8px;
+        left: ${size.xsmall};
     }
 `;
 
@@ -115,7 +119,7 @@ const removeFileValueFromInput = input => (input.value = '');
 
 // Adopted from https://react-dropzone.js.org/#section-previews
 const ImageDropzone = ({ onChange, maxFiles = 6 }) => {
-    const isMobile = useMedia(screenSize.upToLarge);
+    const isMobile = useMedia(screenSize.upToMedium);
     const [files, setFiles] = useState(new Array(maxFiles).fill(null));
     const filesWithoutNulls = useMemo(() => files.filter(f => !!f), [files]);
 

--- a/src/components/pages/student-submit/form/image-dropzone.js
+++ b/src/components/pages/student-submit/form/image-dropzone.js
@@ -46,7 +46,7 @@ const Dropzone = styled('div')`
     justify-content: center;
     position: relative;
     text-align: center;
-    @media ${screenSize.upToLarge} {
+    @media ${screenSize.upToMedium} {
         height: ${DROPZONE_MOBILE_HEIGHT};
     }
 `;
@@ -55,21 +55,29 @@ const ThumbnailGrid = styled('div')`
     column-gap: ${size.mediumLarge};
     display: grid;
     grid-template-columns: repeat(6, ${THUMBNAIL_WIDTH});
-    grid-template-rows: ${size.medium} ${size.xlarge};
+    grid-template-rows: ${size.xlarge};
     margin-top: ${size.mediumLarge};
+    position: relative;
     row-gap: 4px;
     text-align: center;
-    @media ${screenSize.upToLarge} {
+    @media ${screenSize.upToMedium} {
         grid-gap: ${size.default};
         grid-template-columns: repeat(3, 74px);
-        grid-template-rows: ${size.medium} 74px 74px;
-        margin: ${size.xsmall} auto 0;
+        grid-template-rows: 74px 74px;
+        margin: ${size.mediumLarge} auto 0;
         width: fit-content;
     }
 `;
 
 const ImageLabelText = styled(P3)`
     color: ${({ theme }) => theme.colorMap.greyLightTwo};
+    position: absolute;
+    top: -20px;
+    left: 16px;
+    @media ${screenSize.upToMedium} {
+        top: -20px;
+        left: 8px;
+    }
 `;
 
 const FullInput = styled('input')`
@@ -155,7 +163,6 @@ const ImageDropzone = ({ onChange, maxFiles = 6 }) => {
             file={file}
             key={file ? file.name : index}
             removeImage={removeImage(index)}
-            row={1 + Math.ceil((index + 1) / 3)}
         />
     ));
 

--- a/src/components/pages/student-submit/form/image-dropzone.js
+++ b/src/components/pages/student-submit/form/image-dropzone.js
@@ -56,7 +56,7 @@ const ThumbnailGrid = styled('div')`
     display: grid;
     grid-template-columns: repeat(6, ${THUMBNAIL_WIDTH});
     grid-template-rows: ${size.xlarge};
-    margin-top: ${size.mediumLarge};
+    margin-top: 48px;
     position: relative;
     row-gap: 4px;
     text-align: center;
@@ -73,7 +73,7 @@ const ImageLabelText = styled(P3)`
     color: ${({ theme }) => theme.colorMap.greyLightTwo};
     position: absolute;
     top: -20px;
-    left: 16px;
+    left: 14px;
     @media ${screenSize.upToMedium} {
         top: -20px;
         left: 8px;

--- a/src/components/pages/student-submit/form/index.js
+++ b/src/components/pages/student-submit/form/index.js
@@ -8,10 +8,14 @@ import PromoteYourself from './promote-yourself';
 import ShareDetails from './share-details';
 import SuccessState from '~components/dev-hub/success-state';
 import { H3, P2 } from '~components/dev-hub/text';
+import { screenSize } from '~components/dev-hub/theme';
 import Modal from '~src/components/dev-hub/modal';
 
 const FormWithMargin = styled('form')`
     margin: ${size.xlarge} 0;
+    @media ${screenSize.upToLarge} {
+        margin-bottom: 48px;
+    }
 `;
 
 const uploadImagesToStrapi = async images => {

--- a/src/components/pages/student-submit/form/new-student-fieldset.js
+++ b/src/components/pages/student-submit/form/new-student-fieldset.js
@@ -122,6 +122,7 @@ const NewStudentFieldset = ({
                     <ButtonImage>
                         {hasActivePicture ? (
                             <AuthorImage
+                                hideOnMobile={false}
                                 isInternalReference={false}
                                 height={IMAGE_PREVIEW_SIZE}
                                 width={IMAGE_PREVIEW_SIZE}

--- a/src/components/pages/student-submit/form/project-info.js
+++ b/src/components/pages/student-submit/form/project-info.js
@@ -14,8 +14,9 @@ const LinksSection = styled('div')`
     grid-row-gap: ${size.mediumLarge};
     justify-content: space-between;
     margin-bottom: ${size.xlarge};
-    @media ${screenSize.upToMedium} {
+    @media ${screenSize.upToLarge} {
         grid-template-columns: 100%;
+        margin-bottom: ${size.large};
     }
 `;
 

--- a/src/components/pages/student-submit/form/promote-yourself.js
+++ b/src/components/pages/student-submit/form/promote-yourself.js
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react';
 import { STUDENT_DEFAULT_KEYS } from '~utils/student-spotlight-reducer';
 import styled from '@emotion/styled';
 import Button from '~components/dev-hub/button';
+import { screenSize } from '~components/dev-hub/theme';
 import SingleStudentFieldset from './single-student-fieldset';
 import SubmitFormFieldset from './submit-form-fieldset';
 
@@ -12,6 +13,9 @@ const wantsToRemoveStudent = student =>
 const RightAligned = styled('div')`
     display: flex;
     justify-content: flex-end;
+    @media ${screenSize.upToLarge} {
+        justify-content: center;
+    }
 `;
 
 const isEmpty = student => {

--- a/src/components/pages/student-submit/form/promote-yourself.js
+++ b/src/components/pages/student-submit/form/promote-yourself.js
@@ -10,7 +10,7 @@ const getRemoveStudentMsg = name => `Remove ${name} from project?`;
 const wantsToRemoveStudent = student =>
     window.confirm(getRemoveStudentMsg(student.first_name));
 
-const RightAligned = styled('div')`
+const CustomAligned = styled('div')`
     display: flex;
     justify-content: flex-end;
     @media ${screenSize.upToLarge} {
@@ -118,11 +118,11 @@ const PromoteYourself = ({
                     state={s}
                 />
             ))}
-            <RightAligned>
+            <CustomAligned>
                 <Button onClick={addNewStudent}>
                     + Add another team member
                 </Button>
-            </RightAligned>
+            </CustomAligned>
         </SubmitFormFieldset>
     );
 };

--- a/src/components/pages/student-submit/form/submit-form-fieldset.js
+++ b/src/components/pages/student-submit/form/submit-form-fieldset.js
@@ -27,10 +27,14 @@ const Fieldset = styled('fieldset')`
     max-width: ${FIELDSET_MAX_WIDTH};
     margin: 0 auto;
     :not(:last-of-type) {
-        margin-bottom: 24px;
+        margin-bottom: ${size.mediumLarge};
+        @media ${screenSize.upToLarge} {
+            margin-bottom: ${size.default};
+        }
     }
     @media ${screenSize.upToLarge} {
-        padding: ${size.large} ${size.default};
+        margin: 0 ${size.xsmall};
+        padding: ${size.default};
     }
 `;
 

--- a/src/components/pages/student-submit/form/submit-form-fieldset.js
+++ b/src/components/pages/student-submit/form/submit-form-fieldset.js
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import Button from '~components/dev-hub/button';
 import { H5 } from '~components/dev-hub/text';
-import { size } from '~components/dev-hub/theme';
+import { screenSize, size } from '~components/dev-hub/theme';
 
 const FIELDSET_MAX_WIDTH = '794px';
 
@@ -28,6 +28,9 @@ const Fieldset = styled('fieldset')`
     margin: 0 auto;
     :not(:last-of-type) {
         margin-bottom: 24px;
+    }
+    @media ${screenSize.upToLarge} {
+        padding: ${size.large} ${size.default};
     }
 `;
 


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-444-form/academia/students/submit/)

This PR adjusts the project submission form for Student Spotlights to be more mobile-responsive. Here are the highlights:
- Enable the `AuthorImage`s to show on mobile
- Adjust some top/side padding for larger input sizes
- Cleans up the image dropzone grid so we don't have to do manual setting of grid rows on the children