### PR TITLE
DEVHUB-485: Split Images in Form (v1, Pre-refactor)

### DIFF
--- a/src/components/pages/student-submit/form/image-dropzone.js
+++ b/src/components/pages/student-submit/form/image-dropzone.js
@@ -134,6 +134,7 @@ const ImageDropzone = ({ onChange, maxFiles = 5 }) => {
 
     const { getRootProps, getInputProps, inputRef } = useDropzone({
         accept: 'image/*',
+        maxFiles,
         onDrop: onDrop,
     });
 

--- a/src/components/pages/student-submit/form/image-dropzone.js
+++ b/src/components/pages/student-submit/form/image-dropzone.js
@@ -60,27 +60,19 @@ const ThumbnailGrid = styled('div')`
     display: grid;
     grid-template-columns: repeat(5, ${THUMBNAIL_WIDTH});
     grid-template-rows: ${size.xlarge};
-    margin: 48px auto 0;
+    margin: ${size.default} auto 0;
     position: relative;
     row-gap: 4px;
     text-align: center;
     width: fit-content;
     @media ${screenSize.upToMedium} {
         grid-gap: ${size.default};
-        grid-template-columns: repeat(3, ${THUMBNAIL_MOBILE_WIDTH});
-        grid-template-rows: ${THUMBNAIL_MOBILE_HEIGHT} ${THUMBNAIL_MOBILE_HEIGHT};
-        margin: ${size.large} auto 0;
-    }
-`;
-
-const ImageLabelText = styled(P3)`
-    color: ${({ theme }) => theme.colorMap.greyLightTwo};
-    position: absolute;
-    top: -20px;
-    left: 14px;
-    @media ${screenSize.upToMedium} {
-        top: -20px;
-        left: ${size.xsmall};
+        grid-auto-flow: row;
+        grid-template-columns: repeat(auto-fit, ${THUMBNAIL_MOBILE_WIDTH});
+        grid-template-rows: ${THUMBNAIL_MOBILE_HEIGHT};
+        margin: ${size.default} auto 0;
+        justify-content: center;
+        width: unset;
     }
 `;
 
@@ -175,7 +167,6 @@ const ImageDropzone = ({ onChange, maxFiles = 5 }) => {
         <section>
             <Dropzone {...getRootProps()}>
                 <FullInput
-                    required
                     {...getInputProps()}
                     // getInputProps() puts on a display: none
                     // We want to display for the validation message
@@ -197,10 +188,7 @@ const ImageDropzone = ({ onChange, maxFiles = 5 }) => {
                     </>
                 )}
             </Dropzone>
-            <ThumbnailGrid>
-                <ImageLabelText collapse>Main Image</ImageLabelText>
-                {thumbs}
-            </ThumbnailGrid>
+            <ThumbnailGrid>{thumbs}</ThumbnailGrid>
         </section>
     );
 };

--- a/src/components/pages/student-submit/form/image-dropzone.js
+++ b/src/components/pages/student-submit/form/image-dropzone.js
@@ -58,18 +58,18 @@ const Dropzone = styled('div')`
 const ThumbnailGrid = styled('div')`
     column-gap: ${size.mediumLarge};
     display: grid;
-    grid-template-columns: repeat(6, ${THUMBNAIL_WIDTH});
+    grid-template-columns: repeat(5, ${THUMBNAIL_WIDTH});
     grid-template-rows: ${size.xlarge};
-    margin-top: 48px;
+    margin: 48px auto 0;
     position: relative;
     row-gap: 4px;
     text-align: center;
