### PR TITLE
DEVHUB-553: Add Article raw_content to search XML

### DIFF
--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -53,7 +53,7 @@ export const sourceNodes = async ({
         metadata.patchId
     );
 
-    const documents = await stitchClient.callFunction('fetchDocuments', [
+    const documents = await stitchClient.callFunction('fetchDevhubDocuments', [
         DB,
         DOCUMENTS_COLLECTION,
         query,
@@ -63,13 +63,17 @@ export const sourceNodes = async ({
     }
 
     documents.forEach(doc => {
+        const rawContent = doc.source;
+        // We use the source for search RSS XML but do not want it in page data
+        delete doc.source;
         createAssetNodes(doc, createNode, createContentDigest);
         createArticleNode(
             doc,
             PAGE_ID_PREFIX,
             createNode,
             createContentDigest,
-            slugContentMapping
+            slugContentMapping,
+            rawContent
         );
     });
 };

--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -10,7 +10,6 @@ import { createAssetNodes } from './src/utils/setup/create-asset-nodes';
 import { createProjectPages } from './src/utils/setup/create-project-pages';
 import { createClientSideRedirects } from './src/utils/setup/create-client-side-redirects';
 import { createTagPageType } from './src/utils/setup/create-tag-page-type';
-import { replaceDirectivesInContent } from './src/utils/setup/replace-directives-in-content';
 import { getMetadata } from './src/utils/get-metadata';
 import {
     DOCUMENTS_COLLECTION,
@@ -64,7 +63,7 @@ export const sourceNodes = async ({
     }
 
     documents.forEach(doc => {
-        const rawContent = replaceDirectivesInContent(doc.source);
+        const rawContent = doc.source;
         // We use the source for search RSS XML but do not want it in page data
         delete doc.source;
         createAssetNodes(doc, createNode, createContentDigest);

--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -10,6 +10,7 @@ import { createAssetNodes } from './src/utils/setup/create-asset-nodes';
 import { createProjectPages } from './src/utils/setup/create-project-pages';
 import { createClientSideRedirects } from './src/utils/setup/create-client-side-redirects';
 import { createTagPageType } from './src/utils/setup/create-tag-page-type';
+import { replaceDirectivesInContent } from './src/utils/setup/replace-directives-in-content';
 import { getMetadata } from './src/utils/get-metadata';
 import {
     DOCUMENTS_COLLECTION,
@@ -63,7 +64,7 @@ export const sourceNodes = async ({
     }
 
     documents.forEach(doc => {
-        const rawContent = doc.source;
+        const rawContent = replaceDirectivesInContent(doc.source);
         // We use the source for search RSS XML but do not want it in page data
         delete doc.source;
         createAssetNodes(doc, createNode, createContentDigest);

--- a/src/queries/search-article-rss-data.js
+++ b/src/queries/search-article-rss-data.js
@@ -11,6 +11,7 @@ const searchArticleRSSData = `
                 languages
                 products
                 pubdate
+                rawContent
                 tags
                 title
                 type

--- a/src/utils/setup/create-article-node.js
+++ b/src/utils/setup/create-article-node.js
@@ -7,7 +7,8 @@ export const createArticleNode = (
     PAGE_ID_PREFIX,
     createNode,
     createContentDigest,
-    slugContentMapping
+    slugContentMapping,
+    rawContent
 ) => {
     const filename = getNestedValue(['filename'], doc) || '';
     const isArticlePage =
@@ -27,6 +28,7 @@ export const createArticleNode = (
             languages: doc.query_fields['languages'],
             products: doc.query_fields['products'],
             pubdate: doc.query_fields['pubdate'],
+            rawContent,
             tags: doc.query_fields['tags'],
             title: getNestedText(doc.query_fields['title']),
             type: doc.query_fields['type'],

--- a/src/utils/setup/replace-directives-in-content.js
+++ b/src/utils/setup/replace-directives-in-content.js
@@ -1,2 +1,0 @@
-export const replaceDirectivesInContent = content =>
-    content.replace(/(.. [\w-]+::)|(:[\w-]+)|(-+)|(=+)/g, '');

--- a/src/utils/setup/replace-directives-in-content.js
+++ b/src/utils/setup/replace-directives-in-content.js
@@ -1,0 +1,2 @@
+export const replaceDirectivesInContent = content =>
+    content.replace(/(.. [\w-]+::)|(:[\w-]+)|(-+)|(=+)/g, '');

--- a/src/utils/setup/serialize-search-rss-data.js
+++ b/src/utils/setup/serialize-search-rss-data.js
@@ -22,6 +22,7 @@ const getCustomRSSElements = article => {
         'language'
     );
     const products = handlePossiblyEmptyField(article, 'products', 'product');
+    const rawContent = article.rawContent;
     const tags = handlePossiblyEmptyField(article, 'tags', 'tag');
     const customElements = [
         { atf_image: article.atfimage },
@@ -36,6 +37,9 @@ const getCustomRSSElements = article => {
     }
     if (products) {
         customElements.push({ products: products });
+    }
+    if (rawContent) {
+        customElements.push({ raw_content: rawContent });
     }
     if (tags) {
         customElements.push({ tags: tags });

--- a/tests/utils/create-article-node.test.js
+++ b/tests/utils/create-article-node.test.js
@@ -7,6 +7,7 @@ describe('Should properly postprocess an article node after it is fetched', () =
     const articleLanguages = ['Python'];
     const articleProducts = ['MongoDB'];
     const articlePubdate = '2030-01-01';
+    const articleRawContent = 'Raw content';
     const articleSlug = 'article/test-article';
     const articleTags = ['first-tag', 'second-tag'];
     const articleTitle = 'Test Article';
@@ -78,7 +79,8 @@ describe('Should properly postprocess an article node after it is fetched', () =
             pageIdPrefix,
             createNode,
             createContentDigest,
-            {}
+            {},
+            articleRawContent
         );
         expect(createNode.mock.calls.length).toBe(1);
         const createdArticleNode = createNode.mock.calls[0][0];
@@ -87,6 +89,7 @@ describe('Should properly postprocess an article node after it is fetched', () =
         expect(createdArticleNode.title).toBe(articleTitle);
         expect(createdArticleNode.description).toBe(articleDescription);
         expect(createdArticleNode.pubdate).toBe(articlePubdate);
+        expect(createdArticleNode.rawContent).toBe(articleRawContent);
 
         expect(createdArticleNode.internal.contentDigest).not.toBeUndefined();
         expect(createContentDigest.mock.calls.length).toBe(1);
@@ -97,6 +100,7 @@ describe('Should properly postprocess an article node after it is fetched', () =
             languages: articleLanguages,
             products: articleProducts,
             pubdate: articlePubdate,
+            rawContent: articleRawContent,
             tags: articleTags,
             title: articleTitle,
             type: articleType,


### PR DESCRIPTION
[Staging Search XML](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-553/search-rss.xml)

This PR adds a field called `raw_content` ONLY to the search XML file (to prevent page bloating and slowing build times) from a new Snooty Realm App function. This right now is the straight-up file content of the article but in Realm we removed various rST syntax, such as directive definitions and options, long strings of `-` and `=`s.

Once this is in, we can update the webhook to index and search.