### PR TITLE
DEVHUB-444 [Part 8]: Mobile Project Page

### DIFF
--- a/src/components/dev-hub/image-gallery.js
+++ b/src/components/dev-hub/image-gallery.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
+import Button from './button';
 import { P } from './text';
 import { screenSize, size } from './theme';
 
@@ -31,9 +32,9 @@ const CurrentImage = styled('img')`
     }
 `;
 
-const ThumbnailWrapper = styled('div')`
-    cursor: pointer;
+const ThumbnailWrapper = styled(Button)`
     height: ${THUMBNAIL_SIZE};
+    padding: 0;
     width: ${THUMBNAIL_SIZE};
 `;
 

--- a/src/components/dev-hub/image-gallery.js
+++ b/src/components/dev-hub/image-gallery.js
@@ -7,6 +7,7 @@ import { screenSize, size } from './theme';
 const DESKTOP_GALLERY_HEIGHT = '450px';
 const DESKTOP_GALLERY_WIDTH = '1200px';
 const MAX_MOBILE_GALLERY_HEIGHT = '450px';
+const MOBILE_BREAKPOINT = screenSize.upToLarge;
 const THUMBNAIL_SIZE = '56px';
 
 const activeThumbnailBorder = theme => css`
@@ -24,7 +25,7 @@ const CurrentImage = styled('img')`
     margin-bottom: ${size.xsmall};
     object-fit: contain;
     width: ${DESKTOP_GALLERY_WIDTH};
-    @media ${screenSize.upToLarge} {
+    @media ${MOBILE_BREAKPOINT} {
         height: unset;
         max-height: ${MAX_MOBILE_GALLERY_HEIGHT};
     }
@@ -54,7 +55,7 @@ const ImageThumbnail = styled('img')`
 const GalleryItemsContainer = styled('div')`
     display: flex;
     justify-content: space-between;
-    @media ${screenSize.upToLarge} {
+    @media ${MOBILE_BREAKPOINT} {
         flex-direction: column-reverse;
     }
 `;
@@ -65,7 +66,7 @@ const ThumbnailContainer = styled('div')`
     grid-gap: ${size.xsmall};
     grid-template-columns: repeat(auto-fill, ${THUMBNAIL_SIZE});
     grid-template-rows: ${THUMBNAIL_SIZE};
-    @media ${screenSize.upToLarge} {
+    @media ${MOBILE_BREAKPOINT} {
         grid-auto-flow: row;
         justify-content: center;
         padding-bottom: ${size.mediumLarge};

--- a/src/components/dev-hub/image-gallery.js
+++ b/src/components/dev-hub/image-gallery.js
@@ -2,10 +2,11 @@ import React, { useState } from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { P } from './text';
-import { size } from './theme';
+import { screenSize, size } from './theme';
 
 const DESKTOP_GALLERY_HEIGHT = '450px';
 const DESKTOP_GALLERY_WIDTH = '1200px';
+const MAX_MOBILE_GALLERY_HEIGHT = '450px';
 const THUMBNAIL_SIZE = '56px';
 
 const activeThumbnailBorder = theme => css`
@@ -19,18 +20,20 @@ const hoverThumbnailBorder = theme => css`
 const CurrentImage = styled('img')`
     border-radius: ${size.xsmall};
     display: block;
+    height: ${DESKTOP_GALLERY_HEIGHT};
     margin-bottom: ${size.xsmall};
     object-fit: contain;
+    width: ${DESKTOP_GALLERY_WIDTH};
+    @media ${screenSize.upToLarge} {
+        height: unset;
+        max-height: ${MAX_MOBILE_GALLERY_HEIGHT};
+    }
 `;
 
 const ThumbnailWrapper = styled('div')`
     cursor: pointer;
-    margin-right: ${size.xsmall};
     height: ${THUMBNAIL_SIZE};
     width: ${THUMBNAIL_SIZE};
