### PR TITLE
DEVHUB-594 (prep): Add Endpoints for Form Submission

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -30,7 +30,9 @@ export const ADMONITIONS = [
     'warning',
 ];
 
+// Realm App IDs
 export const STITCH_AUTH_APP_ID = 'devhubauthentication-lidpq';
+export const FEEDBACK_APP_ID = 'feedback-ihion';
 
 export const SITE_URL = 'https://developer.mongodb.com';
 export const FORUMS_URL = `${SITE_URL}/community/forums`;

--- a/src/utils/devhub-api-stitch.js
+++ b/src/utils/devhub-api-stitch.js
@@ -1,13 +1,18 @@
-import { STITCH_AUTH_APP_ID } from '../constants';
+import { FEEDBACK_APP_ID, STITCH_AUTH_APP_ID } from '../constants';
 import { callStitchFunction } from './stitch-common';
 
-const callDevhubAPIStitchFunction = async (fnName, ...fnArgs) => {
+const callRealmFunction = appId => async (fnName, ...fnArgs) => {
     try {
-        return callStitchFunction(fnName, STITCH_AUTH_APP_ID, [...fnArgs]);
+        return callStitchFunction(fnName, appId, [...fnArgs]);
     } catch (error) {
         console.error(error);
     }
 };
+
+const callDevhubAPIStitchFunction = callRealmFunction(STITCH_AUTH_APP_ID);
+const callDevhubFeedbackFunction = callRealmFunction(FEEDBACK_APP_ID);
+
+// DevHub Authentication App Functions
 
 export const requestLybsinPodcasts = async () => {
     const result = await callDevhubAPIStitchFunction('fetchLybsinPodcasts');
@@ -66,5 +71,47 @@ export const submitStudentSpotlightProject = async projectData => {
         'submitStudentSpotlightProject',
         projectData
     );
+    return result;
+};
+
+// DevHub Feedback App Functions
+
+// Call as the feedback modal is opened
+export const createDevhubFeedback = async ({
+    authorNames,
+    rating,
+    title,
+    slug,
+    segment_id,
+}) => {
+    const result = await callDevhubFeedbackFunction('createFeedback', {
+        authorNames,
+        rating,
+        title,
+        slug,
+        segment_id,
+    });
+    // This returns the ID of the user's feedback object, let's store it for later updating
+    return result;
+};
+
+// Call to submit the feedback
+export const submitDevhubFeedback = async feedbackId => {
+    const result = await callDevhubFeedbackFunction(
+        'submitFeedback',
+        feedbackId
+    );
+    return result;
+};
+
+// Call when an entry is changed/selected
+export const updateDevhubFeedback = async ({
+    feedbackId,
+    ...formResponses
+}) => {
+    const result = await callDevhubFeedbackFunction('updateFeedback', {
+        feedbackId,
+        ...formResponses,
+    });
     return result;
 };


### PR DESCRIPTION
This PR adds three functions which can be used in the devhub feedback project for handling actions with the modal. They are as follows:

- `createFeedback` which is to be called when the modal is opened. This creates an object in our DB for handling the user's feedback and returns that id
- `updateFeedback` which is to be called as the user enters more data
- `submitFeedback` which is to be called on completion

These are hosted in our backend-as-a-service on MongoDB Realm. Let me know if it is unclear how we plan to use these, thanks!