### PR TITLE
DEVHUB-498: Add tracking param to featured articles on home/learn pages

### DIFF
--- a/src/components/pages/home/hero.js
+++ b/src/components/pages/home/hero.js
@@ -46,7 +46,7 @@ const StyledTopCard = styled(Card)`
 // TODO: Generalize as new content types are supported
 const FeaturedHomePageItem = ({ item }) => {
     if (item.type === 'article') {
-        const { image, slug, title } = getFeaturedCardFields(item);
+        const { image, slug, title } = getFeaturedCardFields(item, 'home');
         return (
             <StyledTopCard image={image} to={slug} title={title} key={title} />
         );

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -130,7 +130,8 @@ const filterArticles = (filter, initialArticles) => {
 const SecondaryFeaturedArticle = ({ article, Wrapper }) => {
     try {
         const { description, slug, tags, title } = getFeaturedCardFields(
-            article
+            article,
+            'learn'
         );
         return (
             <Wrapper
@@ -158,7 +159,8 @@ const FeaturedArticles = ({ articles }) => {
     }
 
     const { description, image, slug, tags, title } = getFeaturedCardFields(
-        articles[0]
+        articles[0],
+        'learn'
     );
     return (
         <MainFeatureGrid data-test="featured-articles">

--- a/src/utils/get-featured-card-fields.js
+++ b/src/utils/get-featured-card-fields.js
@@ -1,7 +1,9 @@
 import { getNestedValue } from './get-nested-value';
 import { withPrefix } from 'gatsby';
 
-export const getFeaturedCardFields = article => {
+const generateTrackingParam = page => `?tck=feat${page}`;
+
+export const getFeaturedCardFields = (article, page) => {
     if (!article || !article.query_fields) {
         return {
             image: null,
@@ -14,7 +16,7 @@ export const getFeaturedCardFields = article => {
     const query_fields = article.query_fields;
     return {
         image: withPrefix(query_fields['atf-image']),
-        slug: query_fields['slug'],
+        slug: query_fields['slug'] + generateTrackingParam(page),
         title: getNestedValue(['title', 0, 'value'], query_fields) || '',
         description: getNestedValue(
             ['meta-description', 0, 'children', 0, 'value'],


### PR DESCRIPTION
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-498/)
[JIRA](https://jira.mongodb.org/browse/DEVHUB-498)

This PR adds `tck` params to articles on the home and learn pages based on the above JIRA request. My approach involved just updating the function we used to generate the fields for featured cards and adding another parameter for the page name.