### PR TITLE
DEVHUB-574: Add CMS Support for Gatsby Redirects

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -28,7 +28,7 @@ module.exports = {
             resolve: `gatsby-source-strapi`,
             options: {
                 apiURL: process.env.STRAPI_URL,
-                contentTypes: ['projects'],
+                contentTypes: ['client-side-redirects', 'projects'],
                 singleTypes: ['student-spotlight-featured', 'top-nav'],
             },
         },

--- a/gatsby-config.prod.js
+++ b/gatsby-config.prod.js
@@ -25,7 +25,7 @@ module.exports = {
             resolve: `gatsby-source-strapi`,
             options: {
                 apiURL: process.env.STRAPI_URL,
-                contentTypes: ['projects'],
+                contentTypes: ['client-side-redirects', 'projects'],
                 singleTypes: ['student-spotlight-featured', 'top-nav'],
             },
         },

--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -8,6 +8,7 @@ import { handleCreatePage } from './src/utils/setup/handle-create-page';
 import { createArticleNode } from './src/utils/setup/create-article-node';
 import { createAssetNodes } from './src/utils/setup/create-asset-nodes';
 import { createProjectPages } from './src/utils/setup/create-project-pages';
+import { createClientSideRedirects } from './src/utils/setup/create-client-side-redirects';
 import { createTagPageType } from './src/utils/setup/create-tag-page-type';
 import { getMetadata } from './src/utils/get-metadata';
 import {
@@ -82,6 +83,14 @@ export const createSchemaCustomization = ({ actions }) => {
     type SitePage implements Node @dontInfer {
         path: String
     }
+    type StrapiClientSideRedirect implements Node {
+        fromPath: String
+        isPermanent: Boolean
+        toPath: String
+    }
+    type allStrapiClientSideRedirects implements Node {
+        nodes: [StrapiClientSideRedirect]
+    }
     `;
     createTypes(typeDefs);
 };
@@ -138,22 +147,7 @@ export const createPages = async ({ actions, graphql }) => {
         );
     });
 
-    // This will shortly be replaced by CMS-friendly logic once verified
-    // This is not a substitute for Fastly redirects, both are needed
-    createRedirect({
-        fromPath: '/quickstart/node-connect-mongodb/',
-        isPermanent: true,
-        redirectInBrowser: true,
-        toPath:
-            'https://www.mongodb.com/blog/post/quick-start-nodejs-mongodb--how-to-get-connected-to-your-database',
-    });
-    createRedirect({
-        fromPath: '/quickstart/node-connect-mongodb-3-3-2/',
-        isPermanent: true,
-        redirectInBrowser: true,
-        toPath:
-            'https://www.mongodb.com/blog/post/quick-start-nodejs-mongodb--how-to-get-connected-to-your-database',
-    });
+    await createClientSideRedirects(graphql, createRedirect);
 
     const tagTypes = ['author', 'languages', 'products', 'tags', 'type'];
     const tagPages = tagTypes.map(type =>

--- a/src/queries/client-side-redirects.js
+++ b/src/queries/client-side-redirects.js
@@ -1,0 +1,11 @@
+export const buildTimeClientSideRedirects = `
+query BuildTimeClientsideRedirects {
+  allStrapiClientSideRedirects {
+    nodes {
+      fromPath
+      isPermanent
+      toPath
+    }
+  }
+}
+`;

--- a/src/utils/setup/create-client-side-redirects.js
+++ b/src/utils/setup/create-client-side-redirects.js
@@ -1,0 +1,12 @@
+import dlv from 'dlv';
+import { buildTimeClientSideRedirects } from '../../queries/client-side-redirects';
+
+// These alone are not enough to fully redirect, we should also
+// be updating Fastly for a 301 response
+export const createClientSideRedirects = async (graphql, createRedirect) => {
+    const resp = await graphql(buildTimeClientSideRedirects);
+    const result = dlv(resp, 'data.allStrapiClientSideRedirects.nodes', []);
+    result.forEach(redirect =>
+        createRedirect({ ...redirect, redirectInBrowser: true })
+    );
+};


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-574/)

This PR builds off of the previous redirect work to add support for client-side redirects to come from the CMS. The two existing redirects are kept, the infrastructure has just moved to Strapi for easier handling.