### PR TITLE
DEVHUB-485 Mobile Cleanup

### DIFF
--- a/src/components/dev-hub/media-block.js
+++ b/src/components/dev-hub/media-block.js
@@ -21,13 +21,16 @@ const columnSizes = ({ mediaWidth, reverse }) => css`
     }
 `;
 
-const gridStructure = ({ reverse, flexible }) => css`
+const gridStructure = ({ reverse, reverseImageOnMobile, flexible }) => css`
     grid-template-areas: ${reverse ? '"content image";' : '"image content";'};
     @media ${screenSize.upToLarge} {
         /* If flexible is true, this will allow media block to allow content to stack on smaller screens */
         ${flexible &&
         `grid-template-areas: 'image'
         'content';`}
+        ${reverseImageOnMobile &&
+        `grid-template-areas: 'content'
+        'image';`}
     }
 `;
 
@@ -76,10 +79,12 @@ const MediaBlock = ({
     reverse,
     fullWidthContentOnMobile,
     flexible = true,
+    reverseImageOnMobile = false,
 }) => (
     <MediaBlockContainer
         flexible={flexible}
         reverse={reverse}
+        reverseImageOnMobile={reverseImageOnMobile}
         mediaWidth={mediaWidth}
         className={className}
     >

--- a/src/components/dev-hub/modal.js
+++ b/src/components/dev-hub/modal.js
@@ -4,7 +4,7 @@ import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import AriaModal from 'react-aria-modal';
 import useMedia from '../../hooks/use-media';
-import { screenSize, size } from './theme';
+import { fontSize, screenSize, size } from './theme';
 import { useTheme } from 'emotion-theming';
 
 const transparentModalStyling = css`
@@ -37,9 +37,10 @@ const ModalDialog = styled('div')`
     ${({ transparent }) => transparent && transparentModalStyling};
 `;
 const CloseButtonWrapper = styled('div')`
-    font-weight: bold;
     color: ${({ theme }) => theme.colorMap.greyLightThree};
     cursor: pointer;
+    font-size: ${fontSize.medium};
+    font-weight: bold;
     padding: ${size.tiny};
 `;
 
