### PR TITLE
DEVHUB-549: Ensure slash key works on Firefox

### DIFF
--- a/cypress/integration/search.js
+++ b/cypress/integration/search.js
@@ -55,6 +55,15 @@ describe('search', () => {
         cy.visitWithoutFetch('/');
         checkCondensedSearchbar();
     });
+    it('should open and focus search bar when press slash', () => {
+        cy.viewport(1040, 660);
+        cy.visitWithoutFetch('/');
+        cy.get(SEARCHBAR).should('not.exist');
+        cy.get("[data-test='Closed Searchbar Button']").should('exist').click();
+        // Simulate slash typing
+        cy.get('body').type('/');
+        cy.get(SEARCHBAR).should('exist');
+    });
     it('should expand search by default on certain sizes', () => {
         // This will reset the viewport to default
         cy.get(SEARCHBAR).should('exist');
@@ -97,26 +106,5 @@ describe('search', () => {
             "[data-test='Search Dropdown']:visible [data-test='Search Result']"
         ).should('have.length', 6);
         checkSearchResults(1);
-    });
-    it('should open and focus search bar when press slash', () => {
-        cy.viewport(1040, 660);
-        cy.visitWithoutFetch('/');
-        cy.get(SEARCHBAR).should('not.exist');
-
-        // Simulate slash typing
-        cy.get('body').trigger('keydown', {
-            key: '/',
-            keyCode: 47,
-            force: true,
-        });
-        // eslint-disable-next-line cypress/no-unnecessary-waiting
-        cy.wait(500);
-        cy.get('body').trigger('keyup', {
-            key: '/',
-            keyCode: 47,
-            force: true,
-        });
-
-        cy.get(SEARCHBAR).should('exist');
     });
 });

--- a/src/components/dev-hub/searchbar/Searchbar.js
+++ b/src/components/dev-hub/searchbar/Searchbar.js
@@ -139,15 +139,20 @@ const Searchbar = ({ isExpanded, setIsExpanded }) => {
     }, [isFocused]);
 
     // Focus when slash pressed
-    const onSlashKeyUp = useCallback(({ key, keyCode }) => {
-        if(key === '/' || keyCode === SLASH_KEY) {
-            onExpand();
-            onFocus();
-        }
-    }, [onExpand, onFocus]);
+    const onSlashKeyDown = useCallback(
+        e => {
+            const { key, keyCode } = e;
+            if (key === '/' || keyCode === SLASH_KEY) {
+                e.preventDefault();
+                onExpand();
+                onFocus();
+            }
+        },
+        [onExpand, onFocus]
+    );
 
     // Add event listener using hook
-    useEventListener("keyup", onSlashKeyUp);
+    useEventListener('keydown', onSlashKeyDown);
 
     // Remove focus and close searchbar if it disrupts the navbar
     const onBlur = useCallback(() => {


### PR DESCRIPTION
[Try it out here](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-549-ff/)

I noticed the Slash did not work on Firefox because Firefox opens a quick find window with that key. We need to use `preventDefault` in order to block that. I also swapped the event from keyUp to keyDown so it would work as soon as the key has been pressed. I also shortened the UI test and was able to omit the `wait`

Give it a try with the link above!