### PR TITLE
DEVHUB-592: Create a Generalized Form

### DIFF
--- a/src/components/dev-hub/cms-form.js
+++ b/src/components/dev-hub/cms-form.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import Checkbox from '@leafygreen-ui/checkbox';
+import Input from './input';
+import TextArea from './text-area';
+
+const FORM_ELEMENT_TYPES = {
+    CHECKBOXES: 'Checkboxes',
+    EMAILINPUT: 'EmailInput',
+    TEXTAREA: 'Textarea',
+};
+
+const mapTypeToFormElement = (type, labels) => {
+    switch (type) {
+        case FORM_ELEMENT_TYPES.CHECKBOXES:
+            return labels.map(({ label }) => (
+                <Checkbox key={label} bold darkMode={true} label={label} />
+            ));
+        case FORM_ELEMENT_TYPES.EMAILINPUT:
+            return (
+                <Input
+                    key={labels[0].label}
+                    bold
+                    darkMode={true}
+                    label={labels[0].label}
+                    type="email"
+                />
+            );
+        case FORM_ELEMENT_TYPES.TEXTAREA:
+            return (
+                <TextArea
+                    key={labels[0].label}
+                    bold
+                    darkMode={true}
+                    label={labels[0].label}
+                />
+            );
+        default:
+            break;
+    }
+};
+
+const CMSForm = ({ form }) => (
+    <>
+        {form.FormElement.map(({ type, labels }) =>
+            mapTypeToFormElement(type, labels)
+        )}
+    </>
+);
+
+export default CMSForm;