+    width: fit-content;
     @media ${screenSize.upToMedium} {
         grid-gap: ${size.default};
         grid-template-columns: repeat(3, ${THUMBNAIL_MOBILE_WIDTH});
         grid-template-rows: ${THUMBNAIL_MOBILE_HEIGHT} ${THUMBNAIL_MOBILE_HEIGHT};
         margin: ${size.large} auto 0;
-        width: fit-content;
     }
 `;
 
@@ -118,7 +118,7 @@ const removeFileFromArray = (files, index) => {
 const removeFileValueFromInput = input => (input.value = '');
 
 // Adopted from https://react-dropzone.js.org/#section-previews
-const ImageDropzone = ({ onChange, maxFiles = 6 }) => {
+const ImageDropzone = ({ onChange, maxFiles = 5 }) => {
     const isMobile = useMedia(screenSize.upToMedium);
     const [files, setFiles] = useState(new Array(maxFiles).fill(null));
     const filesWithoutNulls = useMemo(() => files.filter(f => !!f), [files]);
@@ -186,7 +186,7 @@ const ImageDropzone = ({ onChange, maxFiles = 6 }) => {
                     </GreyP2>
                 ) : (
                     <>
-                        <GreyH5>Drag and drop images (6 max)</GreyH5>
+                        <GreyH5>Drag and drop images (5 max)</GreyH5>
                         <GreyP2 collapse>
                             or <Underline>browse</Underline> to choose a file
                         </GreyP2>

--- a/src/components/pages/student-submit/form/index.js
+++ b/src/components/pages/student-submit/form/index.js
@@ -55,7 +55,6 @@ const Form = () => {
                 (p, c) => p && c.checkValidity(),
                 true
             );
-            console.log(state);
             if (isValid) {
                 if (isFinalPart) {
                     await onStudentSpotlightFormSubmission(

--- a/src/components/pages/student-submit/form/index.js
+++ b/src/components/pages/student-submit/form/index.js
@@ -55,6 +55,7 @@ const Form = () => {
                 (p, c) => p && c.checkValidity(),
                 true
             );
+            console.log(state);
             if (isValid) {
                 if (isFinalPart) {
                     await onStudentSpotlightFormSubmission(

--- a/src/components/pages/student-submit/form/main-image-dropzone.js
+++ b/src/components/pages/student-submit/form/main-image-dropzone.js
@@ -1,11 +1,9 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { useDropzone } from 'react-dropzone';
 import { H5 } from '~components/dev-hub/text';
 import { layer, screenSize } from '~components/dev-hub/theme';
-import Icon from '@leafygreen-ui/icon';
-import Button from '~components/dev-hub/button';
 
 const DROPZONE_HEIGHT = '64px';
 const DROPZONE_MOBILE_HEIGHT = '48px';

--- a/src/components/pages/student-submit/form/main-image-dropzone.js
+++ b/src/components/pages/student-submit/form/main-image-dropzone.js
@@ -1,9 +1,11 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { useDropzone } from 'react-dropzone';
 import { H5 } from '~components/dev-hub/text';
 import { layer, screenSize } from '~components/dev-hub/theme';
+import Icon from '@leafygreen-ui/icon';
+import Button from '~components/dev-hub/button';
 
 const DROPZONE_HEIGHT = '64px';
 const DROPZONE_MOBILE_HEIGHT = '48px';
@@ -43,42 +45,44 @@ const FullInput = styled('input')`
     z-index: ${layer.superBack};
 `;
 
-const addAcceptedFilesToArray = (files, acceptedFiles, maxFiles) => {
-    let newFiles = [
-        ...acceptedFiles.map(file =>
-            Object.assign(file, {
-                preview: URL.createObjectURL(file),
-            })
-        ),
-        ...files,
-    ];
-    if (newFiles.length > maxFiles) {
-        newFiles = newFiles.slice(0, maxFiles);
-    }
-    return newFiles;
-};
+const ThumbnailContent = styled('div')`
+    display: flex;
+    max-height: 300px;
+    min-width: 0;
+    overflow: hidden;
+    position: relative;
+`;
 
-const removeFileFromArray = (files, index) => {
-    const newFiles = [...files];
-    newFiles[index] = null;
-    return newFiles;
-};
-
-const removeFileValueFromInput = input => (input.value = '');
+const Image = styled('img')`
+    display: block;
+    max-height: 100%;
+    margin: 0 auto;
+    object-fit: contain;
+    width: auto;
+`;
 
 // Adopted from https://react-dropzone.js.org/#section-previews
 const MainImageDropzone = ({ onChange }) => {
     const [file, setFile] = useState(null);
 
-    const { getRootProps, getInputProps, inputRef } = useDropzone({
-        accept: 'image/*',
-        onDrop: setFile,
-    });
+    const onDrop = files => {
+        if (files.length) {
+            const mainImage = files[0];
+            setFile(
+                Object.assign(mainImage, {
+                    preview: URL.createObjectURL(mainImage),
+                })
+            );
+        } else {
+            setFile(null);
+        }
+    };
 
-    const removeImage = useCallback(() => {
-        removeFileValueFromInput(inputRef.current);
-        setFile(null);
-    }, [inputRef]);
+    const { getRootProps, getInputProps } = useDropzone({
+        accept: 'image/*',
+        maxFiles: 1,
+        onDrop,
+    });
 
     useEffect(() => {
         onChange(file);
@@ -102,7 +106,13 @@ const MainImageDropzone = ({ onChange }) => {
                     // We want to display for the validation message
                     style={{ display: 'block' }}
                 />
-                <GreyH5 collapse>Drag and drop/upload image</GreyH5>
+                {file ? (
+                    <ThumbnailContent>
+                        <Image src={file.preview} />
+                    </ThumbnailContent>
+                ) : (
+                    <GreyH5 collapse>Drag and drop/upload image</GreyH5>
+                )}
             </Dropzone>
         </section>
     );

--- a/src/components/pages/student-submit/form/main-image-dropzone.js
+++ b/src/components/pages/student-submit/form/main-image-dropzone.js
@@ -1,0 +1,111 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+import { useDropzone } from 'react-dropzone';
+import { H5 } from '~components/dev-hub/text';
+import { layer, screenSize } from '~components/dev-hub/theme';
+
+const DROPZONE_HEIGHT = '64px';
+const DROPZONE_MOBILE_HEIGHT = '48px';
+
+const greyText = theme => css`
+    color: ${theme.colorMap.greyLightTwo};
+`;
+
+const GreyH5 = styled(H5)`
+    ${({ theme }) => greyText(theme)};
+`;
+
+const Dropzone = styled('div')`
+    align-items: center;
+    background: ${({ theme }) => theme.colorMap.greyDarkThree};
+    border: 1px dashed ${({ theme }) => theme.colorMap.greyLightThree};
+    border-radius: 10px;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    min-height: ${DROPZONE_HEIGHT};
+    justify-content: center;
+    position: relative;
+    text-align: center;
+    @media ${screenSize.upToMedium} {
+        height: ${DROPZONE_MOBILE_HEIGHT};
+    }
+`;
+
+const FullInput = styled('input')`
+    position: absolute;
+    content: '';
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    z-index: ${layer.superBack};
+`;
+
+const addAcceptedFilesToArray = (files, acceptedFiles, maxFiles) => {
+    let newFiles = [
+        ...acceptedFiles.map(file =>
+            Object.assign(file, {
+                preview: URL.createObjectURL(file),
+            })
+        ),
+        ...files,
+    ];
+    if (newFiles.length > maxFiles) {
+        newFiles = newFiles.slice(0, maxFiles);
+    }
+    return newFiles;
+};
+
+const removeFileFromArray = (files, index) => {
+    const newFiles = [...files];
+    newFiles[index] = null;
+    return newFiles;
+};
+
+const removeFileValueFromInput = input => (input.value = '');
+
+// Adopted from https://react-dropzone.js.org/#section-previews
+const MainImageDropzone = ({ onChange }) => {
+    const [file, setFile] = useState(null);
+
+    const { getRootProps, getInputProps, inputRef } = useDropzone({
+        accept: 'image/*',
+        onDrop: setFile,
+    });
+
+    const removeImage = useCallback(() => {
+        removeFileValueFromInput(inputRef.current);
+        setFile(null);
+    }, [inputRef]);
+
+    useEffect(() => {
+        onChange(file);
+    }, [file, onChange]);
+
+    useEffect(
+        () => () => {
+            // Make sure to revoke the data uris to avoid memory leaks
+            file && URL.revokeObjectURL(file.preview);
+        },
+        [file]
+    );
+
+    return (
+        <section>
+            <Dropzone {...getRootProps()}>
+                <FullInput
+                    required
+                    {...getInputProps()}
+                    // getInputProps() puts on a display: none
+                    // We want to display for the validation message
+                    style={{ display: 'block' }}
+                />
+                <GreyH5 collapse>Drag and drop/upload image</GreyH5>
+            </Dropzone>
+        </section>
+    );
+};
+
+export default MainImageDropzone;

--- a/src/components/pages/student-submit/form/main-image-dropzone.js
+++ b/src/components/pages/student-submit/form/main-image-dropzone.js
@@ -2,17 +2,26 @@ import React, { useEffect, useState } from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { useDropzone } from 'react-dropzone';
-import { H5 } from '~components/dev-hub/text';
+import { H5, P2 } from '~components/dev-hub/text';
 import { layer, screenSize } from '~components/dev-hub/theme';
+import useMedia from '~hooks/use-media';
 
 const DROPZONE_HEIGHT = '64px';
 const DROPZONE_MOBILE_HEIGHT = '48px';
+
+const firaMono = css`
+    font-family: 'Fira Mono';
+`;
 
 const greyText = theme => css`
     color: ${theme.colorMap.greyLightTwo};
 `;
 
 const GreyH5 = styled(H5)`
