### PR TITLE
DEVHUB-546: Pull in Snooty Articles

### DIFF
--- a/cypress/integration/strapi-author.js
+++ b/cypress/integration/strapi-author.js
@@ -1,7 +1,7 @@
 const AUTHOR_BIO = 'Short bio';
-const AUTHOR_TITLE = 'UI Engineer - NYC';
-const AUTHOR_NAME = 'Jordan Stapinski';
-const AUTHOR_URL = '/author/jordan-stapinski/';
+const AUTHOR_TITLE = 'Developer Advocate - United States';
+const AUTHOR_NAME = 'Lauren Schaefer';
+const AUTHOR_URL = '/author/lauren-schaefer/';
 
 describe('Author Page', () => {
     it('should show an image for the author', () => {
@@ -21,7 +21,7 @@ describe('Author Page', () => {
         });
     });
     // TODO: Fill in once Strapi articles are available, or we swap authors
-    xit('should show articles for this author', () => {
+    it('should show articles for this author', () => {
         cy.get('[data-test="card"]')
             .first()
             .then(card => {

--- a/cypress/integration/strapi-author.js
+++ b/cypress/integration/strapi-author.js
@@ -1,0 +1,31 @@
+const AUTHOR_BIO = 'Short bio';
+const AUTHOR_TITLE = 'UI Engineer - NYC';
+const AUTHOR_NAME = 'Jordan Stapinski';
+const AUTHOR_URL = '/author/jordan-stapinski/';
+
+describe('Author Page', () => {
+    it('should show an image for the author', () => {
+        cy.visit(AUTHOR_URL);
+        cy.get('[data-test="author-image"]').should('exist');
+        cy.get('[data-test="author-image"]').within(() => {
+            cy.get('div')
+                .should('have.css', 'background-image')
+                .should('not.be.empty');
+        });
+    });
+    it('should display a name and description for the author', () => {
+        cy.get('header').within(() => {
+            cy.contains(AUTHOR_NAME);
+            cy.contains(AUTHOR_BIO);
+            cy.contains(AUTHOR_TITLE);
+        });
+    });
+    // TODO: Fill in once Strapi articles are available, or we swap authors
+    xit('should show articles for this author', () => {
+        cy.get('[data-test="card"]')
+            .first()
+            .then(card => {
+                cy.checkArticleCard(card);
+            });
+    });
+});

--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -10,6 +10,7 @@ import { createAssetNodes } from './src/utils/setup/create-asset-nodes';
 import { createStrapiAuthorPages } from './src/utils/setup/create-strapi-author-pages';
 import { createProjectPages } from './src/utils/setup/create-project-pages';
 import { createTagPageType } from './src/utils/setup/create-tag-page-type';
+import { getAuthorListFromGraphql } from './src/utils/setup/get-author-list-from-graphql';
 import { getMetadata } from './src/utils/get-metadata';
 import {
     DOCUMENTS_COLLECTION,
@@ -122,6 +123,8 @@ export const createPages = async ({ actions, graphql }) => {
         graphql(articles),
     ]);
 
+    const strapiAuthors = await getAuthorListFromGraphql(graphql);
+
     await createProjectPages(createPage, graphql);
 
     if (result.error) {
@@ -147,15 +150,16 @@ export const createPages = async ({ actions, graphql }) => {
             createPage,
             metadataDocument,
             slugContentMapping,
-            stitchClient
+            stitchClient,
+            strapiAuthors
         )
     );
     await Promise.all(tagPages);
     await createStrapiAuthorPages(
         createPage,
         metadataDocument,
-        graphql,
-        stitchClient
+        stitchClient,
+        strapiAuthors
     );
 };
 

--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -151,7 +151,12 @@ export const createPages = async ({ actions, graphql }) => {
         )
     );
     await Promise.all(tagPages);
-    await createStrapiAuthorPages(createPage, metadataDocument, graphql);
+    await createStrapiAuthorPages(
+        createPage,
+        metadataDocument,
+        graphql,
+        stitchClient
+    );
 };
 
 // Prevent errors when running gatsby build caused by browser packages run in a node environment.

--- a/src/utils/setup/create-strapi-author-pages.js
+++ b/src/utils/setup/create-strapi-author-pages.js
@@ -1,14 +1,7 @@
 import path from 'path';
-import { buildTimeAuthors } from '../../queries/authors';
 import { getTagPageUriComponent } from '../get-tag-page-uri-component';
 import { transformAuthorStrapiData } from './transform-author-strapi-data';
 import { getMetadata } from '../get-metadata';
-
-const getAuthorListFromGraphql = async graphql => {
-    const authorResp = await graphql(buildTimeAuthors);
-    const result = authorResp.data.allStrapiAuthors.nodes;
-    return result;
-};
 
 const getSnootyArticlesForAuthor = async (snootyAuthor, realmClient) => {
     const requestKey = { author: snootyAuthor._id };
@@ -23,10 +16,9 @@ const metadata = getMetadata();
 export const createStrapiAuthorPages = async (
     createPage,
     pageMetadata,
-    graphql,
-    realmClient
+    realmClient,
+    authors
 ) => {
-    const authors = await getAuthorListFromGraphql(graphql);
     const snootyAuthors = await realmClient.callFunction('getValuesByKey', [
         metadata,
         'author',

--- a/src/utils/setup/create-strapi-author-pages.js
+++ b/src/utils/setup/create-strapi-author-pages.js
@@ -2,6 +2,7 @@ import path from 'path';
 import { buildTimeAuthors } from '../../queries/authors';
 import { getTagPageUriComponent } from '../get-tag-page-uri-component';
 import { transformAuthorStrapiData } from './transform-author-strapi-data';
+import { getMetadata } from '../get-metadata';
 
 const getAuthorListFromGraphql = async graphql => {
     const authorResp = await graphql(buildTimeAuthors);
@@ -9,20 +10,43 @@ const getAuthorListFromGraphql = async graphql => {
     return result;
 };
 
+const getSnootyArticlesForAuthor = async (snootyAuthor, realmClient) => {
+    const requestKey = { author: snootyAuthor._id };
+    return await realmClient.callFunction('fetchDevhubMetadata', [
+        metadata,
+        requestKey,
+    ]);
+};
+
+const metadata = getMetadata();
+
 export const createStrapiAuthorPages = async (
     createPage,
     pageMetadata,
-    graphql
+    graphql,
+    realmClient
 ) => {
     const authors = await getAuthorListFromGraphql(graphql);
-    const createSingleAuthorPage = author => {
+    const snootyAuthors = await realmClient.callFunction('getValuesByKey', [
+        metadata,
+        'author',
+    ]);
+    const createSingleAuthorPage = async author => {
         const transformedAuthorData = transformAuthorStrapiData(author);
-        // Some bad data for authors doesn't follow this structure, so ignore it
         const urlSuffix = getTagPageUriComponent(transformedAuthorData.name);
+        // See if this author also has some work in Snooty
+        const snootyAuthor = snootyAuthors.find(
+            a => a._id.name === transformedAuthorData.name
+        );
+        let pages = [];
+        if (snootyAuthor) {
+            // Get snooty pages
+            pages = await getSnootyArticlesForAuthor(snootyAuthor, realmClient);
+        }
         const newPage = {
             type: 'author',
             slug: `/author/${urlSuffix}`,
-            pages: [],
+            pages,
             ...transformedAuthorData,
         };
         createPage({
@@ -36,6 +60,6 @@ export const createStrapiAuthorPages = async (
             },
         });
     };
-
-    authors.forEach(createSingleAuthorPage);
+    const results = authors.map(createSingleAuthorPage);
+    await Promise.all(results);
 };

--- a/src/utils/setup/create-tag-page-type.js
+++ b/src/utils/setup/create-tag-page-type.js
@@ -35,7 +35,8 @@ export const createTagPageType = async (
     createPage,
     pageMetadata,
     RESOLVED_REF_DOC_MAPPING,
-    stitchClient
+    stitchClient,
+    strapiAuthors
 ) => {
     const isAuthor = stitchType === 'author';
     const pageType = STITCH_TYPE_TO_URL_PREFIX[stitchType];
@@ -72,6 +73,9 @@ export const createTagPageType = async (
         const name = isAuthor ? page.item._id.name : page.item._id;
         // Some bad data for authors doesn't follow this structure, so ignore it
         if (name) {
+            if (strapiAuthors.find(a => a.name === name)) {
+                return;
+            }
             const urlSuffix = getTagPageUriComponent(name);
             const newPage = {
                 name,

--- a/src/utils/setup/get-author-list-from-graphql.js
+++ b/src/utils/setup/get-author-list-from-graphql.js
@@ -1,0 +1,7 @@
+import { buildTimeAuthors } from '../../queries/authors';
+
+export const getAuthorListFromGraphql = async graphql => {
+    const authorResp = await graphql(buildTimeAuthors);
+    const result = authorResp.data.allStrapiAuthors.nodes;
+    return result;
+};


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-546-article-pop/author/lauren-schaefer/)

This PR finishes the work needed to support Authors from Strapi (without Strapi articles yet). We pull articles in from Snooty should they exist. We also now clearly make an author's page using CMS data if available, matching based on name.