### PR TITLE
DEBHUB-610: Implement Rating to Article page

### DIFF
--- a/src/components/ArticleRating.js
+++ b/src/components/ArticleRating.js
@@ -1,17 +1,38 @@
 import React from 'react';
-import styled from '@emotion/styled';
-import { colorMap, size, screenSize } from '~components/dev-hub/theme';
-import StarRating from '~components/dev-hub/star-rating';
 import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+import {
+    default as StarRating,
+    StyledContainer,
+    StyledStarsContainer,
+} from '~components/dev-hub/star-rating';
 
-const StyledContainerTop = styled.div``;
+import { colorMap, size, screenSize } from '~components/dev-hub/theme';
+
+export const StyledContainerTop = styled.div`
+    span {
+        padding: 0;
+    }
+    ${StyledContainer} {
+      align-items: flex-end;
+    }
+    ${StyledStarsContainer} a:last-child {
+      margin-right: 0;
+    }
+ 
+    @media ${screenSize.mediumAndUp} {
+      ${StyledContainer} {
+        align-items: center;
+      }
+    }
+`;
 
 const StyledContainerBottom = styled.div`
     background-color: ${colorMap.devBlack};
     border-radius: ${size.xsmall};
     border: 1px solid ${colorMap.greyDarkThree};
     padding: ${size.mediumLarge};
-  
+
     @media ${screenSize.mediumAndUp} {
         padding-left: ${size.large};
         padding: 15px;

--- a/src/components/dev-hub/article-share-footer.js
+++ b/src/components/dev-hub/article-share-footer.js
@@ -16,11 +16,8 @@ const ArticleShareArea = styled('div')`
     display: flex;
     justify-content: space-between;
     margin-bottom: ${size.large};
-    margin-top: ${size.xlarge};
+    margin-top: ${size.large};
     padding-top: ${size.medium};
-    @media ${screenSize.upToMedium} {
-        margin-top: ${size.large};
-    }
 `;
 
 const BlogShareLinks = styled('div')`

--- a/src/components/dev-hub/star-rating.js
+++ b/src/components/dev-hub/star-rating.js
@@ -29,7 +29,7 @@ const StyledButton = styled(Button)`
     }
 `;
 
-const StyledContainer = styled('div')`
+export const StyledContainer = styled('div')`
     display: flex;
     flex-direction: column;
 
@@ -53,7 +53,7 @@ const StyledTitle = styled('span')`
     }
 `;
 
-const StyledStarsContainer = styled('div')`
+export const StyledStarsContainer = styled('div')`
     align-items: center;
     display: flex;
 

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -23,7 +23,10 @@ import { getNestedValue } from '../utils/get-nested-value';
 import { findSectionHeadings } from '../utils/find-section-headings';
 import { getNestedText } from '../utils/get-nested-text';
 import ArticleSchema from '../components/dev-hub/article-schema';
