### PR TITLE
DEVHUB-515: Apply Design Reskin

### DIFF
--- a/src/components/dev-hub/global-nav.js
+++ b/src/components/dev-hub/global-nav.js
@@ -155,10 +155,8 @@ const GlobalNav = () => {
                 )}
             </NavContent>
             <Searchbar
-                getResultsFromJSON={x => x}
                 isExpanded={isSearchbarExpanded}
                 setIsExpanded={setIsSearchbarExpanded}
-                searchParamsToURL={x => x}
                 // Autofocus the searchbar when the user expands only so the user can start typing
                 shouldAutofocus={false}
             />

--- a/src/components/dev-hub/searchbar/CondensedSearchbar.js
+++ b/src/components/dev-hub/searchbar/CondensedSearchbar.js
@@ -2,18 +2,18 @@ import React from 'react';
 import styled from '@emotion/styled';
 import Icon from '@leafygreen-ui/icon';
 import IconButton from '@leafygreen-ui/icon-button';
-import { uiColors } from '@leafygreen-ui/palette';
 import { size } from '~components/dev-hub/theme';
 
 // Defining as a styled component allows us to use as a selector in ExpandButton
 const ExpandMagnifyingGlass = styled(Icon)``;
 
 const ExpandButton = styled(IconButton)`
-    background-color: #fff;
+    background-color: none;
     background-image: none;
     border: none;
     border-radius: ${size.medium};
     box-shadow: none;
+    color: ${({ theme }) => theme.colorMap.greyLightTwo};
     height: ${size.large};
     position: absolute;
     right: ${size.small};
@@ -23,9 +23,9 @@ const ExpandButton = styled(IconButton)`
     z-index: 1;
     :hover,
     :focus {
-        background-color: #f7f9f8;
+        background-color: none;
         ${ExpandMagnifyingGlass} {
-            color: ${uiColors.gray.dark3};
+            color: ${({ theme }) => theme.colorMap.greyDarkTwo};
             transition: color 150ms ease-in;
         }
     }
@@ -39,10 +39,7 @@ const ExpandButton = styled(IconButton)`
 
 const CondensedSearchbar = ({ onExpand }) => (
     <ExpandButton aria-label="Open MongoDB Docs Search" onClick={onExpand}>
-        <ExpandMagnifyingGlass
-            glyph="MagnifyingGlass"
-            fill={uiColors.gray.base}
-        />
+        <ExpandMagnifyingGlass glyph="MagnifyingGlass" />
     </ExpandButton>
 );
 

--- a/src/components/dev-hub/searchbar/ExpandedSearchbar.js
+++ b/src/components/dev-hub/searchbar/ExpandedSearchbar.js
@@ -3,7 +3,7 @@ import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { useTheme } from 'emotion-theming';
 import { useEventListener } from '@leafygreen-ui/hooks';
-import Icon, { isComponentGlyph } from '@leafygreen-ui/icon';
+import Icon from '@leafygreen-ui/icon';
 import IconButton from '@leafygreen-ui/icon-button';
 import { uiColors } from '@leafygreen-ui/palette';
 import useMedia from '~hooks/use-media';
@@ -16,7 +16,7 @@ const ARROW_DOWN_KEY = 40;
 const CLOSE_BUTTON_SIZE = size.medium;
 const ENTER_KEY = 13;
 const GO_BUTTON_COLOR = '#FFFFFF';
-const GO_BUTTON_SIZE = '20px';
+const GO_BUTTON_SIZE = size.default;
 
 const removeDefaultHoverEffects = css`
     background-image: none;
