### PR TITLE
DEVHUB-568: POC Audio on Every Page

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -33,6 +33,14 @@ module.exports = {
             },
         },
         {
+            resolve: `gatsby-plugin-layout`,
+            options: {
+                component: require.resolve(
+                    `./src/components/dev-hub/audio-layout.js`
+                ),
+            },
+        },
+        {
             resolve: `gatsby-plugin-alias-imports`,
             options: {
                 alias: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14989,6 +14989,14 @@
         "@babel/runtime": "^7.12.5"
       }
     },
+    "gatsby-plugin-layout": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-layout/-/gatsby-plugin-layout-2.1.0.tgz",
+      "integrity": "sha512-5WZ6tRM5B79lEiMWEBWCacUctmrHGgNOHGYklSxYZQaYsXTxtfhGJ4dHf10TUif2bttQ6IRi+4Elm5Lm6AJucg==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      }
+    },
     "gatsby-plugin-meta-redirect": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-meta-redirect/-/gatsby-plugin-meta-redirect-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "gatsby-plugin-feed": "^2.12.0",
     "gatsby-plugin-force-trailing-slashes": "^1.0.5",
     "gatsby-plugin-google-tagmanager": "^2.10.0",
+    "gatsby-plugin-layout": "^2.1.0",
     "gatsby-plugin-meta-redirect": "^1.1.1",
     "gatsby-plugin-react-helmet": "^3.9.0",
     "gatsby-plugin-sitemap": "^2.12.0",

--- a/src/components/dev-hub/audio-context.js
+++ b/src/components/dev-hub/audio-context.js
@@ -1,9 +1,11 @@
 import { createContext } from 'react';
 
 const defaultContextValue = {
-    activeAudioFile: null,
+    activeAudioNode: null,
+    setActiveAudioNode: () => null,
 };
 
 const AudioContext = createContext(defaultContextValue);
+const AudioContextProvider = AudioContext.Provider;
 
-export { AudioContext };
+export { AudioContext, AudioContextProvider };

--- a/src/components/dev-hub/audio-context.js
+++ b/src/components/dev-hub/audio-context.js
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+
+const defaultContextValue = {
+    activeAudioFile: null,
+};
+
+const AudioContext = createContext(defaultContextValue);
+
+export { AudioContext };

--- a/src/components/dev-hub/audio-layout.js
+++ b/src/components/dev-hub/audio-layout.js
@@ -1,0 +1,26 @@
+import React, { useState } from 'react';
+import { ThemeProvider } from 'emotion-theming';
+import { darkTheme } from './theme';
+import { AudioContextProvider } from './audio-context';
+import Audio from './audio';
+
+const AudioLayout = ({ children }) => {
+    const [activeAudioNode, setActiveAudioNode] = useState(null);
+    return (
+        <ThemeProvider theme={darkTheme}>
+            <AudioContextProvider
+                value={{ activeAudioNode, setActiveAudioNode }}
+            >
+                {children}
+                {activeAudioNode ? (
+                    <Audio
+                        onClose={() => setActiveAudioNode(null)}
+                        podcast={activeAudioNode}
+                    />
+                ) : null}
+            </AudioContextProvider>
+        </ThemeProvider>
+    );
+};
+
+export default AudioLayout;

--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -95,10 +95,7 @@ export default React.memo(
             videos.concat(articles, podcasts)
         );
 
