### PR TITLE
DEVHUB-509: Convert to using sitemap-index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ public/
 static/*
 # Assets we can add manually into the static folder
 !static/public
+!static/sitemap.xml
 coverage/
 .coverage
 .env.*

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -50,6 +50,7 @@ module.exports = {
         {
             resolve: 'gatsby-plugin-sitemap',
             options: {
+                output: '/sitemap-pages.xml',
                 // Exclude paths we are using the noindex tag on
                 exclude: [
                     '/language/*',

--- a/gatsby-config.prod.js
+++ b/gatsby-config.prod.js
@@ -46,6 +46,7 @@ module.exports = {
         },
         {
             resolve: 'gatsby-plugin-sitemap',
+            output: '/sitemap-pages.xml',
             options: {
                 // Exclude paths we are using the noindex tag on
                 exclude: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -15823,14 +15823,6 @@
       "integrity": "sha512-RxRdW++bvSHv4Mho999W0LLNdiQX1OMOvY0v1TlafcaYqJ93fYV/Jp3DDD6PKS0PAKNS8Q8DRsD67cipFmZCFA==",
       "requires": {
         "@babel/runtime": "7.12.5"
-      }
-    },
-    "gatsby-plugin-force-trailing-slashes": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-force-trailing-slashes/-/gatsby-plugin-force-trailing-slashes-1.0.5.tgz",
-      "integrity": "sha512-RxRdW++bvSHv4Mho999W0LLNdiQX1OMOvY0v1TlafcaYqJ93fYV/Jp3DDD6PKS0PAKNS8Q8DRsD67cipFmZCFA==",
-      "requires": {
-        "@babel/runtime": "7.12.5"
       },
       "dependencies": {
         "@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "gatsby-plugin-google-tagmanager": "^2.10.0",
     "gatsby-plugin-meta-redirect": "^1.1.1",
     "gatsby-plugin-react-helmet": "^3.9.0",
-    "gatsby-plugin-sitemap": "^2.11.0",
+    "gatsby-plugin-sitemap": "^2.12.0",
     "gatsby-plugin-webpack-bundle-analyser-v2": "^1.1.20",
     "gatsby-source-strapi": "0.0.12",
     "memoizerific": "^1.11.3",

--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <sitemap>
+      <loc>https://developer.mongodb.com/sitemap-pages.xml</loc>
+    </sitemap>
+    <sitemap>
+      <loc>https://developer.mongodb.com/community/forums/sitemap.xml</loc>
+    </sitemap>
+  </sitemapindex>


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-509/sitemap.xml)

This PR updates the logic for the sitemap to use a sitemap-index to point to the DevHub sitemap (now moved) as well as the Community Forums sitemap.

The cleanest way found was to generate a static xml file for the index to the two and use that while updating the location of the existing sitemap. This lets us keep the existing sitemap as-is and add in the new content without breaking past changes.