### PR TITLE
DEVHUB-544 (part 1): Padding, Mobile Colors, Default Expand

### DIFF
--- a/src/components/dev-hub/global-nav.js
+++ b/src/components/dev-hub/global-nav.js
@@ -142,7 +142,7 @@ const MobileItems = ({ items }) => {
 };
 
 const GlobalNav = () => {
-    const isSearchbarDefaultExpanded = useMedia(screenSize.xlargeAndUp);
+    const isSearchbarDefaultExpanded = useMedia(screenSize.smallDesktopAndUp);
     const [isSearchbarExpanded, setIsSearchbarExpanded] = useState(
         isSearchbarDefaultExpanded
     );

--- a/src/components/dev-hub/nav-item.js
+++ b/src/components/dev-hub/nav-item.js
@@ -71,13 +71,7 @@ const NavListHeader = styled('div')`
     justify-content: space-between;
     ${({ isExpanded }) =>
         isExpanded && `background-color: ${HOVER_STATE_BACKGROUND_COLOR}`};
-    padding: ${LINK_VERTICAL_PADDING} ${size.xlarge};
-    @media ${screenSize.upToXlarge} {
-        padding: ${LINK_VERTICAL_PADDING} 40px;
-    }
-    @media ${screenSize.upToSmallDesktop} {
-        padding: ${LINK_VERTICAL_PADDING} ${size.mediumLarge};
-    }
+    padding: ${LINK_VERTICAL_PADDING} ${size.medium};
     @media ${MOBILE_NAV_BREAK} {
         padding: ${size.mediumLarge} ${size.default};
         box-shadow: 0px 1px 0px ${({ theme }) => theme.colorMap.greyDarkTwo};

--- a/src/components/dev-hub/searchbar/SearchResults.js
+++ b/src/components/dev-hub/searchbar/SearchResults.js
@@ -6,7 +6,7 @@ import { reportAnalytics } from '~utils/report-analytics';
 
 const SEARCHBAR_HEIGHT = '36px';
 const SEARCH_RESULT_HEIGHT = '102px';
-const SEARCH_RESULT_MOBILE_HEIGHT = '156px';
+const SEARCH_RESULT_MOBILE_HEIGHT = '136px';
 
 const StyledResultText = styled('p')`
     font-family: Akzidenz;
@@ -30,7 +30,7 @@ const SearchResultsContainer = styled('div')`
     padding-top: 36px;
     width: 100%;
     @media ${screenSize.upToSmall} {
-        background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
+        background-color: ${({ theme }) => theme.colorMap.pageBackground};
         box-shadow: none;
         grid-template-rows: ${size.medium};
         grid-auto-rows: ${SEARCH_RESULT_MOBILE_HEIGHT};
@@ -49,11 +49,9 @@ const StyledSearchResult = styled(SearchResult)`
         padding: ${size.default} ${size.medium};
     }
     @media ${screenSize.upToSmall} {
-        background-color: color: ${({ theme }) =>
-            theme.colorMap.pageBackground};
-        border: 1px solid rgba(184, 196, 194, 0.2);
+        background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
+        border: 1px solid ${({ theme }) => theme.colorMap.greyDarkTwo};
         border-radius: ${size.tiny};
-        box-shadow: 0 0 ${size.tiny} 0 rgba(231, 238, 236, 0.4);
         height: calc(100% - ${size.default});
         /* place-self adds both align-self and justify-self for flexbox */
         place-self: center;


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-544-1/)
[Figma](https://www.figma.com/file/alg7BWjspWbpLmys9vS4KC/DevHub-Search?node-id=213%3A33)

This PR addresses some small search ui related fixes:
- Expand on 1200+px by default only
- Swaps color scheme for mobile
- Makes padding on nav 24px for all above ~1000px
- reduces result space on mobile