### PR TITLE
DEVHUB-516 (part 2): Swap mobile color, remove limit for results on mobile

### DIFF
--- a/src/components/dev-hub/searchbar/SearchDropdown.js
+++ b/src/components/dev-hub/searchbar/SearchDropdown.js
@@ -41,7 +41,7 @@ const SearchResultsContainer = styled('div')`
     ${fadeInAnimation(0, '0.2s')};
     @media ${screenSize.upToSmall} {
         background-color: ${uiColors.gray.light3};
-        top: 60px;
+        top: 50px;
         height: 100vh;
         padding-bottom: 20px;
         overflow: scroll;

--- a/src/components/dev-hub/searchbar/SearchResults.js
+++ b/src/components/dev-hub/searchbar/SearchResults.js
@@ -30,6 +30,7 @@ const SearchResultsContainer = styled('div')`
     padding-top: 36px;
     width: 100%;
     @media ${screenSize.upToSmall} {
+        background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
         box-shadow: none;
         grid-template-rows: ${size.medium};
         grid-auto-rows: ${SEARCH_RESULT_MOBILE_HEIGHT};


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-216-2/)
[Figma](https://www.figma.com/proto/alg7BWjspWbpLmys9vS4KC/DevHub-Search?node-id=188%3A5061&scaling=min-zoom)

This PR addresses two quick mobile changes for search, updating the results background color and removing the 9 limit for results.