### PR TITLE
No Review: Add Associations at Build-Time

### DIFF
--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -11,6 +11,7 @@ import { createProjectPages } from './src/utils/setup/create-project-pages';
 import { createClientSideRedirects } from './src/utils/setup/create-client-side-redirects';
 import { createTagPageType } from './src/utils/setup/create-tag-page-type';
 import { getMetadata } from './src/utils/get-metadata';
+import { STITCH_AUTH_APP_ID } from './src/constants';
 import {
     DOCUMENTS_COLLECTION,
     METADATA_COLLECTION,
@@ -58,6 +59,11 @@ export const sourceNodes = async ({
         DOCUMENTS_COLLECTION,
         query,
     ]);
+    const client = await initStitch(STITCH_AUTH_APP_ID);
+    const recommendedMapping = await client.callFunction(
+        'fetchAssociationData',
+        []
+    );
     if (documents.length === 0) {
         console.error('No documents matched your query.');
     }
@@ -73,7 +79,8 @@ export const sourceNodes = async ({
             createNode,
             createContentDigest,
             slugContentMapping,
-            rawContent
+            rawContent,
+            recommendedMapping
         );
     });
 };

--- a/src/queries/articles.js
+++ b/src/queries/articles.js
@@ -2,6 +2,7 @@ const articles = `
     query Pages {
         allArticle {
             nodes {
+                associations
                 slug: id
                 timeToRead
             }

--- a/src/utils/setup/create-article-node.js
+++ b/src/utils/setup/create-article-node.js
@@ -9,7 +9,8 @@ export const createArticleNode = (
     createNode,
     createContentDigest,
     slugContentMapping,
-    rawContent
+    rawContent,
+    recommendedMapping
 ) => {
     const filename = getNestedValue(['filename'], doc) || '';
     const isArticlePage =
@@ -23,7 +24,10 @@ export const createArticleNode = (
         const filenameWithoutExtension = paths[paths.length - 1];
         updateAttributionLinks(doc, filenameWithoutExtension);
         const timeToRead = getTimeToRead(rawContent);
+        let associations = recommendedMapping.find(x => x._id === `/${slug}/`);
+        associations = associations ? associations.related : [];
         const content = {
+            associations,
             atfimage: doc.query_fields['atf-image'],
             authors: doc.query_fields['author'],
             description: getNestedText(doc.query_fields['meta-description']),

--- a/tests/utils/create-article-node.test.js
+++ b/tests/utils/create-article-node.test.js
@@ -59,14 +59,17 @@ describe('Should properly postprocess an article node after it is fetched', () =
             createNode,
             createContentDigest,
             mapping,
-            articleRawContent
+            articleRawContent,
+            []
         );
         createArticleNode(
             imageNode,
             pageIdPrefix,
             createNode,
             createContentDigest,
-            mapping
+            mapping,
+            articleRawContent,
+            []
         );
         // refDocMapping should not include page_id, but should contain everything else
         expect(mapping[articleSlug]).toStrictEqual(articleNode);
@@ -81,7 +84,8 @@ describe('Should properly postprocess an article node after it is fetched', () =
             createNode,
             createContentDigest,
             {},
-            articleRawContent
+            articleRawContent,
+            []
         );
         expect(createNode.mock.calls.length).toBe(1);
         const createdArticleNode = createNode.mock.calls[0][0];
@@ -96,6 +100,7 @@ describe('Should properly postprocess an article node after it is fetched', () =
         expect(createContentDigest.mock.calls.length).toBe(1);
         const contentToDigest = {
             atfimage,
+            associations: [],
             authors: articleAuthors,
             description: articleDescription,
             languages: articleLanguages,
@@ -118,7 +123,9 @@ describe('Should properly postprocess an article node after it is fetched', () =
             pageIdPrefix,
             createNode,
             createContentDigest,
-            {}
+            {},
+            articleRawContent,
+            []
         );
         expect(createNode.mock.calls.length).toBe(0);
     });

--- a/tests/utils/create-article-page.test.js
+++ b/tests/utils/create-article-page.test.js
@@ -4,7 +4,7 @@ describe('creating an article page', () => {
     const articleOneSlug = '/article1';
     const articleOne = { slug: articleOneSlug };
     const slugContentMapping = {
-        [articleOneSlug]: { ast: { options: { template: 'devhub-article' } } },
+        [articleOne.slug]: { ast: { options: { template: 'devhub-article' } } },
     };
     let createPage;
     beforeEach(() => {
@@ -15,12 +15,12 @@ describe('creating an article page', () => {
     it('should create a page at the correct slug', () => {
         createArticlePage(articleOne, slugContentMapping, {}, {}, createPage);
         expect(createPage.mock.calls.length).toBe(1);
-        expect(createPage.mock.calls[0][0].path).toBe(articleOneSlug);
+        expect(createPage.mock.calls[0][0].path).toBe(articleOne.slug);
     });
 
     it('should properly tag series for a page', () => {
         const series = {
-            seriesWithArticleOne: [articleOneSlug],
+            seriesWithArticleOne: [articleOne.slug],
             seriesWithoutArticleOne: [],
         };
         createArticlePage(
@@ -44,7 +44,7 @@ describe('creating an article page', () => {
     });
 
     it('should get the correct template for a page', () => {
-        slugContentMapping[articleOneSlug].ast = {
+        slugContentMapping[articleOne.slug].ast = {
             options: {
                 // "devhub-article" is a keyword to choose a specific article template
                 template: 'devhub-article',
@@ -59,7 +59,7 @@ describe('creating an article page', () => {
         slugContentMapping[articleTwoSlug] = {
             ast: {},
         };
-        slugContentMapping[articleOneSlug].query_fields = {
+        slugContentMapping[articleOne.slug].query_fields = {
             related: [{ refuri: articleTwoSlug }],
         };
         createArticlePage(articleOne, slugContentMapping, {}, {}, createPage);


### PR DESCRIPTION
No Review

This PR adds the base logic for pulling in associations from Realm/Atlas at build time to lay the groundwork for building a UI.