@@ -50,32 +50,34 @@ const GoButton = styled(IconButton)`
     padding: 0;
     position: absolute;
     right: ${size.default};
-    /* button is 20 px and entire container is 36px so 8px top gives equal spacing */
-    top: ${size.small};
+    /* button is 16 px and entire container is 36px so 10px top gives equal spacing */
+    top: 10px;
     width: ${GO_BUTTON_SIZE};
     z-index: 1;
 `;
 
 const GoIcon = styled(Icon)`
-    /* Icon box size is 20px, 5px gives equal width and height */
-    left: 5px;
-    top: 5px;
-    height: 10px;
+    /* Icon box size is 16px, 4px gives equal width and height */
+    left: 4px;
+    top: 4px;
+    height: 8px;
     position: absolute;
-    width: 10px;
+    width: 8px;
 `;
 
 const MagnifyingGlass = styled(Icon)`
-    color: ${uiColors.gray.base};
+    color: ${({ theme }) => theme.colorMap.greyDarkTwo};
     transition: color 150ms ease-in;
 `;
 
 const MagnifyingGlassButton = styled(IconButton)`
-    left: ${size.small};
+    height: ${size.default};
+    width: ${size.default};
+    left: 10px;
     padding: 0;
     position: absolute;
-    /* This button is 28px tall in a 36px tall container, so 4px gives equal spacing */
-    top: ${size.tiny};
+    /* This button is 16px tall in a 36px tall container, so 4px gives equal spacing */
+    top: 10px;
     z-index: 1;
     /* Remove hover state */
     :before {

--- a/src/components/dev-hub/searchbar/ExpandedSearchbar.js
+++ b/src/components/dev-hub/searchbar/ExpandedSearchbar.js
@@ -1,6 +1,7 @@
 import React, { useCallback, useContext, useMemo, useRef } from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
+import { useTheme } from 'emotion-theming';
 import { useEventListener } from '@leafygreen-ui/hooks';
 import Icon, { isComponentGlyph } from '@leafygreen-ui/icon';
 import IconButton from '@leafygreen-ui/icon-button';
@@ -14,7 +15,7 @@ import SearchContext from './SearchContext';
 const ARROW_DOWN_KEY = 40;
 const CLOSE_BUTTON_SIZE = size.medium;
 const ENTER_KEY = 13;
-const GO_BUTTON_COLOR = uiColors.green.light3;
+const GO_BUTTON_COLOR = '#FFFFFF';
 const GO_BUTTON_SIZE = '20px';
 
 const removeDefaultHoverEffects = css`
