### PR TITLE
DEVHUB-527: Maintain 1:1 Hero Image Aspect Ratio on Mobile

### DIFF
--- a/src/components/dev-hub/hero-banner.js
+++ b/src/components/dev-hub/hero-banner.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import Breadcrumb from './breadcrumb';
 import { fontSize, HERO_CONTENT_WIDTH, screenSize, size } from './theme';
@@ -6,6 +7,19 @@ import useMedia from '../../hooks/use-media';
 
 const HERO_BOTTOM_MARGIN = '30px';
 const BANNER_BOTTOM_PADDING = '50px';
+
+const positionAbsolutelyWithinContainer = css`
+    position: absolute; /* If you want text inside of it */
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+`;
+
+const squareAspectRatioContainer = css`
+    padding-top: 100%;
+    position: relative;
+`;
 
 const ContentContainer = styled('div')`
     ${({ fullWidth }) =>
@@ -52,10 +66,14 @@ const MobileMediaContainer = styled('div')`
     width: 100%;
     @media ${screenSize.upToLarge} {
         margin-bottom: ${size.default};
+        ${squareAspectRatioContainer};
     }
     > img {
         border-radius: ${size.small};
         width: inherit;
+        @media ${screenSize.upToLarge} {
+            ${positionAbsolutelyWithinContainer};
+        }
     }
 `;
 

--- a/src/components/dev-hub/hero-banner.js
+++ b/src/components/dev-hub/hero-banner.js
@@ -66,13 +66,15 @@ const MobileMediaContainer = styled('div')`
     width: 100%;
     @media ${screenSize.upToLarge} {
         margin-bottom: ${size.default};
-        ${squareAspectRatioContainer};
+        ${({ maintainSquareAspectRatio }) =>
+            maintainSquareAspectRatio && squareAspectRatioContainer};
     }
     > img {
         border-radius: ${size.small};
         width: inherit;
         @media ${screenSize.upToLarge} {
-            ${positionAbsolutelyWithinContainer};
+            ${({ maintainSquareAspectRatio }) =>
+                maintainSquareAspectRatio && positionAbsolutelyWithinContainer};
         }
     }
 `;
@@ -83,6 +85,7 @@ const HeroBanner = ({
     children,
     collapse,
     backgroundPosition = '100%',
+    maintainSquareAspectRatio = true,
     // Setting below to false would allow for bleed effect on bg
     shouldContainBackground = true,
     showImageOnMobile = true,
@@ -102,7 +105,11 @@ const HeroBanner = ({
                         <HeroBreadcrumb>{breadcrumb}</HeroBreadcrumb>
                     )}
                     {isMobile && showImageOnMobile && (
-                        <MobileMediaContainer>
+                        <MobileMediaContainer
+                            maintainSquareAspectRatio={
+                                maintainSquareAspectRatio
+                            }
+                        >
                             <img src={background} alt="" />
                         </MobileMediaContainer>
                     )}

--- a/src/components/pages/academia/top-banner.js
+++ b/src/components/pages/academia/top-banner.js
@@ -34,6 +34,7 @@ const TopBanner = () => (
     <ReducedMarginBanner
         background={AcademiaHeader}
         backgroundPosition="100% 42px"
+        maintainSquareAspectRatio={false}
     >
         <Header>
             <H2>MongoDB for Academia</H2>

--- a/src/components/pages/student-submit/top-banner.js
+++ b/src/components/pages/student-submit/top-banner.js
@@ -39,6 +39,7 @@ const TopBanner = () => (
     <ReducedMarginBanner
         background={FormHeader}
         breadcrumb={STUDENT_SPOTLIGHT_BREADCRUMBS}
+        maintainSquareAspectRatio={false}
     >
         <Header>
             <H2>Share Something You're Proud&nbsp;Of</H2>


### PR DESCRIPTION
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-527/)

This PR fixes a bug which did not constrain the aspect ratio of the hero image on articles, etc. on mobile. For some pages, we still don't mind leaving the ratio alone so we disable this behavior selectively.