### PR TITLE
DEVHUB-544: Flash on UI, Forward Refs on Links

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,4 @@
 {
-    "baseUrl": "http://localhost:8000",
+    "baseUrl": "http://localhost:9000",
     "viewportWidth": 1280
 }

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,4 @@
 {
-    "baseUrl": "http://localhost:9000",
+    "baseUrl": "http://localhost:8000",
     "viewportWidth": 1280
 }

--- a/cypress/integration/search.js
+++ b/cypress/integration/search.js
@@ -1,10 +1,10 @@
-const BACK_PAGE_BUTTON = "[data-test='Back Search Page']";
-const FORWARD_PAGE_BUTTON = "[data-test='Forward Search Page']";
-const SEARCHBAR = "[data-test='Expanded Searchbar']";
-const SEARCH_DROPDOWN = "[data-test='Search Dropdown']";
-const SEARCH_INPUT = "[data-test='Expanded Searchbar'] input";
-const SEARCH_PAGINATION_TEXT = "[data-test='Search Page Text']";
-const SEARCH_RESULT = "[data-test='Search Result']";
+const BACK_PAGE_BUTTON = "[data-test='Back Search Page']:visible";
+const FORWARD_PAGE_BUTTON = "[data-test='Forward Search Page']:visible";
+const SEARCHBAR = "[data-test='Expanded Searchbar']:visible";
+const SEARCH_DROPDOWN = "[data-test='Search Dropdown']:visible";
+const SEARCH_INPUT = "[data-test='Expanded Searchbar'] input:visible";
+const SEARCH_PAGINATION_TEXT = "[data-test='Search Page Text']:visible";
+const SEARCH_RESULT = "[data-test='Search Result']:visible";
 
 const DEVHUB_URL = 'https://developer.mongodb.com';
 const RESULTS_PER_PAGE = 3;
@@ -93,7 +93,9 @@ describe('search', () => {
         checkCondensedSearchbar();
         mockJavaSearch();
         // The below line ensures we wait until the stub is done
-        cy.get(SEARCH_RESULT).should('have.length', 6);
+        cy.get(
+            "[data-test='Search Dropdown']:visible [data-test='Search Result']"
+        ).should('have.length', 6);
         checkSearchResults(1);
     });
 });

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -10,32 +10,35 @@ import { isPreviewMode } from '../utils/is-preview-mode';
 
 // Since DOM elements <a> cannot receive activeClassName and partiallyActive,
 // destructure the prop here and pass it only to GatsbyLink.
