### PR TITLE
DEVHUB-107: Update literal style

### DIFF
--- a/src/components/Literal.js
+++ b/src/components/Literal.js
@@ -1,18 +1,35 @@
 import React from 'react';
+import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
+import { screenSize, size } from './dev-hub/theme';
 
-const breakWordOverflow = css`
+const desktopPadding = css`
+    padding: 2px ${size.xsmall} 4px;
+`;
+
+const tabletPadding = css`
+    padding: 0px 4px 2px;
+`;
+
+const StyledLiteral = styled('code')`
+    background: ${({ theme }) => theme.colorMap.greyDarkThree};
+    border-radius: 4px;
+    color: ${({ theme }) => theme.colorMap.greyLightTwo};
     overflow-wrap: break-word;
+    ${tabletPadding};
+    @media ${screenSize.mediumAndUp} {
+        ${desktopPadding};
+    }
 `;
 
 const Literal = ({ nodeData: { children } }) => (
-    <code css={breakWordOverflow}>
+    <StyledLiteral>
         {children.map((node, i) => (
             <ComponentFactory nodeData={node} key={i} />
         ))}
-    </code>
+    </StyledLiteral>
 );
 
 Literal.propTypes = {

--- a/tests/unit/DefinitionList.test.js
+++ b/tests/unit/DefinitionList.test.js
@@ -1,9 +1,15 @@
 import React from 'react';
+import { ThemeProvider } from 'emotion-theming';
 import { render } from 'enzyme';
 import DefinitionList from '../../src/components/DefinitionList';
+import { darkTheme } from '../../src/components/dev-hub/theme';
 import mockData from './data/DefinitionList.test.json';
 
 it('DefinitionList renders correctly', () => {
-    const tree = render(<DefinitionList nodeData={mockData} />);
+    const tree = render(
+        <ThemeProvider theme={darkTheme}>
+            <DefinitionList nodeData={mockData} />
+        </ThemeProvider>
+    );
     expect(tree).toMatchSnapshot();
 });

--- a/tests/unit/Literal.test.js
+++ b/tests/unit/Literal.test.js
@@ -1,11 +1,17 @@
 import React from 'react';
+import { ThemeProvider } from 'emotion-theming';
 import { shallow } from 'enzyme';
 import Literal from '../../src/components/Literal';
+import { darkTheme } from '../../src/components/dev-hub/theme';
 
 // data for this component
 import mockData from './data/Literal.test.json';
 
 it('renders correctly', () => {
-    const tree = shallow(<Literal nodeData={mockData} />);
+    const tree = shallow(
+        <ThemeProvider theme={darkTheme}>
+            <Literal nodeData={mockData} />
+        </ThemeProvider>
+    );
     expect(tree).toMatchSnapshot();
 });

--- a/tests/unit/__snapshots__/DefinitionList.test.js.snap
+++ b/tests/unit/__snapshots__/DefinitionList.test.js.snap
@@ -6,7 +6,7 @@ exports[`DefinitionList renders correctly 1`] = `
 >
   <dt>
     <code
-      css="You have tried to stringify object returned from \`css\` function. It isn't supposed to be used directly (e.g. as value of the \`className\` prop), but rather handed to emotion so it can handle it (e.g. as value of \`css\` prop)."
+      class="css-13dyfgt-StyledLiteral-tabletPadding-desktopPadding es3mzt60"
     >
       MongoDefaultPartitioner
     </code>

--- a/tests/unit/__snapshots__/Literal.test.js.snap
+++ b/tests/unit/__snapshots__/Literal.test.js.snap
@@ -1,29 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<code
-  css={
-    Object {
-      "map": "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIkxpdGVyYWwuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBSzZCIiwiZmlsZSI6IkxpdGVyYWwuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgUmVhY3QgZnJvbSAncmVhY3QnO1xuaW1wb3J0IHsgY3NzIH0gZnJvbSAnQGVtb3Rpb24vY29yZSc7XG5pbXBvcnQgUHJvcFR5cGVzIGZyb20gJ3Byb3AtdHlwZXMnO1xuaW1wb3J0IENvbXBvbmVudEZhY3RvcnkgZnJvbSAnLi9Db21wb25lbnRGYWN0b3J5JztcblxuY29uc3QgYnJlYWtXb3JkT3ZlcmZsb3cgPSBjc3NgXG4gICAgb3ZlcmZsb3ctd3JhcDogYnJlYWstd29yZDtcbmA7XG5cbmNvbnN0IExpdGVyYWwgPSAoeyBub2RlRGF0YTogeyBjaGlsZHJlbiB9IH0pID0+IChcbiAgICA8Y29kZSBjc3M9e2JyZWFrV29yZE92ZXJmbG93fT5cbiAgICAgICAge2NoaWxkcmVuLm1hcCgobm9kZSwgaSkgPT4gKFxuICAgICAgICAgICAgPENvbXBvbmVudEZhY3Rvcnkgbm9kZURhdGE9e25vZGV9IGtleT17aX0gLz5cbiAgICAgICAgKSl9XG4gICAgPC9jb2RlPlxuKTtcblxuTGl0ZXJhbC5wcm9wVHlwZXMgPSB7XG4gICAgbm9kZURhdGE6IFByb3BUeXBlcy5zaGFwZSh7XG4gICAgICAgIGNoaWxkcmVuOiBQcm9wVHlwZXMuYXJyYXlPZihQcm9wVHlwZXMub2JqZWN0KS5pc1JlcXVpcmVkLFxuICAgIH0pLmlzUmVxdWlyZWQsXG59O1xuXG5leHBvcnQgZGVmYXVsdCBMaXRlcmFsO1xuIl19 */",
-      "name": "12btru0-breakWordOverflow",
-      "styles": "overflow-wrap:break-word;;label:breakWordOverflow;",
-      "toString": [Function],
-    }
-  }
->
-  <ComponentFactory
-    key="0"
-    nodeData={
-      Object {
-        "position": Object {
-          "start": Object {
-            "line": 3,
-          },
-        },
-        "type": "text",
-        "value": "N. Virginia (us-east-1)",
-      }
-    }
-  />
-</code>
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
 `;


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DEVHUB-107)
[Staging Article](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-107/quickstart/golang-multi-document-acid-transactions/)

This PR changes the style for a `Literal` based on the discussions in the linked JIRA ticket. We also update related test snapshots and use the `ThemeProvider` where needed.

![Screen Shot 2021-03-30 at 11 51 54 AM](https://user-images.githubusercontent.com/9064401/113021449-98fc9280-9151-11eb-8944-b4de4bb39c1c.png)
![Screen Shot 2021-03-30 at 11 52 02 AM](https://user-images.githubusercontent.com/9064401/113021450-99952900-9151-11eb-9072-098f0cc1bfab.png)
