### PR TITLE
DEVHUB-485: Add support for depth property on nodeData for headings

### DIFF
--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -32,10 +32,12 @@ const HeadingMap = {
 };
 
 const Heading = ({ sectionDepth, nodeData, ...rest }) => {
+    const strapiHeadingDepth = nodeData.depth;
+    const headingDepth = sectionDepth || strapiHeadingDepth;
     const id = nodeData.id || '';
     const HeadingTag =
-        sectionDepth >= 1 && sectionDepth <= 5
-            ? HeadingMap[sectionDepth]
+        headingDepth >= 1 && headingDepth <= 5
+            ? HeadingMap[headingDepth]
             : HeadingMap[5];
     return (
         <HeadingTag id={id} css={showLinkOnHover}>
@@ -56,7 +58,7 @@ const Heading = ({ sectionDepth, nodeData, ...rest }) => {
 };
 
 Heading.propTypes = {
-    sectionDepth: PropTypes.number.isRequired,
+    sectionDepth: PropTypes.number,
     nodeData: PropTypes.shape({
         children: PropTypes.arrayOf(
             PropTypes.shape({

--- a/src/utils/setup/parse-markdown-to-ast.js
+++ b/src/utils/setup/parse-markdown-to-ast.js
@@ -16,7 +16,6 @@ export const parseMarkdownToAST = markdown => {
 
     function ondirective(node) {
         var data = node.data || (node.data = {});
-
         node['argument'] = [{ value: node.attributes.vid }];
         data['name'] = node.name;
         node.type = node.name;


### PR DESCRIPTION
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-485-fix-headings/project/database-development-dcp/)

This PR adds support for the `depth` property coming from Headings from strapi. This let's us properly render a heading as H1-5. It should not impact existing articles but project pages should now have a more clear hierarchy.