### PR TITLE
DEVHUB-570: Don't add trailing slashes to internal image links

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import DevHubLink from './dev-hub/link';
-import { isPreviewMode } from '../utils/is-preview-mode';
+import { isLinkForImage } from '~utils/is-link-for-image';
+import { isPreviewMode } from '~utils/is-preview-mode';
 
 /*
  * Note: This component is not suitable for internal page navigation:
@@ -14,7 +15,9 @@ const Link = React.forwardRef(
     ({ children, to, activeClassName, partiallyActive, ...other }, ref) => {
         if (!to) to = '';
         // Assume that external links begin with http:// or https:// or have mailto
-        const external = /^http(s)?:\/\/|^mailto:[\w-.]+@(\w+.)/.test(to);
+        const external =
+            /^http(s)?:\/\/|^mailto:[\w-.]+@(\w+.)/.test(to) ||
+            isLinkForImage(to);
         const anchor = to.startsWith('#');
 
         // Use Gatsby Link for internal links, and <a> for others

--- a/src/utils/is-link-for-image.js
+++ b/src/utils/is-link-for-image.js
@@ -1,0 +1,2 @@
+export const isLinkForImage = link =>
+    !!link && /\.jpg$|\.png$|\.jpeg$|\.svg$/.test(link);

--- a/src/utils/make-link-internal-if-applicable.js
+++ b/src/utils/make-link-internal-if-applicable.js
@@ -1,6 +1,7 @@
 import { withPrefix } from 'gatsby';
 import { addTrailingSlashIfMissing } from './add-trailing-slash-if-missing';
 import { SITE_URL, FORUMS_URL } from '~src/constants';
+import { isLinkForImage } from '~utils/is-link-for-image';
 
 export const makeLinkInternalIfApplicable = link => {
     if (!link) {
@@ -11,9 +12,9 @@ export const makeLinkInternalIfApplicable = link => {
     if (linkIncludesDevHub && !linkGoesToForums) {
         // Forums is technically "external" from an app standpoint, so we leave
         // that one alone
-        return addTrailingSlashIfMissing(
-            withPrefix(link.replace(SITE_URL, ''))
-        );
+        return isLinkForImage(link)
+            ? withPrefix(link.replace(SITE_URL, ''))
+            : addTrailingSlashIfMissing(link.replace(SITE_URL, ''));
     }
     return link;
 };

--- a/tests/utils/is-link-for-image.test.js
+++ b/tests/utils/is-link-for-image.test.js
@@ -1,0 +1,17 @@
+import { isLinkForImage } from '../../src/utils/is-link-for-image';
+
+it('should remove trailing slashes from links where appropriate', () => {
+    // Null
+    expect(isLinkForImage(null)).toBe(false);
+    expect(isLinkForImage('')).toBe(false);
+    // Easy case
+    expect(isLinkForImage('some_image.jpg')).toBe(true);
+    expect(isLinkForImage('/foo/bar/new_image.png')).toBe(true);
+    // Odd true case
+    expect(isLinkForImage('/foo/bar/new_image.png.new_image.jpg')).toBe(true);
+    // False case
+    expect(isLinkForImage('/foo/bar.html')).toBe(false);
+    expect(isLinkForImage('/foo/.png/')).toBe(false);
+    // Odd false case
+    expect(isLinkForImage('/foo/bar/new_image.png.new_image')).toBe(false);
+});

--- a/tests/utils/is-link-for-image.test.js
+++ b/tests/utils/is-link-for-image.test.js
@@ -1,6 +1,6 @@
 import { isLinkForImage } from '../../src/utils/is-link-for-image';
 
-it('should remove trailing slashes from links where appropriate', () => {
+it('should identify links that lead to images', () => {
     // Null
     expect(isLinkForImage(null)).toBe(false);
     expect(isLinkForImage('')).toBe(false);


### PR DESCRIPTION
[Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-570/)

Some broken links included links to image files, which were being applied with trailing slashes. This PR isolates this case and removes trailing slashes from links to images.