### PR TITLE
DEVHUB-444 [Part 7]: Fix input label overflow, student view

### DIFF
--- a/src/components/dev-hub/input-label.js
+++ b/src/components/dev-hub/input-label.js
@@ -1,6 +1,14 @@
 import React from 'react';
+import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { fontSize, layer, lineHeight } from './theme';
+
+const useEllipsisOnOverflow = labelAbsoluteLeft => css`
+    max-width: calc(100% - ${labelAbsoluteLeft}px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+`;
 
 export const InputLabel = styled('label')`
     background: linear-gradient(
@@ -14,9 +22,10 @@ export const InputLabel = styled('label')`
     line-height: ${lineHeight.tiny};
     left: ${({ labelAbsoluteLeft }) => labelAbsoluteLeft}px;
     position: absolute;
-    top: ${({ labelStartTop }) => labelStartTop}px;
     opacity: 0;
+    top: ${({ labelStartTop }) => labelStartTop}px;
     z-index: ${layer.front};
+    ${({ labelAbsoluteLeft }) => useEllipsisOnOverflow(labelAbsoluteLeft)}
 `;
 
 export default ({ children, ...props }) => {

--- a/src/components/pages/student-submit/form/condensed-student-entry.js
+++ b/src/components/pages/student-submit/form/condensed-student-entry.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import AuthorImage from '~components/dev-hub/author-image';
-import { size } from '~components/dev-hub/theme';
+import { screenSize, size } from '~components/dev-hub/theme';
 import Button from '~components/dev-hub/button';
 import { P3 } from '~components/dev-hub/text';
 
@@ -18,6 +18,11 @@ const CondensedContainer = styled('div')`
     display: grid;
     grid-template-columns: ${`${IMAGE_PREVIEW_SIZE}px`} auto ${EDIT_BUTTON_SIZE} ${REMOVE_BUTTON_SIZE};
     padding-bottom: ${size.mediumLarge};
+    @media ${screenSize.upToMedium} {
+        grid-template-columns: ${`${IMAGE_PREVIEW_SIZE}px`} auto;
+        grid-template-rows: auto 20px;
+        row-gap: ${size.xsmall};
+    }
 `;
 
 const PreviewText = styled(P3)`
@@ -33,11 +38,23 @@ const modifyButtonStyling = css`
 const EditButton = styled(Button)`
     color: ${({ theme }) => theme.colorMap.devWhite};
     ${modifyButtonStyling};
+    @media ${screenSize.upToMedium} {
+        margin-right: ${size.default};
+    }
 `;
 
 const RemoveButton = styled(Button)`
     color: ${({ theme }) => theme.colorMap.salmon};
     ${modifyButtonStyling};
+`;
+
+const ButtonContainer = styled('div')`
+    display: contents;
+    @media ${screenSize.upToMedium} {
+        display: block;
+        grid-column-start: 2;
+        grid-row-start: 2;
+    }
 `;
 
 const CondensedStudentEntry = ({ authorImage, onEdit, onRemove, state }) => (
@@ -55,12 +72,14 @@ const CondensedStudentEntry = ({ authorImage, onEdit, onRemove, state }) => (
             </PreviewText>
             <PreviewText collapse>{state.school_name}</PreviewText>
         </div>
-        <EditButton onClick={onEdit}>
-            <P3 collapse>Edit</P3>
-        </EditButton>
-        <RemoveButton onClick={onRemove}>
-            <P3 collapse>Remove</P3>
-        </RemoveButton>
+        <ButtonContainer>
+            <EditButton onClick={onEdit}>
+                <P3 collapse>Edit</P3>
+            </EditButton>
+            <RemoveButton onClick={onRemove}>
+                <P3 collapse>Remove</P3>
+            </RemoveButton>
+        </ButtonContainer>
     </CondensedContainer>
 );
 


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-444-labels/academia/students/submit/)

This PR updates the `labels` for inputs/textareas to prevent them from wrapping onto the next line. This PR also uses a new grid for the condensed view of a student when submitting, like so:

![Screen Shot 2021-02-22 at 1 49 50 PM](https://user-images.githubusercontent.com/9064401/108755304-16126780-7515-11eb-996c-189a7c786ad5.png)
