### PR TITLE
DEVHUB-500: Fix OG:URL /*/ bug on Academia Static Pages

### DIFF
--- a/src/pages/academia/index.js
+++ b/src/pages/academia/index.js
@@ -7,10 +7,11 @@ import {
     StudentsEducatorsDetails,
 } from '~components/pages/academia';
 import { useSiteMetadata } from '~hooks/use-site-metadata';
+import { removePathPrefixFromUrl } from '~utils/remove-path-prefix-from-url';
 
 const AcademiaLandingPage = ({ location }) => {
     const { siteUrl } = useSiteMetadata();
-    const fullUrl = `${siteUrl}${location.pathname}`;
+    const fullUrl = removePathPrefixFromUrl(`${siteUrl}${location.pathname}`);
     return (
         <Layout>
             <SEO

--- a/src/pages/academia/index.js
+++ b/src/pages/academia/index.js
@@ -8,9 +8,9 @@ import {
 } from '~components/pages/academia';
 import { useSiteMetadata } from '~hooks/use-site-metadata';
 
-const AcademiaLandingPage = ({ path }) => {
+const AcademiaLandingPage = ({ location }) => {
     const { siteUrl } = useSiteMetadata();
-    const fullUrl = `${siteUrl}${path}`;
+    const fullUrl = `${siteUrl}${location.pathname}`;
     return (
         <Layout>
             <SEO

--- a/src/pages/academia/students/index.js
+++ b/src/pages/academia/students/index.js
@@ -31,9 +31,9 @@ const TopPaddedShareProjectCTA = styled(ShareProjectCTA)`
     }
 `;
 
-const Students = ({ path }) => {
+const Students = ({ location }) => {
     const { siteUrl } = useSiteMetadata();
-    const fullUrl = `${siteUrl}${path}`;
+    const fullUrl = `${siteUrl}${location.pathname}`;
     return (
         <Layout>
             <SEO

--- a/src/pages/academia/students/index.js
+++ b/src/pages/academia/students/index.js
@@ -11,6 +11,7 @@ import AllProjects from '~components/pages/students/all-projects';
 import GalleryHeroBanner from '~components/pages/students/gallery-hero-banner';
 import { screenSize, size } from '~components/dev-hub/theme';
 import { useSiteMetadata } from '~hooks/use-site-metadata';
+import { removePathPrefixFromUrl } from '~utils/remove-path-prefix-from-url';
 
 const ContentContainer = styled('div')`
     padding-left: ${size.xxlarge};
@@ -33,7 +34,7 @@ const TopPaddedShareProjectCTA = styled(ShareProjectCTA)`
 
 const Students = ({ location }) => {
     const { siteUrl } = useSiteMetadata();
-    const fullUrl = `${siteUrl}${location.pathname}`;
+    const fullUrl = removePathPrefixFromUrl(`${siteUrl}${location.pathname}`);
     return (
         <Layout>
             <SEO

--- a/src/pages/academia/students/submit.js
+++ b/src/pages/academia/students/submit.js
@@ -3,10 +3,11 @@ import Layout from '~components/dev-hub/layout';
 import SEO from '~components/dev-hub/SEO';
 import { Form, TopBanner } from '~components/pages/student-submit';
 import { useSiteMetadata } from '~hooks/use-site-metadata';
+import { removePathPrefixFromUrl } from '~utils/remove-path-prefix-from-url';
 
 const Submit = ({ location }) => {
     const { siteUrl } = useSiteMetadata();
-    const fullUrl = `${siteUrl}${location.pathname}`;
+    const fullUrl = removePathPrefixFromUrl(`${siteUrl}${location.pathname}`);
     return (
         <Layout>
             <SEO

--- a/src/pages/academia/students/submit.js
+++ b/src/pages/academia/students/submit.js
@@ -4,9 +4,9 @@ import SEO from '~components/dev-hub/SEO';
 import { Form, TopBanner } from '~components/pages/student-submit';
 import { useSiteMetadata } from '~hooks/use-site-metadata';
 
-const Submit = ({ path }) => {
+const Submit = ({ location }) => {
     const { siteUrl } = useSiteMetadata();
-    const fullUrl = `${siteUrl}${path}`;
+    const fullUrl = `${siteUrl}${location.pathname}`;
     return (
         <Layout>
             <SEO


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/fix-spotlight-og/academia/)

This PR updates the logic for generating OG links on several static pages. This actually populates the tag correctly at build-time as `location` is provided at build time.