-const Link = ({ children, to, activeClassName, partiallyActive, ...other }) => {
-    if (!to) to = '';
-    // Assume that external links begin with http:// or https://
-    const external = /^http(s)?:\/\//.test(to);
-    const anchor = to.startsWith('#');
+const Link = React.forwardRef(
+    ({ children, to, activeClassName, partiallyActive, ...other }, ref) => {
+        if (!to) to = '';
+        // Assume that external links begin with http:// or https://
+        const external = /^http(s)?:\/\//.test(to);
+        const anchor = to.startsWith('#');
 
-    // Use Gatsby Link for internal links, and <a> for others
-    if (!isPreviewMode() && to && !external && !anchor) {
-        if (!to.startsWith('/')) to = `/${to}`;
+        // Use Gatsby Link for internal links, and <a> for others
+        if (!isPreviewMode() && to && !external && !anchor) {
+            if (!to.startsWith('/')) to = `/${to}`;
+            return (
+                <DevHubLink
+                    ref={ref}
+                    to={to}
+                    activeClassName={activeClassName}
+                    partiallyActive={partiallyActive}
+                    {...other}
+                >
+                    {children}
+                </DevHubLink>
+            );
+        }
         return (
-            <DevHubLink
-                to={to}
-                activeClassName={activeClassName}
-                partiallyActive={partiallyActive}
-                {...other}
-            >
+            <DevHubLink ref={ref} href={to} {...other}>
                 {children}
             </DevHubLink>
         );
     }
-    return (
-        <DevHubLink href={to} {...other}>
-            {children}
-        </DevHubLink>
-    );
-};
+);
 
 Link.propTypes = {
     to: PropTypes.string.isRequired,

--- a/src/components/dev-hub/global-nav.js
+++ b/src/components/dev-hub/global-nav.js
@@ -55,8 +55,9 @@ const NavContent = styled('div')`
     max-width: ${size.maxWidth};
     position: relative;
     width: 100%;
-    ${({ isExpanded, shouldOpaqueWhenExpanded }) =>
-        isExpanded && shouldOpaqueWhenExpanded && 'opacity: 0.2;'};
+    @media ${screenSize.upToSmallDesktop} {
+        ${({ isExpanded }) => isExpanded && 'opacity: 0.2;'};
+    }
     @media ${MOBILE_NAV_BREAK} {
         display: grid;
         grid-template-columns: ${size.large} auto ${size.large};
@@ -142,31 +143,17 @@ const MobileItems = ({ items }) => {
 };
 
 const GlobalNav = () => {
-    const isSearchbarDefaultExpanded = useMedia(screenSize.smallDesktopAndUp);
-    const [isSearchbarExpanded, setIsSearchbarExpanded] = useState(
-        isSearchbarDefaultExpanded
-    );
-    useEffect(() => {
-        setIsSearchbarExpanded(isSearchbarDefaultExpanded);
-    }, [isSearchbarDefaultExpanded]);
+    const [isSearchbarExpanded, setIsSearchbarExpanded] = useState(false);
     const data = useStaticQuery(topNavItems);
     const items = dlv(data, ['strapiTopNav', 'items'], []);
     const isMobile = useMedia(MOBILE_NAV_BREAK);
-    const onSearchbarExpand = useCallback(
-        isExpanded => {
-            // On certain screens the searchbar is never collapsed
-            if (!isSearchbarDefaultExpanded) {
-                setIsSearchbarExpanded(isExpanded);
-            }
-        },
-        [isSearchbarDefaultExpanded]
-    );
+    const onSearchbarExpand = useCallback(isExpanded => {
+        // On certain screens the searchbar is never collapsed
+        setIsSearchbarExpanded(isExpanded);
+    }, []);
     return (
         <Nav>
-            <NavContent
-                isExpanded={isSearchbarExpanded}
-                shouldOpaqueWhenExpanded={!isSearchbarDefaultExpanded}
-            >
+            <NavContent isExpanded={isSearchbarExpanded}>
                 {isMobile ? (
                     <>
                         <MobileItems items={items} />

--- a/src/components/dev-hub/link.js
+++ b/src/components/dev-hub/link.js
@@ -74,35 +74,39 @@ const StyledLink = styled('a')`
  * @property {boolean?} props.tertiary
  * @property {string?} props.to
  */
-const Link = ({ href, onClick, target, tertiary, to, ...rest }) => {
-    if (to) {
-        const AsInternalLink = StyledLink.withComponent(RouterLink);
-        const absoluteLink = to.startsWith('/') ? to : `/${to}`;
-        const linkWithTrailingSlash = addTrailingSlashBeforeParams(
-            absoluteLink
-        );
+const Link = React.forwardRef(
+    ({ href, onClick, target, tertiary, to, ...rest }, ref) => {
+        if (to) {
+            const AsInternalLink = StyledLink.withComponent(RouterLink);
+            const absoluteLink = to.startsWith('/') ? to : `/${to}`;
+            const linkWithTrailingSlash = addTrailingSlashBeforeParams(
+                absoluteLink
+            );
+            return (
+                <AsInternalLink
+                    ref={ref}
+                    onClick={onClick}
+                    to={linkWithTrailingSlash}
+                    tertiary={tertiary}
+                    {...rest}
+                />
+            );
+        }
         return (
-            <AsInternalLink
-                onClick={onClick}
-                to={linkWithTrailingSlash}
+            <StyledLink
+                ref={ref}
+                href={href}
+                onClick={wrapPreventDefault(onClick, href)}
+                onKeyPress={href ? undefined : handleEnter(onClick)}
+                rel={target === '_blank' ? 'noreferrer noopener' : void 0}
+                target={target}
+                {...(typeof href === 'undefined' ? BUTTON_PROPS : null)}
                 tertiary={tertiary}
                 {...rest}
             />
         );
     }
-    return (
-        <StyledLink
-            href={href}
-            onClick={wrapPreventDefault(onClick, href)}
-            onKeyPress={href ? undefined : handleEnter(onClick)}
-            rel={target === '_blank' ? 'noreferrer noopener' : void 0}
-            target={target}
-            {...(typeof href === 'undefined' ? BUTTON_PROPS : null)}
-            tertiary={tertiary}
-            {...rest}
-        />
-    );
-};
+);
 
 Link.displayName = 'Link';
 

--- a/src/components/dev-hub/searchbar/SearchResult.js
+++ b/src/components/dev-hub/searchbar/SearchResult.js
@@ -140,6 +140,8 @@ const SearchResult = React.memo(
                     if (e.key === 'ArrowDown' || e.keyCode === ARROW_DOWN_KEY) {
                         e.preventDefault();
                         // find next result and focus
+
+                        console.log('arrow down');
                         onArrowDown(resultLinkRef);
                     } else if (
                         e.key === 'ArrowUp' ||

--- a/src/components/dev-hub/searchbar/Searchbar.js
+++ b/src/components/dev-hub/searchbar/Searchbar.js
@@ -12,7 +12,7 @@ import SearchContext from './SearchContext';
 import { activeTextBarStyling, StyledTextInput } from './SearchTextInput';
 import { useClickOutside } from '~hooks/use-click-outside';
 import useMedia from '~hooks/use-media';
-import { screenSize, size } from '~components/dev-hub/theme';
+import { layer, screenSize, size } from '~components/dev-hub/theme';
 import { requestTextFilterResults } from '~utils/devhub-api-stitch';
 import { reportAnalytics } from '~utils/report-analytics';
 import SearchDropdown from './SearchDropdown';
@@ -26,16 +26,14 @@ const SEARCHBAR_HEIGHT = '36px';
 const SEARCHBAR_HEIGHT_OFFSET = '10px';
 const TRANSITION_SPEED = '150ms';
 
-const SearchbarContainer = styled('div')`
+const CommonSearchbarContainer = styled('div')`
+    display: none;
     top: ${SEARCHBAR_HEIGHT_OFFSET};
     height: ${SEARCHBAR_HEIGHT};
     position: absolute;
     right: ${size.default};
-    transition: width ${TRANSITION_SPEED} ease-in;
-    width: ${({ isExpanded }) =>
-        isExpanded ? SEARCHBAR_DESKTOP_WIDTH : BUTTON_SIZE};
     /* docs-tools navbar z-index is 9999 */
-    z-index: 10000;
+    z-index: ${layer.front};
     :hover,
     :focus,
     :focus-within {
@@ -54,6 +52,22 @@ const SearchbarContainer = styled('div')`
                 }
             }
         }
+    }
+`;
+
+const DesktopSearchbarContainer = styled(CommonSearchbarContainer)`
+    width: ${SEARCHBAR_DESKTOP_WIDTH};
+    @media ${screenSize.smallDesktopAndUp} {
+        display: block;
+    }
+`;
+
+const MobileSearchbarContainer = styled(CommonSearchbarContainer)`
+    transition: width ${TRANSITION_SPEED} ease-in;
+    width: ${({ isExpanded }) =>
+        isExpanded ? SEARCHBAR_DESKTOP_WIDTH : BUTTON_SIZE};
+    @media ${screenSize.upToSmallDesktop} {
+        display: block;
     }
     @media ${screenSize.upToSmall} {
         top: ${SEARCHBAR_HEIGHT_OFFSET};
@@ -141,13 +155,13 @@ const Searchbar = ({ isExpanded, setIsExpanded, shouldAutofocus }) => {
     }, [fetchNewSearchResults, reportSearchEvent, value]);
 
     return (
-        <SearchbarContainer
-            isSearching={isSearching}
-            isExpanded={isExpanded}
-            onFocus={onFocus}
-            ref={searchContainerRef}
-        >
-            {isExpanded ? (
+        <>
+            {/* Expanded Desktop */}
+            <DesktopSearchbarContainer
+                isSearching={isSearching}
+                onFocus={onFocus}
+                ref={searchContainerRef}
+            >
                 <SearchContext.Provider
                     value={{
                         searchContainerRef,
@@ -156,16 +170,41 @@ const Searchbar = ({ isExpanded, setIsExpanded, shouldAutofocus }) => {
                     }}
                 >
                     <ExpandedSearchbar
-                        onMobileClose={onClose}
                         onChange={onSearchChange}
                         value={value}
                     />
                     {isSearching && <SearchDropdown results={searchResults} />}
                 </SearchContext.Provider>
-            ) : (
-                <CondensedSearchbar onExpand={onExpand} />
-            )}
-        </SearchbarContainer>
+            </DesktopSearchbarContainer>
+            {/* Condensed */}
+            <MobileSearchbarContainer
+                isSearching={isSearching}
+                isExpanded={isExpanded}
+                onFocus={onFocus}
+                ref={searchContainerRef}
+            >
+                {isExpanded ? (
+                    <SearchContext.Provider
+                        value={{
+                            searchContainerRef,
+                            searchTerm: value,
+                            shouldAutofocus,
+                        }}
+                    >
+                        <ExpandedSearchbar
+                            onMobileClose={onClose}
+                            onChange={onSearchChange}
+                            value={value}
+                        />
+                        {isSearching && (
+                            <SearchDropdown results={searchResults} />
+                        )}
+                    </SearchContext.Provider>
+                ) : (
+                    <CondensedSearchbar onExpand={onExpand} />
+                )}
+            </MobileSearchbarContainer>
+        </>
     );
 };
 

--- a/src/components/dev-hub/searchbar/Searchbar.js
+++ b/src/components/dev-hub/searchbar/Searchbar.js
@@ -14,6 +14,7 @@ import { useClickOutside } from '~hooks/use-click-outside';
 import useMedia from '~hooks/use-media';
 import { layer, screenSize, size } from '~components/dev-hub/theme';
 import { requestTextFilterResults } from '~utils/devhub-api-stitch';
+import { showOnDeviceSize } from '~utils/show-on-device-size';
 import { reportAnalytics } from '~utils/report-analytics';
 import SearchDropdown from './SearchDropdown';
 
@@ -27,7 +28,6 @@ const SEARCHBAR_HEIGHT_OFFSET = '10px';
 const TRANSITION_SPEED = '150ms';
 
 const CommonSearchbarContainer = styled('div')`
-    display: none;
     top: ${SEARCHBAR_HEIGHT_OFFSET};
     height: ${SEARCHBAR_HEIGHT};
     position: absolute;
@@ -56,19 +56,15 @@ const CommonSearchbarContainer = styled('div')`
 `;
 
 const DesktopSearchbarContainer = styled(CommonSearchbarContainer)`
+    ${showOnDeviceSize(screenSize.smallDesktopAndUp)}
     width: ${SEARCHBAR_DESKTOP_WIDTH};
-    @media ${screenSize.smallDesktopAndUp} {
-        display: block;
-    }
 `;
 
 const MobileSearchbarContainer = styled(CommonSearchbarContainer)`
+    ${showOnDeviceSize(screenSize.upToSmallDesktop)}
     transition: width ${TRANSITION_SPEED} ease-in;
     width: ${({ isExpanded }) =>
         isExpanded ? SEARCHBAR_DESKTOP_WIDTH : BUTTON_SIZE};
-    @media ${screenSize.upToSmallDesktop} {
-        display: block;
-    }
     @media ${screenSize.upToSmall} {
         top: ${SEARCHBAR_HEIGHT_OFFSET};
         height: ${({ isExpanded, isSearching }) =>

--- a/src/components/dev-hub/searchbar/Searchbar.js
+++ b/src/components/dev-hub/searchbar/Searchbar.js
@@ -151,12 +151,11 @@ const Searchbar = ({ isExpanded, setIsExpanded, shouldAutofocus }) => {
     }, [fetchNewSearchResults, reportSearchEvent, value]);
 
     return (
-        <>
+        <div ref={searchContainerRef}>
             {/* Expanded Desktop */}
             <DesktopSearchbarContainer
                 isSearching={isSearching}
                 onFocus={onFocus}
-                ref={searchContainerRef}
             >
                 <SearchContext.Provider
                     value={{
@@ -177,7 +176,6 @@ const Searchbar = ({ isExpanded, setIsExpanded, shouldAutofocus }) => {
                 isSearching={isSearching}
                 isExpanded={isExpanded}
                 onFocus={onFocus}
-                ref={searchContainerRef}
             >
                 {isExpanded ? (
                     <SearchContext.Provider
@@ -200,7 +198,7 @@ const Searchbar = ({ isExpanded, setIsExpanded, shouldAutofocus }) => {
                     <CondensedSearchbar onExpand={onExpand} />
                 )}
             </MobileSearchbarContainer>
-        </>
+        </div>
     );
 };
 

--- a/src/utils/show-on-device-size.js
+++ b/src/utils/show-on-device-size.js
@@ -2,7 +2,9 @@ import { css } from '@emotion/core';
 
 export const showOnDeviceSize = query => css`
     display: none;
+    visibility: hidden;
     @media ${query} {
         display: block;
+        visibility: visible;
     }
 `;

--- a/src/utils/show-on-device-size.js
+++ b/src/utils/show-on-device-size.js
@@ -1,0 +1,8 @@
+import { css } from '@emotion/core';
+
+export const showOnDeviceSize = query => css`
+    display: none;
+    @media ${query} {
+        display: block;
+    }
+`;

--- a/tests/unit/__snapshots__/Heading.test.js.snap
+++ b/tests/unit/__snapshots__/Heading.test.js.snap
@@ -6,7 +6,7 @@ exports[`renders correctly 1`] = `
   id="create-an-administrative-username-and-password"
 >
   <a
-    class="e1hiqreu0 css-1adrtmc-StyledLink-PermaLink eygprlc0"
+    class="e1hiqreu0 css-1jtgatg-StyledLink-PermaLink eygprlc0"
     href="#create-an-administrative-username-and-password"
     title="Permalink to this headline"
   >

--- a/tests/unit/__snapshots__/Link.test.js.snap
+++ b/tests/unit/__snapshots__/Link.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Link component renders a variety of strings correctly empty string 1`] = `
 <a
-  class="css-1j9ygug-StyledLink eygprlc0"
+  class="css-5b30hw-StyledLink eygprlc0"
   href=""
 >
   Empty string
@@ -11,7 +11,7 @@ exports[`Link component renders a variety of strings correctly empty string 1`] 
 
 exports[`Link component renders a variety of strings correctly external URL 1`] = `
 <a
-  class="css-1j9ygug-StyledLink eygprlc0"
+  class="css-5b30hw-StyledLink eygprlc0"
   href="http://mongodb.com"
 >
   MongoDB Company
@@ -20,7 +20,7 @@ exports[`Link component renders a variety of strings correctly external URL 1`] 
 
 exports[`Link component renders a variety of strings correctly internal link 1`] = `
 <a
-  class="test-class css-1on21yj-AsInternalLink-StyledLink eygprlc1"
+  class="test-class css-mvucl6-AsInternalLink-StyledLink eygprlc1"
   href="/drivers/c/"
 >
   C Driver

--- a/tests/unit/__snapshots__/Reference.test.js.snap
+++ b/tests/unit/__snapshots__/Reference.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders correctly 1`] = `
 <a
-  class="reference css-1j9ygug-StyledLink eygprlc0"
+  class="reference css-5b30hw-StyledLink eygprlc0"
   href="https://docs.mlab.com/subscriptions/#change-plans-using-rnr"
   rel="noreferrer noopener"
   target="_blank"


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-544-flash/)

This PR addresses an SSR issue with the searchbar. Previously, the logic for expand/collapse was a bit complicated, so we used a `useMedia` hook to render the same searchbar if expanded or condensed. This resulted in some jittering on renders due to SSR, since the condensed state would be the default state when building HTML.

This approaches uses a different SSR responsive-layout pattern (similar to artsy/fresnel) where we ship two layout options and use CSS to render the correct one. While the DOM get slightly larger, the UX benefit is far greater in this case, since we would not add significant code being sent. This is also not duplicate-content, so it should not have SEO impacts.

I also added the `forwardRef` ability to links.