-        const { activeAudioNode, setActiveAudioNode } = useContext(
-            AudioContext
-        );
-        console.log(activeAudioNode, setActiveAudioNode);
+        const { setActiveAudioNode } = useContext(AudioContext);
         return (
             <>
                 <Paginate limit={limit} data-test="card-list">

--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -1,6 +1,6 @@
-import React, { useCallback, useState } from 'react';
+import React, { useContext } from 'react';
 import styled from '@emotion/styled';
-import Audio from './audio';
+import { AudioContext } from './audio-context';
 import Card from './card';
 import { withPrefix } from 'gatsby';
 import Paginate from './paginate';
@@ -59,14 +59,14 @@ const renderVideo = video => (
     />
 );
 
-const renderPodcast = (podcast, openAudio) => (
+const renderPodcast = (podcast, setActiveAudioNode) => (
     <Card
         key={podcast.mediaType + podcast.title}
         image={getThumbnailUrl(podcast)}
         title={podcast.title}
         badge={podcast.mediaType}
         description={podcast.description}
-        onClick={() => openAudio(podcast)}
+        onClick={() => setActiveAudioNode(podcast)}
     />
 );
 
@@ -95,26 +95,17 @@ export default React.memo(
             videos.concat(articles, podcasts)
         );
 
-        const [activePodcast, setActivePodcast] = useState(false);
-
-        const openAudio = useCallback(podcast => {
-            setActivePodcast(podcast);
-        }, []);
-        const closeAudio = useCallback(e => {
-            e.stopPropagation();
-            setActivePodcast(null);
-        }, []);
-
+        const { activeAudioNode, setActiveAudioNode } = useContext(
+            AudioContext
+        );
+        console.log(activeAudioNode, setActiveAudioNode);
         return (
             <>
                 <Paginate limit={limit} data-test="card-list">
                     {fullContentList.map(contentType =>
-                        renderContentTypeCard(contentType, openAudio)
+                        renderContentTypeCard(contentType, setActiveAudioNode)
                     )}
                 </Paginate>
-                {podcasts.length ? (
-                    <Audio onClose={closeAudio} podcast={activePodcast} />
-                ) : null}
             </>
         );
     }

--- a/src/components/dev-hub/global-nav.js
+++ b/src/components/dev-hub/global-nav.js
@@ -10,6 +10,7 @@ import useMedia from '~hooks/use-media';
 import NavItem, { MobileNavItem } from './nav-item';
 import MenuToggle from './menu-toggle';
 import Searchbar from './searchbar';
+import { makeLinkInternalIfApplicable } from '~src/utils/make-link-internal-if-applicable';
 
 const GREEN_BORDER_SIZE = '2px';
 // Account for bottom bar on mobile browsers
@@ -156,6 +157,17 @@ const GlobalNav = () => {
     const [isSearchbarExpanded, setIsSearchbarExpanded] = useState(false);
     const data = useStaticQuery(topNavItems);
     const items = dlv(data, ['strapiTopNav', 'items'], []);
+    items.forEach(i => {
+        const hasSubMenu = !!i.subitems.length;
+        if (hasSubMenu) {
+            i.subitems = i.subitems.map(item => ({
+                ...item,
+                url: makeLinkInternalIfApplicable(item.url),
+            }));
+        } else {
+            i.url = makeLinkInternalIfApplicable(i.url);
+        }
+    });
     const isMobile = useMedia(MOBILE_NAV_BREAK);
     const onSearchbarExpand = useCallback(isExpanded => {
         // On certain screens the searchbar is never collapsed

--- a/src/utils/make-link-internal-if-applicable.js
+++ b/src/utils/make-link-internal-if-applicable.js
@@ -1,5 +1,5 @@
 import { withPrefix } from 'gatsby';
-import { addTrailingSlashIfMissing } from './add-trailing-slash-if-missing';
+import { addTrailingSlashBeforeParams } from './add-trailing-slash-if-missing';
 import { SITE_URL, FORUMS_URL } from '~src/constants';
 import { isLinkForImage } from '~utils/is-link-for-image';
 
@@ -15,7 +15,7 @@ export const makeLinkInternalIfApplicable = (link, includePrefix = false) => {
         // that one alone
         return isLinkForImage(link)
             ? withPrefix(linkWithoutSiteUrl)
-            : addTrailingSlashIfMissing(
+            : addTrailingSlashBeforeParams(
                   includePrefix
                       ? withPrefix(linkWithoutSiteUrl)
                       : linkWithoutSiteUrl


### PR DESCRIPTION
[Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-568/)

This PR POCs using a Gatsby plugin to keep the Podcasts playing while navigating the site. The reason this is still a POC is:
- Using nav internal links gives an odd effect where the dropdowns don't close
- We now use the `ThemeProvider` twice for the layout.
- We don't know the impact of using the layout component everywhere

Once functionality is verified we can break this into two parts:
- Making nav links internal if applicable
- Making the Audio layout