--- a/src/components/dev-hub/cms-form.js
+++ b/src/components/dev-hub/cms-form.js
@@ -26,7 +26,7 @@ const mapTypeToFormElement = (type, labels, state, dispatch, name) => {
                     onChange={e =>
                         dispatch({
                             field: `${name}-${index}`,
-                            value: e.target.value,
+                            value: e.target.checked,
                         })
                     }
                     darkMode={true}

--- a/src/components/dev-hub/cms-form.js
+++ b/src/components/dev-hub/cms-form.js
@@ -16,7 +16,11 @@ const handleCMSFormChange = (state, { field, value }) => ({
     [field]: value,
 });
 
-const mapTypeToFormElement = (type, labels, state, dispatch, name) => {
+const mapTypeToFormElement = (
+    { labels, name, placeholder, type },
+    state,
+    dispatch
+) => {
     switch (type) {
         case FORM_ELEMENT_TYPES.CHECKBOXES:
             return labels.map(({ label }, index) => (
@@ -40,7 +44,7 @@ const mapTypeToFormElement = (type, labels, state, dispatch, name) => {
                     bold
                     darkMode={true}
                     label={labels[0].label}
-                    placeholder={labels[1].label}
+                    placeholder={placeholder}
                     type="email"
                     value={state[name]}
                     onChange={e =>
@@ -58,7 +62,7 @@ const mapTypeToFormElement = (type, labels, state, dispatch, name) => {
                     bold
                     darkMode={true}
                     label={labels[0].label}
-                    placeholder={labels[1].label}
+                    placeholder={placeholder}
                     value={state[name]}
                     onChange={e =>
                         dispatch({
@@ -80,8 +84,8 @@ const CMSForm = ({ form }) => {
     );
     return (
         <>
-            {form.FormElement.map(({ type, labels, name }) =>
-                mapTypeToFormElement(type, labels, state, dispatch, name)
+            {form.FormElement.map(formElement =>
+                mapTypeToFormElement(formElement, state, dispatch)
             )}
         </>
     );

--- a/src/components/dev-hub/cms-form.js
+++ b/src/components/dev-hub/cms-form.js
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useReducer } from 'react';
 import Checkbox from '@leafygreen-ui/checkbox';
 import Input from './input';
 import TextArea from './text-area';
+
+const getInitialFormState = () => ({});
 
 const FORM_ELEMENT_TYPES = {
     CHECKBOXES: 'Checkboxes',
@@ -9,11 +11,27 @@ const FORM_ELEMENT_TYPES = {
     TEXTAREA: 'Textarea',
 };
 
-const mapTypeToFormElement = (type, labels) => {
+const handleCMSFormChange = (state, { field, value }) => ({
+    ...state,
+    [field]: value,
+});
+
+const mapTypeToFormElement = (type, labels, state, dispatch, name) => {
     switch (type) {
         case FORM_ELEMENT_TYPES.CHECKBOXES:
-            return labels.map(({ label }) => (
-                <Checkbox key={label} bold darkMode={true} label={label} />
+            return labels.map(({ label }, index) => (
+                <Checkbox
+                    key={`${name}-${index}`}
+                    bold
+                    onChange={e =>
+                        dispatch({
+                            field: `${name}-${index}`,
+                            value: e.target.value,
+                        })
+                    }
+                    darkMode={true}
+                    label={label}
+                />
             ));
         case FORM_ELEMENT_TYPES.EMAILINPUT:
             return (
@@ -22,7 +40,15 @@ const mapTypeToFormElement = (type, labels) => {
                     bold
                     darkMode={true}
                     label={labels[0].label}
+                    placeholder={labels[1].label}
                     type="email"
+                    value={state[name]}
+                    onChange={e =>
+                        dispatch({
+                            field: name,
+                            value: e.target.value,
+                        })
+                    }
                 />
             );
         case FORM_ELEMENT_TYPES.TEXTAREA:
@@ -32,6 +58,14 @@ const mapTypeToFormElement = (type, labels) => {
                     bold
                     darkMode={true}
                     label={labels[0].label}
+                    placeholder={labels[1].label}
+                    value={state[name]}
+                    onChange={e =>
+                        dispatch({
+                            field: name,
+                            value: e.target.value,
+                        })
+                    }
                 />
             );
         default:
@@ -39,12 +73,18 @@ const mapTypeToFormElement = (type, labels) => {
     }
 };
 
-const CMSForm = ({ form }) => (
-    <>
-        {form.FormElement.map(({ type, labels }) =>
-            mapTypeToFormElement(type, labels)
-        )}
-    </>
-);
+const CMSForm = ({ form }) => {
+    const [state, dispatch] = useReducer(
+        handleCMSFormChange,
+        getInitialFormState()
+    );
+    return (
+        <>
+            {form.FormElement.map(({ type, labels, name }) =>
+                mapTypeToFormElement(type, labels, state, dispatch, name)
+            )}
+        </>
+    );
+};
 
 export default CMSForm;

--- a/src/components/dev-hub/feedback/feedback-container.js
+++ b/src/components/dev-hub/feedback/feedback-container.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import dlv from 'dlv';
 import { graphql, useStaticQuery } from 'gatsby';
 import CMSForm from '~components/dev-hub/cms-form';
 
@@ -12,17 +13,18 @@ const feedbackItems = graphql`
 
 const FeedbackContainer = () => {
     const data = useStaticQuery(feedbackItems);
-    // Uncomment below to see shape of data
-    console.log(data);
+    const {
+        OneStarRatingFlow,
+        TwoStarRatingFlow,
+        ThreeStarRatingFlow,
+        FourStarRatingFlow,
+        FiveStarRatingFlow,
+    } = dlv(data, 'strapiFeedbackRatingFlow', {});
+    // Uncomment below to see shape of data, other forms
+    // console.log(data);
     // TODO: Implement feedback UI
     return (
-        <CMSForm
-            form={
-                data
-                    ? data.strapiFeedbackRatingFlow.OneStarRatingFlow.forms[0]
-                    : []
-            }
-        />
+        <CMSForm form={OneStarRatingFlow ? OneStarRatingFlow.forms[1] : []} />
     );
 };
 

--- a/src/components/dev-hub/feedback/feedback-container.js
+++ b/src/components/dev-hub/feedback/feedback-container.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { graphql, useStaticQuery } from 'gatsby';
+import CMSForm from '~components/dev-hub/cms-form';
 
 const feedbackItems = graphql`
     query FeedbackItems {
@@ -12,9 +13,17 @@ const feedbackItems = graphql`
 const FeedbackContainer = () => {
     const data = useStaticQuery(feedbackItems);
     // Uncomment below to see shape of data
-    // console.log(data);
+    console.log(data);
     // TODO: Implement feedback UI
-    return <div />;
+    return (
+        <CMSForm
+            form={
+                data
+                    ? data.strapiFeedbackRatingFlow.OneStarRatingFlow.forms[0]
+                    : []
+            }
+        />
+    );
 };
 
 export default FeedbackContainer;

--- a/src/queries/fragments/feedback.js
+++ b/src/queries/fragments/feedback.js
@@ -5,12 +5,13 @@ export const feedbackFlows = graphql`
         OneStarRatingFlow {
             forms {
                 FormElement {
-                    type
                     labels {
                         label
                     }
                     name
+                    placeholder
                     required
+                    type
                 }
                 cta
                 description
@@ -23,9 +24,10 @@ export const feedbackFlows = graphql`
                     labels {
                         label
                     }
-                    type
                     name
+                    placeholder
                     required
+                    type
                 }
                 cta
                 description
@@ -38,9 +40,10 @@ export const feedbackFlows = graphql`
                     labels {
                         label
                     }
-                    type
                     name
+                    placeholder
                     required
+                    type
                 }
                 cta
                 description
@@ -53,9 +56,10 @@ export const feedbackFlows = graphql`
                     labels {
                         label
                     }
-                    type
                     name
+                    placeholder
                     required
+                    type
                 }
                 cta
                 description
@@ -68,9 +72,10 @@ export const feedbackFlows = graphql`
                     labels {
                         label
                     }
-                    type
                     name
+                    placeholder
                     required
+                    type
                 }
                 cta
                 description

--- a/src/queries/fragments/feedback.js
+++ b/src/queries/fragments/feedback.js
@@ -9,6 +9,8 @@ export const feedbackFlows = graphql`
                     labels {
                         label
                     }
+                    name
+                    required
                 }
                 cta
                 description
@@ -22,6 +24,8 @@ export const feedbackFlows = graphql`
                         label
                     }
                     type
+                    name
+                    required
                 }
                 cta
                 description
@@ -35,6 +39,8 @@ export const feedbackFlows = graphql`
                         label
                     }
                     type
+                    name
+                    required
                 }
                 cta
                 description
@@ -48,6 +54,8 @@ export const feedbackFlows = graphql`
                         label
                     }
                     type
+                    name
+                    required
                 }
                 cta
                 description
@@ -61,6 +69,8 @@ export const feedbackFlows = graphql`
                         label
                     }
                     type
+                    name
+                    required
                 }
                 cta
                 description

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -196,8 +196,8 @@ const Article = props => {
                 title={articleTitle}
                 updatedDate={formattedUpdatedDate}
             />
-            <FeedbackContainer />
             <Container>
+                <FeedbackContainer />
                 <Icons>
                     <ContentsMenu
                         title="Contents"


### PR DESCRIPTION
This PR begins to add logic to support "Generalized Forms", which are forms that can be re-used with incoming data about the layout of a form.

There is still more work to be done, but this begins to allow us to render forms more easily.

We should be sure of the following:
- Form state works appropriately
- Form labels/placeholders work appropriately

We will add some tests for this when the full project is coming together, but for now we can continue to clean this up so we can keep moving on the project.