### PR TITLE
DEVHUB-508: Upgrade General Support to Node 14

### DIFF
--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -6,10 +6,10 @@ jobs:
         steps:
             - name: Checkout target branch
               uses: actions/checkout@v2
-            - name: Use Node.js 12.x
+            - name: Use Node.js 14.x
               uses: actions/setup-node@v1
               with:
-                  node-version: '12.x'
+                  node-version: '14.x'
             - name: Cache node modules
               uses: actions/cache@v2
               id: cache

--- a/.github/workflows/devhub-npm-test.yaml
+++ b/.github/workflows/devhub-npm-test.yaml
@@ -10,10 +10,10 @@ jobs:
         steps:
             - name: Checkout target branch
               uses: actions/checkout@v2
-            - name: Use Node.js 12.x
+            - name: Use Node.js 14.x
               uses: actions/setup-node@v1
               with:
-                  node-version: '12.x'
+                  node-version: '14.x'
             - name: Cache node modules
               uses: actions/cache@v2
               id: cache


### PR DESCRIPTION
I have tried to run testing (unit and e2e) and Gatsby scripts on my local machine with node 14. Looks all is fine. This PR just updates config.