-import ArticleRating from '~components/ArticleRating';
+import {
+    default as ArticleRating,
+    StyledContainerTop,
+} from '~components/ArticleRating';
 
 /**
  * Name map of directives we want to display in an article
@@ -78,29 +81,58 @@ const ArticleContent = styled('article')`
     max-width: ${size.maxContentWidth};
     padding-left: ${size.small};
     padding-right: ${size.small};
+
+    ${StyledContainerTop} {
+        display: flex;
+        justify-content: flex-end;
+        margin-bottom: 48px;
+    }
+
     @media ${screenSize.upToLarge} {
         margin: 0 auto;
+
+        ${StyledContainerTop} {
+            display: none;
+        }
     }
 `;
 const Icons = styled('div')`
+    display: flex;
     margin: ${size.tiny} ${size.default};
     span {
         padding: 0 ${size.tiny};
     }
+
     @media ${screenSize.largeAndUp} {
-        display: flex;
         flex-direction: column;
+        margin-top: 80px;
+
         span:not(:first-of-type) {
             margin-top: ${size.small};
         }
+
+        ${StyledContainerTop} {
+            display: none;
+        }
     }
     @media ${screenSize.upToLarge} {
-        margin: 0 ${size.small};
+        justify-content: space-between;
+        margin: ${size.mediumLarge} ${size.small} ${size.large} ${size.small};
+
         span:not(:first-of-type) {
             margin-left: ${size.small};
         }
     }
 `;
+
+const MenuContainer = styled('div')`
+    display: flex;
+
+    @media ${screenSize.largeAndUp} {
+        flex-direction: column;
+    }
+`;
+
 const Container = styled('div')`
     margin: 0 auto;
     @media ${screenSize.largeAndUp} {
@@ -200,20 +232,24 @@ const Article = props => {
             <FeedbackContainer />
             <Container>
                 <Icons>
-                    <ContentsMenu
-                        title="Contents"
-                        headingNodes={headingNodes}
-                        height={size.default}
-                        width={size.default}
-                    />
-                    <ShareMenu
-                        title={articleTitle}
-                        url={articleUrl}
-                        height={size.default}
-                        width={size.default}
-                    />
+                    <MenuContainer>
+                        <ContentsMenu
+                            title="Contents"
+                            headingNodes={headingNodes}
+                            height={size.default}
+                            width={size.default}
+                        />
+                        <ShareMenu
+                            title={articleTitle}
+                            url={articleUrl}
+                            height={size.default}
+                            width={size.default}
+                        />
+                    </MenuContainer>
+                    <ArticleRating isTop />
                 </Icons>
                 <ArticleContent>
+                    <ArticleRating isTop />
                     <DocumentBody
                         pageNodes={contentNodes}
                         slugTitleMapping={slugTitleMapping}

--- a/tests/unit/ArticleRating.test.js
+++ b/tests/unit/ArticleRating.test.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import ArticleRating from '~components/ArticleRating';
+
+describe('ArticleRating', () => {
+    it('renders bottom variant correctly', () => {
+        expect(shallow(<ArticleRating isBottom />)).toMatchSnapshot();
+    });
+
+    it('renders top variant correctly', () => {
+        expect(shallow(<ArticleRating isTop />)).toMatchSnapshot();
+    });
+});

--- a/tests/unit/__snapshots__/ArticleRating.test.js.snap
+++ b/tests/unit/__snapshots__/ArticleRating.test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ArticleRating renders bottom variant correctly 1`] = `
+<StyledContainerBottom>
+  <Memo(StarRating)
+    clickHandlers={
+      Array [
+        [Function],
+        [Function],
+        [Function],
+        [Function],
+        [Function],
+      ]
+    }
+  />
+</StyledContainerBottom>
+`;
+
+exports[`ArticleRating renders top variant correctly 1`] = `
+<StyledContainerTop>
+  <Memo(StarRating)
+    clickHandlers={
+      Array [
+        [Function],
+        [Function],
+        [Function],
+        [Function],
+        [Function],
+      ]
+    }
+  />
+</StyledContainerTop>
+`;


### PR DESCRIPTION
https://jira.mongodb.org/browse/DEVHUB-610

This PR implements component to article page. CSS was changed and now we have 2 variants - bottom rating (< 767px and > 767px) and top rating (< 767px and < 1023px and > 1023px). Check screenshots belowe.

<img width="563" alt="Screenshot 2021-04-09 at 17 41 06" src="https://user-images.githubusercontent.com/79590294/114199045-9faeb500-995c-11eb-90c8-247aff043b0f.png">
<img width="563" alt="Screenshot 2021-04-09 at 17 41 27" src="https://user-images.githubusercontent.com/79590294/114199052-a2110f00-995c-11eb-9deb-e3d8cbb21140.png">
<img width="900" alt="Screenshot 2021-04-09 at 17 41 44" src="https://user-images.githubusercontent.com/79590294/114199056-a3423c00-995c-11eb-88dd-6f7fd24e3df9.png">
<img width="900" alt="Screenshot 2021-04-09 at 17 41 50" src="https://user-images.githubusercontent.com/79590294/114199058-a3423c00-995c-11eb-9487-ead07a742100.png">
<img width="900" alt="Screenshot 2021-04-09 at 17 42 08" src="https://user-images.githubusercontent.com/79590294/114199059-a3dad280-995c-11eb-9fbe-7ca466ba43a8.png">

