### PR TITLE
DEVHUB-545 [Part 2]: Add Authors, Twitter

### DIFF
--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -18,6 +18,7 @@ import {
     METADATA_COLLECTION,
 } from './src/build-constants';
 import { createArticlePage } from './src/utils/setup/create-article-page';
+import { getStrapiArticleListFromGraphql } from './src/utils/setup/create-strapi-article-pages';
 
 // Consolidated metadata object used to identify build and env variables
 const metadata = getMetadata();
@@ -134,6 +135,8 @@ export const createPages = async ({ actions, graphql }) => {
 
     const allSeries = filteredPageGroups(metadataDocument.pageGroups);
 
+    const articleList = await getStrapiArticleListFromGraphql(graphql);
+
     await createStrapiArticlePages(graphql, createPage, metadataDocument);
 
     result.data.allArticle.nodes.forEach(article => {
@@ -162,7 +165,8 @@ export const createPages = async ({ actions, graphql }) => {
         createPage,
         metadataDocument,
         stitchClient,
-        strapiAuthors
+        strapiAuthors,
+        articleList
     );
 };
 

--- a/src/components/dev-hub/SEO.js
+++ b/src/components/dev-hub/SEO.js
@@ -28,7 +28,7 @@ const SEO = ({
 }) => {
     const twitter = twitterNode ? twitterNode.options : {};
     const twitterDescription = twitterNode
-        ? getNestedText(twitterNode.children)
+        ? twitterNode.options.description || getNestedText(twitterNode.children)
         : null;
     const { siteUrl } = useSiteMetadata();
     const ogImgSrc = image ? getImageSrc(image, siteUrl) : null;

--- a/src/components/dev-hub/byline-block.js
+++ b/src/components/dev-hub/byline-block.js
@@ -47,8 +47,12 @@ const StyledAuthorImage = styled(AuthorImage)`
 
 const AuthorImages = ({ authors }) => (
     <AuthorImageContainer>
-        {authors.map(({ name, image }) => (
-            <StyledAuthorImage image={image} key={name} />
+        {authors.map(({ name, image, isInternalReference = false }) => (
+            <StyledAuthorImage
+                image={image}
+                key={name}
+                isInternalReference={isInternalReference}
+            />
         ))}
     </AuthorImageContainer>
 );

--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -52,7 +52,6 @@ const renderStrapiArticle = article => (
         to={article['slug']}
         key={article['_id']}
         image={article['image']}
-        // Cleanup below
         tags={getTagLinksFromMeta(article)}
         title={article['name']}
         badge="article"

--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -47,6 +47,19 @@ const renderArticle = article => (
     />
 );
 
+const renderStrapiArticle = article => (
+    <ArticleCard
+        to={article['slug']}
+        key={article['_id']}
+        image={article['image']}
+        // Cleanup below
+        tags={getTagLinksFromMeta(article)}
+        title={article['name']}
+        badge="article"
+        description={article['description']}
+    />
+);
+
 const renderVideo = video => (
     <VideoCard
         key={video.mediaType + video.title}
@@ -81,7 +94,9 @@ const renderContentTypeCard = (item, openAudio) => {
             default:
                 return;
         }
-
+    if (item.isFromStrapi) {
+        return renderStrapiArticle(item);
+    }
     return renderArticle(item);
 };
 

--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -38,7 +38,7 @@ const sortCardsByDate = contentList =>
 const renderArticle = article => (
     <ArticleCard
         to={article['slug']}
-        key={article['_id']}
+        key={article['id']}
         image={withPrefix(article['atf-image'])}
         tags={getTagLinksFromMeta(article)}
         title={getNestedText(article['title'])}

--- a/src/queries/articles.js
+++ b/src/queries/articles.js
@@ -12,6 +12,7 @@ export const buildTimeArticles = `
 query Articles {
     allStrapiArticles {
       nodes {
+        _id
         authors {
           name
           image {

--- a/src/queries/articles.js
+++ b/src/queries/articles.js
@@ -12,7 +12,7 @@ export const buildTimeArticles = `
 query Articles {
     allStrapiArticles {
       nodes {
-        _id
+        id
         authors {
           name
           image {

--- a/src/queries/articles.js
+++ b/src/queries/articles.js
@@ -12,6 +12,12 @@ export const buildTimeArticles = `
 query Articles {
     allStrapiArticles {
       nodes {
+        authors {
+          name
+          image {
+            url
+          }
+        }
         content
         type
         description

--- a/src/templates/strapi-article.js
+++ b/src/templates/strapi-article.js
@@ -85,7 +85,7 @@ const StrapiArticle = props => {
             },
             seriesArticles,
             // Clarify and add in type in transform
-            slug: thisPage,
+            slug,
             tags,
             type,
             updatedAt,
@@ -94,17 +94,18 @@ const StrapiArticle = props => {
     } = props;
     const { siteUrl } = useSiteMetadata();
     const childNodes = dlv(parsedContent, 'children', []);
-    // TODO: Fix with SEO component
+    // TODO: Put in transform
     const twitterNode = {
-        twitter_creator,
-        description: twitter_description,
-        image: twitter_image.url,
+        options: {
+            creator: twitter_creator,
+            description: twitter_description,
+            image: twitter_image.url,
+        },
     };
     const articleBreadcrumbs = [
         { label: 'Home', target: '/' },
         { label: 'Learn', target: '/learn' },
     ];
-    // Add mapping for type in transform
     if (type && type.length) {
         articleBreadcrumbs.push({
             label: type[0].toUpperCase() + type.substring(1),
@@ -112,7 +113,7 @@ const StrapiArticle = props => {
         });
     }
     const tagList = getTagLinksFromMeta({ tags, products, languages });
-    const articleUrl = addTrailingSlashIfMissing(`${siteUrl}/${thisPage}`);
+    const articleUrl = addTrailingSlashIfMissing(`${siteUrl}${slug}`);
     // TODO: Fill in
     const headingNodes = [];
     const formattedPublishedDate = toDateString(
@@ -130,7 +131,7 @@ const StrapiArticle = props => {
                 ogDescription={og_description}
                 ogTitle={name}
                 ogUrl={og_url || articleUrl}
-                twitterNode={null}
+                twitterNode={twitterNode}
                 type={og_type}
             />
             <ArticleSchema
@@ -170,7 +171,7 @@ const StrapiArticle = props => {
                     <DocumentBody
                         pageNodes={childNodes}
                         slugTitleMapping={slugTitleMapping}
-                        slug={thisPage}
+                        slug={slug}
                         {...rest}
                     />
                     <ArticleShareFooter

--- a/src/templates/strapi-article.js
+++ b/src/templates/strapi-article.js
@@ -92,7 +92,6 @@ const StrapiArticle = props => {
     } = props;
     const { siteUrl } = useSiteMetadata();
     const childNodes = dlv(parsedContent, 'children', []);
-    // TODO: Put in transform
     const articleBreadcrumbs = [
         { label: 'Home', target: '/' },
         { label: 'Learn', target: '/learn' },

--- a/src/templates/strapi-article.js
+++ b/src/templates/strapi-article.js
@@ -121,9 +121,6 @@ const StrapiArticle = props => {
     );
     const formattedUpdatedDate = toDateString(updatedAt, dateFormatOptions);
 
-    // Move into transform
-    const articleImage = image.url;
-
     return (
         <Layout includeCanonical={false}>
             <SEOComponent
@@ -143,11 +140,11 @@ const StrapiArticle = props => {
                 description={meta_description}
                 publishedDate={published_at}
                 modifiedDate={updatedAt}
-                imageUrl={articleImage}
+                imageUrl={image}
                 authors={authors}
             />
             <BlogPostTitleArea
-                articleImage={articleImage}
+                articleImage={image}
                 authors={authors}
                 breadcrumb={articleBreadcrumbs}
                 originalDate={formattedPublishedDate}

--- a/src/templates/strapi-article.js
+++ b/src/templates/strapi-article.js
@@ -120,7 +120,6 @@ const StrapiArticle = props => {
         dateFormatOptions
     );
     const formattedUpdatedDate = toDateString(updatedAt, dateFormatOptions);
-
     return (
         <Layout includeCanonical={false}>
             <SEOComponent

--- a/src/templates/strapi-article.js
+++ b/src/templates/strapi-article.js
@@ -79,9 +79,7 @@ const StrapiArticle = props => {
                 og_image,
                 og_type,
                 og_url,
-                twitter_creator,
-                twitter_description,
-                twitter_image,
+                twitterNode,
             },
             seriesArticles,
             // Clarify and add in type in transform
@@ -95,13 +93,6 @@ const StrapiArticle = props => {
     const { siteUrl } = useSiteMetadata();
     const childNodes = dlv(parsedContent, 'children', []);
     // TODO: Put in transform
-    const twitterNode = {
-        options: {
-            creator: twitter_creator,
-            description: twitter_description,
-            image: twitter_image.url,
-        },
-    };
     const articleBreadcrumbs = [
         { label: 'Home', target: '/' },
         { label: 'Learn', target: '/learn' },

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -60,7 +60,11 @@ const SyledAuthorImage = styled(AuthorImage)`
 const constructArticles = data =>
     data.reduce(
         (accum, article) =>
-            accum.concat({ ...article.query_fields, _id: article._id }),
+            accum.concat(
+                article.query_fields
+                    ? { ...article.query_fields, _id: article._id }
+                    : article
+            ),
         []
     );
 

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -61,9 +61,9 @@ const constructArticles = data =>
     data.reduce(
         (accum, article) =>
             accum.concat(
-                article.query_fields
-                    ? { ...article.query_fields, _id: article._id }
-                    : article
+                article.isFromStrapi
+                    ? article
+                    : { ...article.query_fields, _id: article._id }
             ),
         []
     );

--- a/src/utils/setup/create-strapi-article-pages.js
+++ b/src/utils/setup/create-strapi-article-pages.js
@@ -4,8 +4,7 @@ import { buildTimeArticles } from '../../queries/articles';
 import { parseMarkdownToAST } from './parse-markdown-to-ast';
 
 const createPageForStrapiArticle = async (article, createPage, metadata) => {
-    const updatedArticle = transformArticleStrapiData(article);
-    const { content, slug, ...rest } = updatedArticle;
+    const { content, slug, ...rest } = article;
     const parsedContent = await parseMarkdownToAST(content);
     const template = 'strapi-article';
     if (parsedContent && Object.keys(parsedContent).length > 0) {
@@ -24,9 +23,11 @@ const createPageForStrapiArticle = async (article, createPage, metadata) => {
     }
 };
 
-const getStrapiArticleListFromGraphql = async graphql => {
+export const getStrapiArticleListFromGraphql = async graphql => {
     const projectResp = await graphql(buildTimeArticles);
-    const result = projectResp.data.allStrapiArticles.nodes;
+    const result = projectResp.data.allStrapiArticles.nodes.map(
+        transformArticleStrapiData
+    );
     return result;
 };
 

--- a/src/utils/setup/create-strapi-author-pages.js
+++ b/src/utils/setup/create-strapi-author-pages.js
@@ -17,7 +17,8 @@ export const createStrapiAuthorPages = async (
     createPage,
     pageMetadata,
     realmClient,
-    authors
+    authors,
+    strapiArticles
 ) => {
     const snootyAuthors = await realmClient.callFunction('getValuesByKey', [
         metadata,
@@ -30,10 +31,17 @@ export const createStrapiAuthorPages = async (
         const snootyAuthor = snootyAuthors.find(
             a => a._id.name === transformedAuthorData.name
         );
-        let pages = [];
+        let pages = strapiArticles.filter(
+            a =>
+                !!a.authors.find(
+                    author => author.name === transformedAuthorData.name
+                )
+        );
         if (snootyAuthor) {
             // Get snooty pages
-            pages = await getSnootyArticlesForAuthor(snootyAuthor, realmClient);
+            pages.push(
+                ...(await getSnootyArticlesForAuthor(snootyAuthor, realmClient))
+            );
         }
         const newPage = {
             type: 'author',

--- a/src/utils/transform-article-strapi-data.js
+++ b/src/utils/transform-article-strapi-data.js
@@ -15,6 +15,7 @@ export const transformArticleStrapiData = article => {
         ...article,
         authors: transformedAuthors,
         image: article.image.url,
+        isFromStrapi: true,
         languages: article.languages.map(l => l.language),
         products: article.products.map(p => p.product),
         SEO: {

--- a/src/utils/transform-article-strapi-data.js
+++ b/src/utils/transform-article-strapi-data.js
@@ -1,7 +1,16 @@
+const typeMap = {
+    Article: 'article',
+    HowTo: 'how-to',
+    Quickstart: 'quickstart',
+};
+
 // This will get more complicated as we build the pipeline out
 export const transformArticleStrapiData = article => ({
     ...article,
+    image: article.image.url,
     languages: article.languages.map(l => l.language),
     products: article.products.map(p => p.product),
+    slug: `/${typeMap[article.type]}${article.slug}`,
     tags: article.tags.map(t => t.tag),
+    type: typeMap[article.type],
 });

--- a/src/utils/transform-article-strapi-data.js
+++ b/src/utils/transform-article-strapi-data.js
@@ -5,12 +5,20 @@ const typeMap = {
 };
 
 // This will get more complicated as we build the pipeline out
-export const transformArticleStrapiData = article => ({
-    ...article,
-    image: article.image.url,
-    languages: article.languages.map(l => l.language),
-    products: article.products.map(p => p.product),
-    slug: `/${typeMap[article.type]}${article.slug}`,
-    tags: article.tags.map(t => t.tag),
-    type: typeMap[article.type],
-});
+export const transformArticleStrapiData = article => {
+    const authors =
+        typeof article.authors === 'object'
+            ? [article.authors]
+            : article.authors;
+    const transformedAuthors = authors.map(a => ({ ...a, image: a.image.url }));
+    return {
+        ...article,
+        authors: transformedAuthors,
+        image: article.image.url,
+        languages: article.languages.map(l => l.language),
+        products: article.products.map(p => p.product),
+        slug: `/${typeMap[article.type]}${article.slug}`,
+        tags: article.tags.map(t => t.tag),
+        type: typeMap[article.type],
+    };
+};

--- a/src/utils/transform-article-strapi-data.js
+++ b/src/utils/transform-article-strapi-data.js
@@ -17,6 +17,16 @@ export const transformArticleStrapiData = article => {
         image: article.image.url,
         languages: article.languages.map(l => l.language),
         products: article.products.map(p => p.product),
+        SEO: {
+            ...article.SEO,
+            twitterNode: {
+                options: {
+                    creator: article.SEO.twitter_creator,
+                    description: article.SEO.twitter_description,
+                    image: article.SEO.twitter_image.url,
+                },
+            },
+        },
         slug: `/${typeMap[article.type]}${article.slug}`,
         tags: article.tags.map(t => t.tag),
         type: typeMap[article.type],


### PR DESCRIPTION
[Staging Article](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-545-authors-seo/how-to/realm-test/)

This PR is another check in for DEVHUB-545. I started to deviate from the adapter pattern in some places where we were making things more convoluted just to use Snooty. It includes:
- Support for authors
- Support on Author pages
- Twitter Social Share support

Next will be:
- Setting up UI testing
- (New ticket) Adding articles to other tag/learn pages