@@ -106,7 +107,7 @@ export const Modal = ({
         ...dialogContainerStyle,
     };
     const dialogMobileStyle = {
-        padding: `${size.large}`,
+        padding: `${size.xsmall}`,
         ...dialogMobileContainerStyle,
     };
     const [isActive, setIsActive] = useState(isOpenToStart);

--- a/src/components/pages/academia/students-educators-details.js
+++ b/src/components/pages/academia/students-educators-details.js
@@ -54,6 +54,7 @@ const BenefitsLayout = styled('div')`
     padding: ${size.xlarge} 0;
     @media ${screenSize.upToLarge} {
         display: block;
+        padding: 0;
     }
 `;
 

--- a/src/components/pages/academia/students-educators-details.js
+++ b/src/components/pages/academia/students-educators-details.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import GreenBulletedList, {
     BulletText,
@@ -9,13 +10,39 @@ import Card from '~components/dev-hub/card';
 import { H5, P2 } from '~components/dev-hub/text';
 import { screenSize, size } from '~components/dev-hub/theme';
 
-const MOBILE_IMG_MAX_HEIGHT = '300px';
+const MOBILE_IMG_MAX_SIZE = '50%';
 const IMAGE_HEIGHT = '98px';
 const IMAGE_WIDTH = '130px';
 
+const absolutelyPlaceInSquare = css`
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+`;
+
+const responsiveSquareContainer = css`
+    margin: 0 auto;
+    position: relative;
+    :after {
+        content: '';
+        display: block;
+        padding-bottom: 100%;
+    }
+`;
+
+const ImageWrapper = styled('div')`
+    @media ${screenSize.upToMedium} {
+        max-height: ${MOBILE_IMG_MAX_SIZE};
+        max-width: ${MOBILE_IMG_MAX_SIZE};
+        ${responsiveSquareContainer}
+    }
+`;
+
 const MaxWidthMobileImage = styled('img')`
     @media ${screenSize.upToMedium} {
-        max-height: ${MOBILE_IMG_MAX_HEIGHT};
+        ${absolutelyPlaceInSquare}
     }
 `;
 
@@ -82,12 +109,9 @@ const BenefitTypeCard = ({ bullets, image, href, to, isStudents = true }) => {
     return (
         <NoMaxWidthCard href={href} to={to} collapseImage>
             <SingleBenefitLayout>
-                <MaxWidthMobileImage
-                    height="100%"
-                    width="100%"
-                    alt=""
-                    src={image}
-                />
+                <ImageWrapper>
+                    <MaxWidthMobileImage alt="" src={image} />
+                </ImageWrapper>
                 <CardRightSideContent>
                     <H5>{forAudienceText}</H5>
                     <GreenBulletedList children={bullets} />

--- a/src/components/pages/educators/how-to-join.js
+++ b/src/components/pages/educators/how-to-join.js
@@ -13,6 +13,12 @@ const CUSTOM_BULLET_SIZE = '24px';
 const SECTION_HORIZONTAL_PADDING = '120px';
 const SECTION_VERTICAL_PADDING = '60px';
 
+const P2WithConsistentLineHeight = styled(P2)`
+    @media ${screenSize.upToMedium} {
+        line-height: ${CUSTOM_BULLET_SIZE};
+    }
+`;
+
 // Custom counter so we can apply custom styles after disabling list-style
 const customOrderedListCounter = css`
     counter-reset: ordered-list-counter;
@@ -98,18 +104,24 @@ const HowToJoin = () => {
                 {!isMobile && <Requirements />}
                 <CustomGradientOrderedList>
                     <li>
-                        <P2 collapse>Fill out a form with teaching details</P2>
+                        <P2WithConsistentLineHeight collapse>
+                            Fill out a form with teaching details
+                        </P2WithConsistentLineHeight>
                     </li>
                     <li>
-                        <P2 collapse>Our team will verify your details</P2>
+                        <P2WithConsistentLineHeight collapse>
+                            Our team will verify your details
+                        </P2WithConsistentLineHeight>
                     </li>
                     <li>
-                        <P2 collapse>
+                        <P2WithConsistentLineHeight collapse>
                             You'll get an email within 5 business days
-                        </P2>
+                        </P2WithConsistentLineHeight>
                     </li>
                     <li>
-                        <P2 collapse>Bring your students on board</P2>
+                        <P2WithConsistentLineHeight collapse>
+                            Bring your students on board
+                        </P2WithConsistentLineHeight>
                     </li>
                 </CustomGradientOrderedList>
                 <SignUpModal />

--- a/src/components/pages/home/academia-feature.js
+++ b/src/components/pages/home/academia-feature.js
@@ -15,7 +15,7 @@ const DescriptiveText = styled(P)`
 `;
 
 const SectionContent = styled('div')`
-    padding: 0 ${size.default};
+    padding: ${size.large} ${size.default};
     @media ${screenSize.largeAndUp} {
         margin-top: 15%;
         padding: 8%;
@@ -30,6 +30,7 @@ const AcademiaFeature = () => {
                 mediaWidth="550px"
                 mediaComponent={<ProjectCardGrid />}
                 reverse
+                reverseImageOnMobile
                 fullWidthContentOnMobile
             >
                 <SectionContent>

--- a/src/components/pages/student-submit/form/promote-yourself.js
+++ b/src/components/pages/student-submit/form/promote-yourself.js
@@ -37,6 +37,14 @@ const PromoteYourself = ({
         we allow for students to be added or removed
     */
     const [numStudents, setNumStudents] = useState(1);
+    const scrollToTopOfSection = useCallback(
+        () =>
+            window.scrollTo({
+                behavior: 'smooth',
+                top: newRef.current.offsetTop,
+            }),
+        [newRef]
+    );
     const updateStudents = useCallback(
         value => dispatch({ field: 'students', value }),
         [dispatch]
@@ -65,10 +73,17 @@ const PromoteYourself = ({
 
             newStudents.push({ key: numStudents, isExpanded: true });
             updateStudents(newStudents);
+            scrollToTopOfSection();
         } else {
             form.reportValidity();
         }
-    }, [newRef, numStudents, state.students, updateStudents]);
+    }, [
+        newRef,
+        numStudents,
+        scrollToTopOfSection,
+        state.students,
+        updateStudents,
+    ]);
     const editStudent = useCallback(
         i => () => {
             const newStudents = removeLastStudentIfEmpty();

--- a/src/components/pages/students/featured-project.js
+++ b/src/components/pages/students/featured-project.js
@@ -131,7 +131,9 @@ const FeaturedProject = () => {
                 mobileGridGap={size.default}
                 numCols={3}
             >
-                <FeaturedImage src={image_url} />
+                <Link to={slug}>
+                    <FeaturedImage src={image_url} />
+                </Link>
                 {!isMobile && <ProjectDetails />}
             </GridWithBottomBorder>
             {isMobile && <ProjectDetails />}


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-444-cleanup/)

This PR cleans up some mobile-specific issues for Student Spotlight. Here are the highlights:
- Adds a new prop to `MediaBlock` which lets us reverse the order of content on mobile
- Decreases the amount of padding on modals for mobile displays by default to 8px
- Drops the size of images on the academia entry page
- Properly aligns content on the "How to Join" section
- Makes the featured project image a link
- Adds scrolling to top of the form section when a new student is added