### PR TITLE
DEVHUB-545 [Part 3]: Add Headings to TOC

### DIFF
--- a/src/templates/strapi-article.js
+++ b/src/templates/strapi-article.js
@@ -18,6 +18,7 @@ import ShareMenu from '../components/dev-hub/share-menu';
 import ContentsMenu from '../components/dev-hub/contents-menu';
 import { addTrailingSlashIfMissing } from '../utils/add-trailing-slash-if-missing';
 import ArticleSchema from '../components/dev-hub/article-schema';
+import { findSectionHeadings } from '../utils/find-section-headings';
 
 const dateFormatOptions = {
     month: 'short',
@@ -104,8 +105,13 @@ const StrapiArticle = props => {
     }
     const tagList = getTagLinksFromMeta({ tags, products, languages });
     const articleUrl = addTrailingSlashIfMissing(`${siteUrl}${slug}`);
-    // TODO: Fill in
-    const headingNodes = [];
+    const headingNodes = findSectionHeadings(
+        childNodes,
+        'type',
+        'heading',
+        1,
+        -1
+    );
     const formattedPublishedDate = toDateString(
         published_at,
         dateFormatOptions

--- a/src/utils/find-section-headings.js
+++ b/src/utils/find-section-headings.js
@@ -1,10 +1,16 @@
-export const findSectionHeadings = (nodes, key, value, maxDepth) => {
+export const findSectionHeadings = (
+    nodes,
+    key,
+    value,
+    maxDepth,
+    minDepth = 1
+) => {
     const results = [];
     const searchNode = (node, sectionDepth) => {
         if (
             node[key] === value &&
             sectionDepth - 1 <= maxDepth &&
-            sectionDepth > 1
+            sectionDepth > minDepth
         ) {
             const nodeTitle = node.children;
             const newNode = {

--- a/src/utils/setup/parse-markdown-to-ast.js
+++ b/src/utils/setup/parse-markdown-to-ast.js
@@ -2,6 +2,8 @@ import remark from 'remark';
 import directive from 'remark-directive';
 import gfm from 'remark-gfm';
 import visit from 'unist-util-visit';
+import { getNestedText } from '../get-nested-text';
+import { getTagPageUriComponent } from '../get-tag-page-uri-component';
 
 export const parseMarkdownToAST = markdown => {
     const result = remark().use(gfm).use(directive).parse(markdown);
@@ -9,17 +11,30 @@ export const parseMarkdownToAST = markdown => {
     function transform(tree) {
         visit(
             tree,
-            ['textDirective', 'leafDirective', 'containerDirective'],
+            ['heading', 'textDirective', 'leafDirective', 'containerDirective'],
             ondirective
         );
     }
 
     function ondirective(node) {
-        var data = node.data || (node.data = {});
-        node['argument'] = [{ value: node.attributes.vid }];
-        data['name'] = node.name;
-        node.type = node.name;
-        node.nodeData = data;
+        const data = node.data || (node.data = {});
+        switch (node.type) {
+            case 'heading':
+                node['id'] = getTagPageUriComponent(
+                    getNestedText(node['children'])
+                );
+                break;
+            case 'textDirective':
+                // Custom directive definitions go here
+                // Right now, this is just YouTube
+                node['argument'] = [{ value: node.attributes.vid }];
+                data['name'] = node.name;
+                node.type = node.name;
+                node.nodeData = data;
+                break;
+            default:
+                break;
+        }
     }
     transform(result);
     return result;


### PR DESCRIPTION
[Staging Article](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-545-TOC/how-to/realm-test/)

This PR finishes off rendering the basic Strapi article content by adding heading content to the TOC. To do this, we did the following:
- Added the `id` field to headings to match Snooty's
- Updated the `find-section-headings` logic to check at a various `minDepth`.