+    ${({ theme }) => greyText(theme)};
+`;
+
+const GreyP2 = styled(P2)`
     ${({ theme }) => greyText(theme)};
 `;
 
@@ -29,7 +38,7 @@ const Dropzone = styled('div')`
     position: relative;
     text-align: center;
     @media ${screenSize.upToMedium} {
-        height: ${DROPZONE_MOBILE_HEIGHT};
+        min-height: ${DROPZONE_MOBILE_HEIGHT};
     }
 `;
 
@@ -62,7 +71,7 @@ const Image = styled('img')`
 // Adopted from https://react-dropzone.js.org/#section-previews
 const MainImageDropzone = ({ onChange }) => {
     const [file, setFile] = useState(null);
-
+    const isMobile = useMedia(screenSize.upToMedium);
     const onDrop = files => {
         if (files.length) {
             const mainImage = files[0];
@@ -108,6 +117,10 @@ const MainImageDropzone = ({ onChange }) => {
                     <ThumbnailContent>
                         <Image src={file.preview} />
                     </ThumbnailContent>
+                ) : isMobile ? (
+                    <GreyP2 collapse css={firaMono}>
+                        + Add Image
+                    </GreyP2>
                 ) : (
                     <GreyH5 collapse>Drag and drop/upload image</GreyH5>
                 )}

--- a/src/components/pages/student-submit/form/project-info.js
+++ b/src/components/pages/student-submit/form/project-info.js
@@ -5,9 +5,13 @@ import MainImageDropzone from './main-image-dropzone';
 import ImageDropzone from './image-dropzone';
 import SubmitFormFieldset from './submit-form-fieldset';
 import { screenSize, size } from '~components/dev-hub/theme';
-import { H5 } from '~components/dev-hub/text';
+import { H5, P2 } from '~components/dev-hub/text';
 
 const INPUT_BOX_WIDTH = '336px';
+
+const GreyP2 = styled(P2)`
+    color: ${({ theme }) => theme.colorMap.greyLightTwo};
+`;
 
 const LinksSection = styled('div')`
     display: grid;
@@ -91,7 +95,9 @@ const ProjectInfo = ({ state, onChange, ...props }) => {
                 />
             </LinksSection>
             <H5>Show off with images and video</H5>
+            <GreyP2 collapse>Main Image</GreyP2>
             <MainImageDropzone onChange={onMainImageDropzoneChange} />
+            <GreyP2 collapse>Additional Images</GreyP2>
             <ImageDropzone onChange={onAdditionalImageDropzoneChange} />
             <FormInput
                 required={false}

--- a/src/components/pages/student-submit/form/project-info.js
+++ b/src/components/pages/student-submit/form/project-info.js
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import styled from '@emotion/styled';
 import Input from '~components/dev-hub/input';
+import MainImageDropzone from './main-image-dropzone';
 import ImageDropzone from './image-dropzone';
 import SubmitFormFieldset from './submit-form-fieldset';
 import { screenSize, size } from '~components/dev-hub/theme';
@@ -25,12 +26,23 @@ const FormInput = ({ required = true, ...props }) => (
 );
 
 const ProjectInfo = ({ state, onChange, ...props }) => {
-    const onImageDropzoneChange = useCallback(
+    const onAdditionalImageDropzoneChange = useCallback(
         images => {
             onChange({
                 target: {
-                    name: 'project_images',
+                    name: 'additional_images',
                     value: images,
+                },
+            });
+        },
+        [onChange]
+    );
+    const onMainImageDropzoneChange = useCallback(
+        image => {
+            onChange({
+                target: {
+                    name: 'image',
+                    value: image,
                 },
             });
         },
@@ -79,7 +91,8 @@ const ProjectInfo = ({ state, onChange, ...props }) => {
                 />
             </LinksSection>
             <H5>Show off with images and video</H5>
-            <ImageDropzone onChange={onImageDropzoneChange} />
+            <MainImageDropzone onChange={onMainImageDropzoneChange} />
+            <ImageDropzone onChange={onAdditionalImageDropzoneChange} />
             <FormInput
                 required={false}
                 name="youtube_link"

--- a/src/utils/on-student-spotlight-form-submission.js
+++ b/src/utils/on-student-spotlight-form-submission.js
@@ -15,13 +15,25 @@ export const onStudentSpotlightFormSubmission = async (
     const {
         success: projImageSuccess,
         data: projImageData,
-    } = await uploadImagesToStrapi(newState.project_images);
+    } = await uploadImagesToStrapi([newState.image]);
     if (!projImageSuccess) {
         setError(projImageData);
         setIsSubmitting(false);
         return;
     }
-    newState.project_images = projImageData;
+    newState.image = projImageData;
+
+    // Try project additional image upload
+    const {
+        success: addtlImageSuccess,
+        data: addtlImageData,
+    } = await uploadImagesToStrapi(newState.additional_images);
+    if (!addtlImageSuccess) {
+        setError(addtlImageData);
+        setIsSubmitting(false);
+        return;
+    }
+    newState.additional_images = addtlImageData;
 
     // Try student images upload
     const studentImages = newState.students.map(s => s.image);


### PR DESCRIPTION
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-485-split-form/academia/students/submit/)

This PR switches the functionality of the image collection for student spotlight projects to have a separate `input` for the Main Image versus the Additional Images. This makes choosing the main image for a project more intuitive since we don't have drag/drop or so.

This logic can definitely be generalized and refactored and that will come next. The first step is making the functional change and then we will refactor both the image-dropzone to generalize as well as the upload logic to batch everything together.

![Screen Shot 2021-02-24 at 12 03 16 PM](https://user-images.githubusercontent.com/9064401/109037093-54845f80-7698-11eb-80ad-63e4bcae7142.png)
