### PR TITLE
WIP: Add TTR to Article Headers

### DIFF
--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -143,7 +143,7 @@ export const createPages = async ({ actions, graphql }) => {
 
     result.data.allArticle.nodes.forEach(article => {
         createArticlePage(
-            article.slug,
+            article,
             slugContentMapping,
             allSeries,
             metadataDocument,

--- a/src/components/dev-hub/blog-post-title-area.js
+++ b/src/components/dev-hub/blog-post-title-area.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import Clock from '~components/dev-hub/icons/clock';
 import BlogTagList from './blog-tag-list';
 import { H2, P } from './text';
 import { screenSize, fontSize, size } from './theme';
@@ -53,6 +54,13 @@ const TextContainer = styled('div')`
     }
 `;
 
+const StyledClock = styled(Clock)`
+    line-height: 20px;
+    margin-right: 4px;
+    margin-top: -3px;
+    vertical-align: middle;
+`;
+
 const BlogPostTitleArea = ({
     articleImage,
     authors,
@@ -88,26 +96,7 @@ const BlogPostTitleArea = ({
                     {timeToRead && (
                         <TimeToReadContainer>
                             <DateText collapse>
-                                <svg
-                                    width="12"
-                                    height="12"
-                                    viewBox="0 0 12 12"
-                                    fill="none"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    style={{
-                                        lineHeight: '20px',
-                                        marginRight: '4px',
-                                        marginTop: '-3px',
-                                        verticalAlign: 'middle',
-                                    }}
-                                >
-                                    <path
-                                        fill-rule="evenodd"
-                                        clip-rule="evenodd"
-                                        d="M0 6C0 2.68634 2.68634 0 6 0C9.31366 0 12 2.68634 12 6C12 9.31366 9.31366 12 6 12C2.68634 12 0 9.31366 0 6ZM6 3C6 2.44772 5.55228 2 5 2C4.44772 2 4 2.44772 4 3V6.375C4 6.80939 4.28044 7.1941 4.69399 7.32703L8.19399 8.45203C8.71978 8.62103 9.28302 8.3318 9.45203 7.80601C9.62103 7.28022 9.3318 6.71698 8.80601 6.54797L6 5.64604V3Z"
-                                        fill="#B8C4C2"
-                                    />
-                                </svg>
+                                <StyledClock />
                                 {timeToRead} min read
                             </DateText>
                         </TimeToReadContainer>

--- a/src/components/dev-hub/blog-post-title-area.js
+++ b/src/components/dev-hub/blog-post-title-area.js
@@ -36,6 +36,7 @@ const BlogPostTitleArea = ({
     breadcrumb,
     originalDate,
     tags,
+    timeToRead,
     title,
     updatedDate,
 }) => {
@@ -55,6 +56,7 @@ const BlogPostTitleArea = ({
                     {originalDate && (
                         <DateText collapse>Published: {originalDate}</DateText>
                     )}
+                    {timeToRead && timeToRead}
                 </DateTextContainer>
                 <BlogTagList tags={tags} />
             </PostMetaLine>

--- a/src/components/dev-hub/blog-post-title-area.js
+++ b/src/components/dev-hub/blog-post-title-area.js
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import Clock from '~components/dev-hub/icons/clock';
 import BlogTagList from './blog-tag-list';
 import { H2, P } from './text';
-import { screenSize, fontSize, size } from './theme';
+import { fontSize, lineHeight, screenSize, size } from './theme';
 import BylineBlock from './byline-block';
 import HeroBanner from './hero-banner';
 
@@ -15,8 +15,8 @@ const stackedView = css`
 const PostMetaLine = styled('div')`
     color: ${({ theme }) => theme.colorMap.greyLightThree};
     display: flex;
-    margin: ${size.medium} 0 40px;
     font-size: ${fontSize.tiny};
+    margin: ${size.medium} 0 40px;
     ${({ hasTimeToRead }) => hasTimeToRead && stackedView};
     @media ${screenSize.upToLarge} {
         font-size: ${fontSize.xsmall};
@@ -27,7 +27,7 @@ const PostMetaLine = styled('div')`
 
 const TimeToReadContainer = styled('span')`
     @media ${screenSize.largeAndUp} {
-        margin-left: 24px;
+        margin-left: ${size.medium};
     }
 `;
 
@@ -36,15 +36,15 @@ const DateText = styled(P)`
     margin-right: ${size.tiny};
     @media ${screenSize.upToLarge} {
         font-size: ${fontSize.xsmall};
-        line-height: 20px;
+        line-height: ${lineHeight.tiny};
     }
 `;
 
 const TextContainer = styled('div')`
     display: inline-block;
     flex: 0 0 auto;
-    margin-right: ${size.medium};
     line-height: 20px;
+    margin-right: ${size.medium};
     ${({ hasTimeToRead }) => hasTimeToRead && `margin-bottom: ${size.medium}`};
     @media ${screenSize.upToLarge} {
         display: flex;
@@ -55,7 +55,7 @@ const TextContainer = styled('div')`
 `;
 
 const StyledClock = styled(Clock)`
-    line-height: 20px;
+    line-height: ${lineHeight.tiny};
     margin-right: 4px;
     margin-top: -3px;
     vertical-align: middle;

--- a/src/components/dev-hub/blog-post-title-area.js
+++ b/src/components/dev-hub/blog-post-title-area.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import BlogTagList from './blog-tag-list';
 import { H2, P } from './text';
@@ -6,28 +7,50 @@ import { screenSize, fontSize, size } from './theme';
 import BylineBlock from './byline-block';
 import HeroBanner from './hero-banner';
 
+const stackedView = css`
+    flex-direction: column;
+`;
+
 const PostMetaLine = styled('div')`
     color: ${({ theme }) => theme.colorMap.greyLightThree};
     display: flex;
     margin: ${size.medium} 0 40px;
     font-size: ${fontSize.tiny};
+    ${({ hasTimeToRead }) => hasTimeToRead && stackedView};
     @media ${screenSize.upToLarge} {
-        flex-direction: column;
         font-size: ${fontSize.xsmall};
         margin-bottom: ${size.medium};
+        ${stackedView};
+    }
+`;
+
+const TimeToReadContainer = styled('span')`
+    @media ${screenSize.largeAndUp} {
+        margin-left: 24px;
     }
 `;
 
 const DateText = styled(P)`
+    display: inline-block;
     margin-right: ${size.tiny};
     @media ${screenSize.upToLarge} {
         font-size: ${fontSize.xsmall};
+        line-height: 20px;
     }
 `;
 
-const DateTextContainer = styled('div')`
+const TextContainer = styled('div')`
+    display: inline-block;
+    flex: 0 0 auto;
     margin-right: ${size.medium};
-    display: flex;
+    line-height: 20px;
+    ${({ hasTimeToRead }) => hasTimeToRead && `margin-bottom: ${size.medium}`};
+    @media ${screenSize.upToLarge} {
+        display: flex;
+        font-size: ${fontSize.xsmall};
+        margin-right: 0;
+        ${stackedView};
+    }
 `;
 
 const BlogPostTitleArea = ({
@@ -48,16 +71,48 @@ const BlogPostTitleArea = ({
             data-test="hero-banner"
         >
             <BlogTitle collapse>{title}</BlogTitle>
-            <PostMetaLine>
-                <DateTextContainer>
-                    {updatedDate && (
-                        <DateText collapse>Updated: {updatedDate} | </DateText>
+            <PostMetaLine hasTimeToRead={!!timeToRead}>
+                <TextContainer hasTimeToRead={!!timeToRead}>
+                    <span>
+                        {updatedDate && (
+                            <DateText collapse>
+                                Updated: {updatedDate} |{' '}
+                            </DateText>
+                        )}
+                        {originalDate && (
+                            <DateText collapse>
+                                Published: {originalDate}
+                            </DateText>
+                        )}
+                    </span>
+                    {timeToRead && (
+                        <TimeToReadContainer>
+                            <DateText collapse>
+                                <svg
+                                    width="12"
+                                    height="12"
+                                    viewBox="0 0 12 12"
+                                    fill="none"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    style={{
+                                        lineHeight: '20px',
+                                        marginRight: '4px',
+                                        marginTop: '-3px',
+                                        verticalAlign: 'middle',
+                                    }}
+                                >
+                                    <path
+                                        fill-rule="evenodd"
+                                        clip-rule="evenodd"
+                                        d="M0 6C0 2.68634 2.68634 0 6 0C9.31366 0 12 2.68634 12 6C12 9.31366 9.31366 12 6 12C2.68634 12 0 9.31366 0 6ZM6 3C6 2.44772 5.55228 2 5 2C4.44772 2 4 2.44772 4 3V6.375C4 6.80939 4.28044 7.1941 4.69399 7.32703L8.19399 8.45203C8.71978 8.62103 9.28302 8.3318 9.45203 7.80601C9.62103 7.28022 9.3318 6.71698 8.80601 6.54797L6 5.64604V3Z"
+                                        fill="#B8C4C2"
+                                    />
+                                </svg>
+                                {timeToRead} min read
+                            </DateText>
+                        </TimeToReadContainer>
                     )}
-                    {originalDate && (
-                        <DateText collapse>Published: {originalDate}</DateText>
-                    )}
-                    {timeToRead && timeToRead}
-                </DateTextContainer>
+                </TextContainer>
                 <BlogTagList tags={tags} />
             </PostMetaLine>
             <BylineBlock authors={authors} />

--- a/src/components/dev-hub/icons/clock.js
+++ b/src/components/dev-hub/icons/clock.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+const Clock = ({ color, ...props }) => (
+    <svg
+        width="12"
+        height="12"
+        viewBox="0 0 12 12"
+        fill={color || 'none'}
+        xmlns="http://www.w3.org/2000/svg"
+        style={{
+            lineHeight: '20px',
+            marginRight: '4px',
+            marginTop: '-3px',
+            verticalAlign: 'middle',
+        }}
+        {...props}
+    >
+        <path
+            fill-rule="evenodd"
+            clip-rule="evenodd"
+            d="M0 6C0 2.68634 2.68634 0 6 0C9.31366 0 12 2.68634 12 6C12 9.31366 9.31366 12 6 12C2.68634 12 0 9.31366 0 6ZM6 3C6 2.44772 5.55228 2 5 2C4.44772 2 4 2.44772 4 3V6.375C4 6.80939 4.28044 7.1941 4.69399 7.32703L8.19399 8.45203C8.71978 8.62103 9.28302 8.3318 9.45203 7.80601C9.62103 7.28022 9.3318 6.71698 8.80601 6.54797L6 5.64604V3Z"
+            fill="#B8C4C2"
+        />
+    </svg>
+);
+
+export default Clock;

--- a/src/components/dev-hub/icons/clock.js
+++ b/src/components/dev-hub/icons/clock.js
@@ -7,12 +7,6 @@ const Clock = ({ color, ...props }) => (
         viewBox="0 0 12 12"
         fill={color || 'none'}
         xmlns="http://www.w3.org/2000/svg"
-        style={{
-            lineHeight: '20px',
-            marginRight: '4px',
-            marginTop: '-3px',
-            verticalAlign: 'middle',
-        }}
         {...props}
     >
         <path

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -112,6 +112,7 @@ const Article = props => {
             __refDocMapping,
             seriesArticles,
             slug: thisPage,
+            timeToRead,
             metadata: { slugToTitle: slugTitleMapping },
         },
         ...rest
@@ -192,6 +193,7 @@ const Article = props => {
                 breadcrumb={articleBreadcrumbs}
                 originalDate={formattedPublishedDate}
                 tags={tagList}
+                timeToRead={timeToRead}
                 title={articleTitle}
                 updatedDate={formattedUpdatedDate}
             />

--- a/src/utils/setup/create-article-page.js
+++ b/src/utils/setup/create-article-page.js
@@ -7,7 +7,7 @@ import { getTemplate } from '../get-template';
 import { SNOOTY_STITCH_ID } from '../../build-constants';
 
 export const createArticlePage = (
-    page,
+    { slug: page, ...rest },
     slugContentMapping,
     allSeries,
     metadata,
@@ -36,6 +36,7 @@ export const createArticlePage = (
                 slug,
                 snootyStitchId: SNOOTY_STITCH_ID,
                 __refDocMapping: pageNodes,
+                ...rest,
             },
         });
     }

--- a/tests/utils/create-article-page.test.js
+++ b/tests/utils/create-article-page.test.js
@@ -2,6 +2,7 @@ import { createArticlePage } from '../../src/utils/setup/create-article-page';
 
 describe('creating an article page', () => {
     const articleOneSlug = '/article1';
+    const articleOne = { slug: articleOneSlug };
     const slugContentMapping = {
         [articleOneSlug]: { ast: { options: { template: 'devhub-article' } } },
     };
@@ -12,13 +13,7 @@ describe('creating an article page', () => {
     });
 
     it('should create a page at the correct slug', () => {
-        createArticlePage(
-            articleOneSlug,
-            slugContentMapping,
-            {},
-            {},
-            createPage
-        );
+        createArticlePage(articleOne, slugContentMapping, {}, {}, createPage);
         expect(createPage.mock.calls.length).toBe(1);
         expect(createPage.mock.calls[0][0].path).toBe(articleOneSlug);
     });
@@ -29,7 +24,7 @@ describe('creating an article page', () => {
             seriesWithoutArticleOne: [],
         };
         createArticlePage(
-            articleOneSlug,
+            articleOne,
             slugContentMapping,
             series,
             {},
@@ -55,13 +50,7 @@ describe('creating an article page', () => {
                 template: 'devhub-article',
             },
         };
-        createArticlePage(
-            articleOneSlug,
-            slugContentMapping,
-            {},
-            {},
-            createPage
-        );
+        createArticlePage(articleOne, slugContentMapping, {}, {}, createPage);
         expect(createPage.mock.calls[0][0].component).toContain('article.js');
     });
 
@@ -73,13 +62,7 @@ describe('creating an article page', () => {
         slugContentMapping[articleOneSlug].query_fields = {
             related: [{ refuri: articleTwoSlug }],
         };
-        createArticlePage(
-            articleOneSlug,
-            slugContentMapping,
-            {},
-            {},
-            createPage
-        );
+        createArticlePage(articleOne, slugContentMapping, {}, {}, createPage);
         expect(
             createPage.mock.calls[0][0].context.__refDocMapping.query_fields
                 .related.length


### PR DESCRIPTION
No Review Needed

[Staging Link (Sample Article)](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/add-ttr-to-article/quickstart/php-setup/?tck=feathome)

This PR adds TTR to the header for articles. More cleanup is needed here, such as:
- Turning the clock icon into a component for reuse
- Cleaning up CSS/Number of elements for the `BlogPostTitleArea`