### PR TITLE
Use Realm Webhook for HTTPS FormData Pass Through

### DIFF
--- a/src/utils/on-student-spotlight-form-submission.js
+++ b/src/utils/on-student-spotlight-form-submission.js
@@ -15,7 +15,7 @@ export const onStudentSpotlightFormSubmission = async (
     const {
         success: projImageSuccess,
         data: projImageData,
-    } = await uploadImagesToStrapi([newState.image]);
+    } = await uploadImagesToStrapi(newState.image);
     if (!projImageSuccess) {
         setError(projImageData);
         setIsSubmitting(false);

--- a/src/utils/upload-images-to-strapi.js
+++ b/src/utils/upload-images-to-strapi.js
@@ -1,25 +1,30 @@
 import dlv from 'dlv';
 
+const WEBHOOK = `https://webhooks.mongodb-realm.com/api/client/v2.0/app/devhubauthentication-lidpq/service/strapi-image-webhook/incoming_webhook/photo-webhook`;
+
 export const uploadImagesToStrapi = async images => {
-    const form_data = new FormData();
-    images.forEach(img => {
-        form_data.append('files', img);
-    });
-    const r = await fetch(`${process.env.STRAPI_URL}/upload`, {
-        'Content-Type': 'multipart/form-data',
-        method: 'post',
-        body: form_data,
-    });
-    const resp = await r.json();
-    try {
-        return { success: true, data: resp.map(r => r._id) };
-    } catch (e) {
-        // Something failed in image upload
-        const errorMsg = dlv(
-            resp,
-            'data.errors.0.message',
-            'An unknown error occurred'
-        );
-        return { success: false, data: `${resp.error} ${errorMsg}` };
+    if (images && images.length) {
+        const form_data = new FormData();
+        images.forEach(img => {
+            form_data.append('files', img);
+        });
+        const r = await fetch(WEBHOOK, {
+            'Content-Type': 'multipart/form-data',
+            method: 'post',
+            body: form_data,
+        });
+        const resp = await r.json();
+        try {
+            return { success: true, data: resp.map(r => r._id) };
+        } catch (e) {
+            // Something failed in image upload
+            const errorMsg = dlv(
+                resp,
+                'data.errors.0.message',
+                'An unknown error occurred'
+            );
+            return { success: false, data: `${resp.error} ${errorMsg}` };
+        }
     }
+    return { success: true, data: [] };
 };


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/fix-submission-form/academia/students/submit)

This PR fixes a security issue with how we were uploading images to Strapi. Now we use a Realm webhook which acts as a pass-through which forwards requests to Strapi.