### PR TITLE
DEVHUB-457: Ensure Trailing Slash on Home URL for Breadcrumb

### DIFF
--- a/src/components/dev-hub/breadcrumb-schema.js
+++ b/src/components/dev-hub/breadcrumb-schema.js
@@ -12,7 +12,10 @@ const getBreadcrumbList = (breadcrumb, siteUrl) =>
             '@type': 'ListItem',
             position: index + 1,
             name: label,
-            item: path === '/' ? siteUrl : addTrailingSlashIfMissing(siteUrl + path),
+            item:
+                path === '/'
+                    ? addTrailingSlashIfMissing(siteUrl)
+                    : addTrailingSlashIfMissing(siteUrl + path),
         };
     });
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -14,6 +14,7 @@ import {
     TwitchFeature,
 } from '~components/pages/home';
 import { SITE_URL } from '~src/constants';
+import { addTrailingSlashIfMissing } from '~utils/add-trailing-slash-if-missing';
 
 const BackgroundImage = styled('div')`
     background-image: url(${homepageBackground});
@@ -43,7 +44,7 @@ const Index = ({ pageContext: { fallbackTwitchVideo, featuredItems } }) => {
                         name: 'MongoDB Developer Hub',
                         logo:
                             'https://webassets.mongodb.com/_com_assets/cms/mongodb_logo1-76twgcu2dm.png',
-                        url: SITE_URL,
+                        url: addTrailingSlashIfMissing(SITE_URL),
                         telephone: '+1-844-666-4632',
                         sameAs: [
                             'https://www.facebook.com/MongoDB/',

--- a/tests/unit/BreadcrumbSchema.test.js
+++ b/tests/unit/BreadcrumbSchema.test.js
@@ -4,10 +4,10 @@ import BreadcrumbSchema from '../../src/components/dev-hub/breadcrumb-schema';
 
 import mockData from './data/BreadcrumbSchema.test.json';
 
-const siteUrl = 'https://developer.mongodb.com';
+const siteUrl = 'https://developer.mongodb.com/';
 
 jest.mock('../../src/hooks/use-site-metadata', () => ({
-    useSiteMetadata: () => ({ siteUrl })
+    useSiteMetadata: () => ({ siteUrl }),
 }));
 
 describe('BreadcrumbSchema', () => {
@@ -24,14 +24,25 @@ describe('BreadcrumbSchema', () => {
     it('script has a correct schema', () => {
         const script = shallowWrapper.find('script');
 
-        expect(script.text()).toEqual(JSON.stringify(
-            {
-                "@context": "https://schema.org",
-                "@type": "BreadcrumbList",
+        expect(script.text()).toEqual(
+            JSON.stringify({
+                '@context': 'https://schema.org',
+                '@type': 'BreadcrumbList',
                 itemListElement: [
-                    { "@type": "ListItem", "position": 1, name: "Home", item: siteUrl },
-                    { "@type": "ListItem", "position": 2, name: "Learn", item: siteUrl + "/learn/" }]
-            }
-        ));
+                    {
+                        '@type': 'ListItem',
+                        position: 1,
+                        name: 'Home',
+                        item: siteUrl,
+                    },
+                    {
+                        '@type': 'ListItem',
+                        position: 2,
+                        name: 'Learn',
+                        item: siteUrl + '/learn/',
+                    },
+                ],
+            })
+        );
     });
-})
+});

--- a/tests/unit/__snapshots__/BreadcrumbSchema.test.js.snap
+++ b/tests/unit/__snapshots__/BreadcrumbSchema.test.js.snap
@@ -8,7 +8,7 @@ exports[`BreadcrumbSchema renders correctly 1`] = `
   <script
     type="application/ld+json"
   >
-    {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://developer.mongodb.com"},{"@type":"ListItem","position":2,"name":"Learn","item":"https://developer.mongodb.com/learn/"}]}
+    {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://developer.mongodb.com/"},{"@type":"ListItem","position":2,"name":"Learn","item":"https://developer.mongodb.com//learn/"}]}
   </script>
 </HelmetWrapper>
 `;


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DEVHUB-457)
[Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-457-trailing-slash/)

This PR adds the trailing slash to uses of the home page URL `https://developer.mongodb.com/` in the breadcrumb schema as using the `SITE_URL` is great but it leaves out the trailing slash when used as-is.

To verify, let's be sure pages with the breadcrumb schema now have a trailing slash for the home page url as such:

![Screen Shot 2021-04-19 at 10 29 15 AM](https://user-images.githubusercontent.com/9064401/115253912-dcb43d80-a0fa-11eb-9436-8d954b0cfe98.png)
