### PR TITLE
DEVHUB-559: Fix Staging Internal Links

### DIFF
--- a/src/components/dev-hub/related-articles.js
+++ b/src/components/dev-hub/related-articles.js
@@ -78,7 +78,10 @@ const getCardParamsFromRelatedType = (relatedArticle, slugTitleMapping) => {
                 image: relatedArticle.image
                     ? withPrefix(relatedArticle.image)
                     : ARTICLE_PLACEHOLDER,
-                target: makeLinkInternalIfApplicable(relatedArticle.refuri),
+                target: makeLinkInternalIfApplicable(
+                    relatedArticle.refuri,
+                    true
+                ),
                 title: dlv(relatedArticle, ['children', 0, 'value'], ''),
             };
         default:

--- a/src/components/dev-hub/searchbar/SearchResult.js
+++ b/src/components/dev-hub/searchbar/SearchResult.js
@@ -145,7 +145,6 @@ const SearchResult = React.memo(
                         e.preventDefault();
                         // find next result and focus
 
-                        console.log('arrow down');
                         onArrowDown(resultLinkRef);
                     } else if (
                         e.key === 'ArrowUp' ||

--- a/src/utils/make-link-internal-if-applicable.js
+++ b/src/utils/make-link-internal-if-applicable.js
@@ -3,18 +3,23 @@ import { addTrailingSlashIfMissing } from './add-trailing-slash-if-missing';
 import { SITE_URL, FORUMS_URL } from '~src/constants';
 import { isLinkForImage } from '~utils/is-link-for-image';
 
-export const makeLinkInternalIfApplicable = link => {
+export const makeLinkInternalIfApplicable = (link, includePrefix = false) => {
     if (!link) {
         return link;
     }
     const linkIncludesDevHub = link.includes(SITE_URL);
     const linkGoesToForums = link.includes(FORUMS_URL);
     if (linkIncludesDevHub && !linkGoesToForums) {
+        const linkWithoutSiteUrl = link.replace(SITE_URL, '');
         // Forums is technically "external" from an app standpoint, so we leave
         // that one alone
         return isLinkForImage(link)
-            ? withPrefix(link.replace(SITE_URL, ''))
-            : addTrailingSlashIfMissing(link.replace(SITE_URL, ''));
+            ? withPrefix(linkWithoutSiteUrl)
+            : addTrailingSlashIfMissing(
+                  includePrefix
+                      ? withPrefix(linkWithoutSiteUrl)
+                      : linkWithoutSiteUrl
+              );
     }
     return link;
 };


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-559-related/)

This PR follows the broken picture links PR by adding an optional param to enable `withPrefix` for internal links that are referenced as external links.