@@ -86,6 +87,7 @@ const MagnifyingGlassButton = styled(IconButton)`
 `;
 
 const ExpandedSearchbar = ({ isFocused, onChange, onMobileClose }) => {
+    const theme = useTheme();
     const { isMobile } = useMedia(screenSize.upToMedium);
     const { searchContainerRef, searchTerm } = useContext(SearchContext);
     const isSearching = useMemo(() => !!searchTerm && isFocused, [
@@ -166,7 +168,10 @@ const ExpandedSearchbar = ({ isFocused, onChange, onMobileClose }) => {
                     aria-label="Go"
                     href={searchUrl}
                 >
-                    <GoIcon glyph="ArrowRight" fill="#13AA52" />
+                    <GoIcon
+                        glyph="ArrowRight"
+                        fill={theme.colorMap.pageBackground}
+                    />
                 </GoButton>
             )}
             {isMobile && (

--- a/src/components/dev-hub/searchbar/Pagination.js
+++ b/src/components/dev-hub/searchbar/Pagination.js
@@ -19,7 +19,7 @@ const PaginationButton = styled(IconButton)`
     &:hover,
     &:focus {
         :before {
-            background-color: ${({ theme }) => theme.colorMap.pageBackground};
+            background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
         }
     }
 `;

--- a/src/components/dev-hub/searchbar/Pagination.js
+++ b/src/components/dev-hub/searchbar/Pagination.js
@@ -2,20 +2,26 @@ import React, { useCallback, useMemo } from 'react';
 import styled from '@emotion/styled';
 import IconButton from '@leafygreen-ui/icon-button';
 import Icon from '@leafygreen-ui/icon';
-import { uiColors } from '@leafygreen-ui/palette';
-import { size } from '~components/dev-hub/theme';
+import { colorMap, size } from '~components/dev-hub/theme';
 
 // 16px for the icon + 2px padding on each side for hover circle
 const BUTTON_WIDTH = `${size.stripUnit(size.default) + 4}px`;
-const ENABLED_COLOR = uiColors.gray.dark2;
-const DISABLED_COLOR = uiColors.gray.light1;
+const ENABLED_COLOR = colorMap.devWhite;
+const DISABLED_COLOR = colorMap.greyDarkOne;
 
 const PaginationButton = styled(IconButton)`
-    background-color: #fff;
+    background-color: ${({ theme }) => theme.colorMap.pageBackground};
     height: ${BUTTON_WIDTH};
     padding: 0;
     width: ${BUTTON_WIDTH};
     z-index: 1;
+    &:active,
+    &:hover,
+    &:focus {
+        :before {
+            background-color: ${({ theme }) => theme.colorMap.pageBackground};
+        }
+    }
 `;
 
 const PaginationContainer = styled('div')`

--- a/src/components/dev-hub/searchbar/SearchDropdown.js
+++ b/src/components/dev-hub/searchbar/SearchDropdown.js
@@ -32,7 +32,6 @@ const FixedHeightSearchResults = styled(SearchResults)`
 `;
 
 const SearchResultsContainer = styled('div')`
-    background-color: #ffffff;
     border-radius: 0 0 ${size.tiny} ${size.tiny};
     opacity: 1;
     position: absolute;

--- a/src/components/dev-hub/searchbar/SearchDropdown.js
+++ b/src/components/dev-hub/searchbar/SearchDropdown.js
@@ -49,7 +49,7 @@ const SearchResultsContainer = styled('div')`
 
 const SearchFooter = styled('div')`
     align-items: center;
-    box-shadow: 0 2px ${size.tiny} 0 rgba(184, 196, 194, 0.56);
+    background-color: ${({ theme }) => theme.colorMap.pageBackground};
     display: flex;
     height: ${SEARCH_FOOTER_DESKTOP_HEIGHT};
     justify-content: space-between;

--- a/src/components/dev-hub/searchbar/SearchResult.js
+++ b/src/components/dev-hub/searchbar/SearchResult.js
@@ -55,19 +55,21 @@ const SearchResultLink = styled(Link)`
     color: ${LINK_COLOR};
     height: 100%;
     text-decoration: none;
+    background-color: ${({ theme }) => theme.colorMap.pageBackground};
     :hover,
     :focus {
         color: ${LINK_COLOR};
         text-decoration: none;
         ${SearchResultContainer} {
-            background-color: rgba(231, 238, 236, 0.4);
+            background-color: ${({ theme }) => theme.colorMap.pageBackground};
             transition: background-color 150ms ease-in;
         }
     }
 `;
 
 const StyledPreviewText = styled('p')`
-    font-family: 'Akzidenz Grotesk BQ Light';
+    color: ${({ theme }) => theme.colorMap.greyLightTwo};
+    font-family: Akzidenz;
     font-size: ${fontSize.small};
     letter-spacing: 0.5px;
     line-height: 20px;
@@ -77,6 +79,7 @@ const StyledPreviewText = styled('p')`
 `;
 
 const StyledResultTitle = styled('p')`
+    color: ${({ theme }) => theme.colorMap.devWhite};
     font-family: Akzidenz;
     font-size: ${fontSize.small};
     line-height: ${size.medium};

--- a/src/components/dev-hub/searchbar/SearchResult.js
+++ b/src/components/dev-hub/searchbar/SearchResult.js
@@ -61,7 +61,7 @@ const SearchResultLink = styled(Link)`
         color: ${LINK_COLOR};
         text-decoration: none;
         ${SearchResultContainer} {
-            background-color: ${({ theme }) => theme.colorMap.pageBackground};
+            background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
             transition: background-color 150ms ease-in;
         }
     }

--- a/src/components/dev-hub/searchbar/SearchResults.js
+++ b/src/components/dev-hub/searchbar/SearchResults.js
@@ -19,7 +19,7 @@ const StyledResultText = styled('p')`
 
 const SearchResultsContainer = styled('div')`
     align-items: center;
-    box-shadow: 0 0 ${size.tiny} 0 rgba(184, 196, 194, 0.48);
+    background-color: ${({ theme }) => theme.colorMap.pageBackground};
     display: grid;
     grid-template-columns: 100%;
     grid-template-rows: ${({ hasResults }) =>
@@ -48,7 +48,8 @@ const StyledSearchResult = styled(SearchResult)`
         padding: ${size.default} ${size.medium};
     }
     @media ${screenSize.upToSmall} {
-        background-color: #fff;
+        background-color: color: ${({ theme }) =>
+            theme.colorMap.pageBackground};
         border: 1px solid rgba(184, 196, 194, 0.2);
         border-radius: ${size.tiny};
         box-shadow: 0 0 ${size.tiny} 0 rgba(231, 238, 236, 0.4);
@@ -74,7 +75,6 @@ const SearchResults = ({
         index => (currentPage - 1) * index + 1,
         [currentPage]
     );
-    console.log(visibleResults);
     return (
         <SearchResultsContainer hasResults={hasResults} {...props}>
             <StyledResultText>

--- a/src/components/dev-hub/searchbar/SearchResults.js
+++ b/src/components/dev-hub/searchbar/SearchResults.js
@@ -28,7 +28,7 @@ const SearchResultsContainer = styled('div')`
             : `${size.medium} ${size.large}`};
     position: relative;
     /* Give top padding on desktop to offset this extending into the searchbar */
-    padding-top: ${size.large};
+    padding-top: 36px;
     width: 100%;
     @media ${screenSize.upToSmall} {
         box-shadow: none;
@@ -42,6 +42,7 @@ const SearchResultsContainer = styled('div')`
 `;
 
 const StyledSearchResult = styled(SearchResult)`
+    border-bottom: 1px solid ${({ theme }) => theme.colorMap.greyDarkTwo};
     max-height: 100%;
     height: 100%;
     > div {

--- a/src/components/dev-hub/searchbar/SearchTextInput.js
+++ b/src/components/dev-hub/searchbar/SearchTextInput.js
@@ -1,7 +1,6 @@
-import React, { useContext, useMemo } from 'react';
+import React, { useContext } from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
-import { uiColors } from '@leafygreen-ui/palette';
 import TextInput from '@leafygreen-ui/text-input';
 import { useSiteMetadata } from '~hooks/use-site-metadata';
 import {

--- a/src/components/dev-hub/searchbar/SearchTextInput.js
+++ b/src/components/dev-hub/searchbar/SearchTextInput.js
@@ -4,24 +4,28 @@ import styled from '@emotion/styled';
 import { uiColors } from '@leafygreen-ui/palette';
 import TextInput from '@leafygreen-ui/text-input';
 import { useSiteMetadata } from '~hooks/use-site-metadata';
-import { fontSize, screenSize, size } from '~components/dev-hub/theme';
+import {
+    colorMap,
+    fontSize,
+    screenSize,
+    size,
+} from '~components/dev-hub/theme';
 import SearchContext from './SearchContext';
 
 const SEARCHBAR_HEIGHT_OFFSET = '5px';
 
 const activeTextBarStyling = css`
-    background-color: #fff;
+    background-color: ${colorMap.pageBackground};
     border: none;
-    color: ${uiColors.gray.dark3};
 `;
 
 const StyledTextInput = styled(TextInput)`
     /* Curve the text input box and put padding around text for icons/buttons */
     div > input {
         border: none;
-        background-color: ${uiColors.gray.light3};
+        background-color: ${({ theme }) => theme.colorMap.pageBackground};
         border-radius: ${size.medium};
-        color: ${uiColors.gray.dark1};
+        color: ${({ theme }) => theme.colorMap.devWhite};
         /* 24 px for magnifying glass plus 16px margin */
         padding-left: 40px;
         padding-right: ${size.large};
@@ -29,7 +33,7 @@ const StyledTextInput = styled(TextInput)`
         letter-spacing: 0.5px;
         transition: background-color 150ms ease-in;
         ::placeholder {
-            color: ${uiColors.gray.dark1};
+            color: ${({ theme }) => theme.colorMap.greyLightTwo};
         }
         @media ${screenSize.upToSmall} {
             border: none;
@@ -50,7 +54,7 @@ const StyledTextInput = styled(TextInput)`
     }
 
     @media ${screenSize.upToSmall} {
-        background-color: #fff;
+        background-color: ${({ theme }) => theme.colorMap.pageBackground};
         padding-bottom: ${size.tiny};
         div > input {
             /* Always have this element filled in for mobile */
@@ -65,7 +69,7 @@ const StyledTextInput = styled(TextInput)`
       below from peeking through with a pseudoelement to cover this top space
     */
         :before {
-            background-color: #fff;
+            background-color: ${({ theme }) => theme.colorMap.pageBackground};
             bottom: 100%;
             content: '';
             position: absolute;
@@ -87,20 +91,13 @@ const SearchTextInput = React.forwardRef(
     ({ isSearching, onChange, value, ...props }, ref) => {
         const { searchFilter, shouldAutofocus } = useContext(SearchContext);
         const { project } = useSiteMetadata();
-        const placeholder = useMemo(
-            () =>
-                project === 'realm' && searchFilter === 'realm-master'
-                    ? 'Search Realm Documentation'
-                    : 'Search Documentation',
-            [project, searchFilter]
-        );
         return (
             <SearchWrapper isSearching={isSearching}>
                 <StyledTextInput
                     autoFocus={shouldAutofocus}
                     label="Search Docs"
                     onChange={onChange}
-                    placeholder={placeholder}
+                    placeholder={'Search Articles...'}
                     ref={ref}
                     tabIndex="0"
                     value={value}

--- a/src/components/dev-hub/searchbar/SearchTextInput.js
+++ b/src/components/dev-hub/searchbar/SearchTextInput.js
@@ -22,7 +22,7 @@ const activeTextBarStyling = css`
 const StyledTextInput = styled(TextInput)`
     /* Curve the text input box and put padding around text for icons/buttons */
     div > input {
-        border: none;
+        border: 1px solid transparent;
         background-color: ${({ theme }) => theme.colorMap.pageBackground};
         border-radius: ${size.medium};
         color: ${({ theme }) => theme.colorMap.devWhite};

--- a/src/components/dev-hub/searchbar/Searchbar.js
+++ b/src/components/dev-hub/searchbar/Searchbar.js
@@ -11,7 +11,6 @@ import ExpandedSearchbar, { MagnifyingGlass } from './ExpandedSearchbar';
 import SearchContext from './SearchContext';
 import { activeTextBarStyling, StyledTextInput } from './SearchTextInput';
 import { useClickOutside } from '~hooks/use-click-outside';
-import { useSiteMetadata } from '~hooks/use-site-metadata';
 import { screenSize, size } from '~components/dev-hub/theme';
 import { requestTextFilterResults } from '~utils/devhub-api-stitch';
 import { reportAnalytics } from '~utils/report-analytics';
@@ -64,26 +63,10 @@ const SearchbarContainer = styled('div')`
     }
 `;
 
-const Searchbar = ({
-    getResultsFromJSON,
-    isExpanded,
-    setIsExpanded,
-    searchParamsToURL,
-    shouldAutofocus,
-}) => {
-    const { project } = useSiteMetadata();
-    const [value, setValue] = useState('');
+const limitSearchResults = (results, limit) => results.slice(0, limit);
 
-    // XXX: Search filter defaults to Realm if a user is on the Realm docs
-    const defaultSearchFilter = useMemo(
-        () => (project === 'realm' ? 'realm-master' : null),
-        [project]
-    );
-    const [searchFilter, setSearchFilter] = useState(defaultSearchFilter);
-    // Use a second search filter state var to track filters but not make any calls yet
-    const [draftSearchFilter, setDraftSearchFilter] = useState(
-        defaultSearchFilter
-    );
+const Searchbar = ({ isExpanded, setIsExpanded, shouldAutofocus }) => {
+    const [value, setValue] = useState('');
     const [searchEvent, setSearchEvent] = useState(null);
     const [reportEvent, setReportEvent] = useState(null);
     const [searchResults, setSearchResults] = useState([]);
@@ -91,12 +74,6 @@ const Searchbar = ({
     const searchContainerRef = useRef(null);
     // A user is searching if the text input is focused and it is not empty
     const isSearching = useMemo(() => !!value && isFocused, [isFocused, value]);
-    // Callback to "promote" an in-progress search filter to kick off a search
-    const onApplyFilters = useCallback(
-        () => setSearchFilter(draftSearchFilter),
-        [draftSearchFilter]
-    );
-
     // Focus Handlers
     const onExpand = useCallback(() => setIsExpanded(true), [setIsExpanded]);
     const onFocus = useCallback(() => {
@@ -136,7 +113,7 @@ const Searchbar = ({
     // Update state on a new search query or filters
     const fetchNewSearchResults = useCallback(async () => {
         const result = await requestTextFilterResults(value);
-        setSearchResults(result);
+        setSearchResults(limitSearchResults(result, NUMBER_SEARCH_RESULTS));
     }, [value]);
 
     const reportSearchEvent = useCallback(() => {
@@ -166,8 +143,6 @@ const Searchbar = ({
                 <SearchContext.Provider
                     value={{
                         searchContainerRef,
-                        searchFilter: draftSearchFilter,
-                        setSearchFilter: setDraftSearchFilter,
                         searchTerm: value,
                         shouldAutofocus,
                     }}
@@ -177,12 +152,7 @@ const Searchbar = ({
                         onChange={onSearchChange}
                         value={value}
                     />
-                    {isSearching && (
-                        <SearchDropdown
-                            applySearchFilter={onApplyFilters}
-                            results={searchResults}
-                        />
-                    )}
+                    {isSearching && <SearchDropdown results={searchResults} />}
                 </SearchContext.Provider>
             ) : (
                 <CondensedSearchbar onExpand={onExpand} />

--- a/src/components/dev-hub/searchbar/Searchbar.js
+++ b/src/components/dev-hub/searchbar/Searchbar.js
@@ -6,7 +6,6 @@ import React, {
     useRef,
 } from 'react';
 import styled from '@emotion/styled';
-import { uiColors } from '@leafygreen-ui/palette';
 import CondensedSearchbar from './CondensedSearchbar';
 import ExpandedSearchbar, { MagnifyingGlass } from './ExpandedSearchbar';
 import SearchContext from './SearchContext';
@@ -41,12 +40,12 @@ const SearchbarContainer = styled('div')`
     :focus,
     :focus-within {
         ${MagnifyingGlass} {
-            color: ${uiColors.gray.dark3};
+            color: ${({ theme }) => theme.colorMap.devWhite};
         }
         ${StyledTextInput} {
             div > input {
                 ${activeTextBarStyling}
-                box-shadow: 0 0 ${size.tiny} 0 rgba(184, 196, 194, 0.56);
+                border: 1px solid ${({ theme }) => theme.colorMap.greyDarkOne};
                 transition: background-color ${TRANSITION_SPEED} ease-in,
                     color ${TRANSITION_SPEED} ease-in;
                 @media ${screenSize.upToSmall} {

--- a/src/components/dev-hub/searchbar/Searchbar.js
+++ b/src/components/dev-hub/searchbar/Searchbar.js
@@ -23,7 +23,7 @@ const REPORT_SEARCH_DELAY_TIME = 1000;
 const SEARCH_DELAY_TIME = 200;
 const SEARCHBAR_DESKTOP_WIDTH = '372px';
 const SEARCHBAR_HEIGHT = '36px';
-const SEARCHBAR_HEIGHT_OFFSET = '5px';
+const SEARCHBAR_HEIGHT_OFFSET = '10px';
 const TRANSITION_SPEED = '150ms';
 
 const SearchbarContainer = styled('div')`


### PR DESCRIPTION
[Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-515/)
[Figma](https://www.figma.com/proto/alg7BWjspWbpLmys9vS4KC/DevHub-Search?node-id=31%3A2711&scaling=min-zoom)

I expect CI to still fail while we mess with the mobile nav. So long as that is the sole issue we can merge into the staging branch since we will come back to this anyway.

This PR applies the majority of the DevHub search reskin to the new search UI. I also removed some dead code and such. This should remove all `uiColors` uses (aside from some uses on `upToSmall` which will be removed when it is time to do mobile).