-    :last-of-type {
-        margin-right: 0;
-    }
 `;
 
 const ImageThumbnail = styled('img')`
@@ -51,10 +54,22 @@ const ImageThumbnail = styled('img')`
 const GalleryItemsContainer = styled('div')`
     display: flex;
     justify-content: space-between;
+    @media ${screenSize.upToLarge} {
+        flex-direction: column-reverse;
+    }
 `;
 
 const ThumbnailContainer = styled('div')`
-    display: flex;
+    display: grid;
+    grid-auto-flow: column;
+    grid-gap: ${size.xsmall};
+    grid-template-columns: repeat(auto-fill, ${THUMBNAIL_SIZE});
+    grid-template-rows: ${THUMBNAIL_SIZE};
+    @media ${screenSize.upToLarge} {
+        grid-auto-flow: row;
+        justify-content: center;
+        padding-bottom: ${size.mediumLarge};
+    }
 `;
 
 /**
@@ -66,11 +81,7 @@ const ImageGallery = ({ description, images }) => {
     const updateCurrentImage = img => setCurrentImage(img);
     return (
         <div>
-            <CurrentImage
-                height={DESKTOP_GALLERY_HEIGHT}
-                src={currentImage.src}
-                width={DESKTOP_GALLERY_WIDTH}
-            />
+            <CurrentImage src={currentImage.src} />
             <GalleryItemsContainer>
                 <P>{description}</P>
                 <ThumbnailContainer>

--- a/src/components/dev-hub/student-spotlight/share-project-cta.js
+++ b/src/components/dev-hub/student-spotlight/share-project-cta.js
@@ -10,6 +10,7 @@ const MAX_WIDTH = '600px';
 const MaxWidthContainer = styled('div')`
     margin: 0 auto;
     max-width: ${MAX_WIDTH};
+    padding: 0 ${size.default};
     text-align: center;
 `;
 

--- a/src/components/pages/project/students.js
+++ b/src/components/pages/project/students.js
@@ -8,7 +8,7 @@ import LinkedinIcon from '~components/dev-hub/icons/linkedin';
 import YoutubeIcon from '~components/dev-hub/icons/youtube';
 import AuthorImage from '~components/dev-hub/author-image';
 import { P3, H5 } from '~components/dev-hub/text';
-import { size } from '~components/dev-hub/theme';
+import { screenSize, size } from '~components/dev-hub/theme';
 import Link from '~components/Link';
 
 const AUTHOR_IMAGE_SIZE = 32;
@@ -46,6 +46,11 @@ const StudentLi = styled('li')`
     flex-direction: column;
     padding-bottom: 10px;
     margin-bottom: 10px;
+    @media ${screenSize.upToMedium} {
+        :last-of-type {
+            border-bottom: none;
+        }
+    }
 `;
 const StudentsList = styled('ul')`
     list-style: none;

--- a/src/templates/project.js
+++ b/src/templates/project.js
@@ -68,7 +68,7 @@ const InfoSidebar = styled('div')`
     }
 `;
 
-const TopPaddedShareProjectCTA = styled(ShareProjectCTA)`
+const ShareProjectCTAWithPadding = styled(ShareProjectCTA)`
     padding-top: ${size.xlarge};
     padding-bottom: 88px;
 `;
@@ -129,7 +129,7 @@ const Project = props => {
                 />
             </Container>
             <AdditionalProjects excludedProjectName={name} />
-            <TopPaddedShareProjectCTA />
+            <ShareProjectCTAWithPadding />
             <GithubStudentPack />
         </Layout>
     );


### PR DESCRIPTION
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-444-project-page/project/go-fifa/)

This PR clean up non-responsive elements of the project page, including the image gallery. Namely:
- Swaps image gallery to CSS grid and changes layout for mobile
- Removes bottom border from students list on mobile
- Adds 16px padding on the left and right for the share CTA component (since it is now below max width)