### PR TITLE
DEVHUB-457: Structured data breadcrumbs: Implement breadcrumb schema to all pages

### DIFF
--- a/src/components/dev-hub/breadcrumb-schema.js
+++ b/src/components/dev-hub/breadcrumb-schema.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Helmet } from 'react-helmet';
+import { useSiteMetadata } from '~hooks/use-site-metadata';
+import { addTrailingSlashIfMissing } from '~utils/add-trailing-slash-if-missing';
+
+const getBreadcrumbList = (breadcrumb, siteUrl) =>
+    breadcrumb.map(({ label, target, to }, index) => {
+        const path = target || to;
+
+        return {
+            '@type': 'ListItem',
+            position: index + 1,
+            name: label,
+            item: path === '/' ? siteUrl : addTrailingSlashIfMissing(siteUrl + path),
+        };
+    });
+
+const BreadcrumbSchema = ({ breadcrumb }) => {
+    const { siteUrl } = useSiteMetadata();
+    return (
+        <Helmet>
+            {Array.isArray(breadcrumb) && (
+                <script type="application/ld+json">
+                    {JSON.stringify({
+                        '@context': 'https://schema.org',
+                        '@type': 'BreadcrumbList',
+                        itemListElement: getBreadcrumbList(breadcrumb, siteUrl),
+                    })}
+                </script>
+            )}
+        </Helmet>
+    );
+};
+
+BreadcrumbSchema.propTypes = {
+    breadcrumb: PropTypes.arrayOf(
+        PropTypes.oneOfType([
+            PropTypes.shape({
+                label: PropTypes.string,
+                target: PropTypes.string,
+            }),
+            PropTypes.shape({
+                label: PropTypes.string,
+                to: PropTypes.string,
+            }),
+        ])
+    ).isRequired,
+};
+
+export default BreadcrumbSchema;

--- a/src/components/dev-hub/breadcrumb.js
+++ b/src/components/dev-hub/breadcrumb.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import Link from './link';
+import BreadcrumbSchema from './breadcrumb-schema';
+
 const StyledBreadcrumb = styled(Link)`
     display: inline-block;
     font-family: 'Fira Mono', monospace;
@@ -41,6 +43,8 @@ const BreadcrumbList = styled('div')`
 */
 const Breadcrumb = ({ children, ...props }) => {
     return (
+        <>
+        <BreadcrumbSchema breadcrumb={children} />
         <BreadcrumbList {...props}>
             {children.map(c => (
                 <StyledBreadcrumb tertiary key={c.label} to={c.to || c.target}>
@@ -48,6 +52,7 @@ const Breadcrumb = ({ children, ...props }) => {
                 </StyledBreadcrumb>
             ))}
         </BreadcrumbList>
+        </>
     );
 };
 

--- a/tests/unit/BreadcrumbSchema.test.js
+++ b/tests/unit/BreadcrumbSchema.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import BreadcrumbSchema from '../../src/components/dev-hub/breadcrumb-schema';
+
+import mockData from './data/BreadcrumbSchema.test.json';
+
+const siteUrl = 'https://developer.mongodb.com';
+
+jest.mock('../../src/hooks/use-site-metadata', () => ({
+    useSiteMetadata: () => ({ siteUrl })
+}));
+
+describe('BreadcrumbSchema', () => {
+    let shallowWrapper;
+
+    beforeAll(() => {
+        shallowWrapper = shallow(<BreadcrumbSchema breadcrumb={mockData} />);
+    });
+
+    it('renders correctly', () => {
+        expect(shallowWrapper).toMatchSnapshot();
+    });
+
+    it('script has a correct schema', () => {
+        const script = shallowWrapper.find('script');
+
+        expect(script.text()).toEqual(JSON.stringify(
+            {
+                "@context": "https://schema.org",
+                "@type": "BreadcrumbList",
+                itemListElement: [
+                    { "@type": "ListItem", "position": 1, name: "Home", item: siteUrl },
+                    { "@type": "ListItem", "position": 2, name: "Learn", item: siteUrl + "/learn/" }]
+            }
+        ));
+    });
+})

--- a/tests/unit/__snapshots__/BreadcrumbSchema.test.js.snap
+++ b/tests/unit/__snapshots__/BreadcrumbSchema.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BreadcrumbSchema renders correctly 1`] = `
+<HelmetWrapper
+  defer={true}
+  encodeSpecialCharacters={true}
+>
+  <script
+    type="application/ld+json"
+  >
+    {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://developer.mongodb.com"},{"@type":"ListItem","position":2,"name":"Learn","item":"https://developer.mongodb.com/learn/"}]}
+  </script>
+</HelmetWrapper>
+`;

--- a/tests/unit/data/BreadcrumbSchema.test.json
+++ b/tests/unit/data/BreadcrumbSchema.test.json
@@ -1,0 +1,10 @@
+[
+    {
+        "label": "Home",
+        "target": "/"
+    },
+    {
+        "label": "Learn",
+        "target": "/learn"
+    }
+]


### PR DESCRIPTION
This PR adds schema for breadcrumbs. Breadcrumb structured data can be used to mark-up breadcrumb navigation links and provide search engines with additional information on the hierarchy and structure of the website.