### PR TITLE
DEVHUB-566: Fix Pop-up on Search Results - MongoDB

### DIFF
--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -242,7 +242,7 @@ export default ({
             const filter = stripAllParam(filterValue);
             const searchParams = buildQueryString(filter);
             const filteredArticles = filterActiveArticles(filter);
-            setArticles(filteredArticles);
+            filteredArticles.length && setArticles(filteredArticles);
             if (window.location.search !== searchParams) {
                 // if the search params are empty, push the pathname state in order to remove params
                 navigate(


### PR DESCRIPTION
This PR fixes pop-up on Search Results. The problem is in 'articles' and 'ActiveCardList' component. When we have some result from search bar - 'articles' will be empty, that why the scrollbar is blinking.