### PR TITLE
DEVHUB-585: Fix withPrefix Usage for Article Assets

### DIFF
--- a/src/classes/snooty-article.ts
+++ b/src/classes/snooty-article.ts
@@ -11,6 +11,8 @@ import { getNestedValue } from '../utils/get-nested-value';
 import { findSectionHeadings } from '../utils/find-section-headings';
 import { getRelevantSnootyNodeContent } from '../utils/setup/get-relevant-snooty-node-content.js';
 import { getImageSrc } from '../utils/get-image-src';
+import { generatePathPrefix } from '../utils/generate-path-prefix';
+import { getMetadata } from '../utils/get-metadata';
 
 const dateFormatOptions = {
     month: 'short',
@@ -37,6 +39,8 @@ export class SnootyArticle implements Article {
     type: ArticleCategory;
     updatedDate: String;
     constructor(slug, pageNodes) {
+        const metadata = getMetadata();
+        const pathPrefix = generatePathPrefix(metadata);
         this._id = pageNodes._id;
         const articleUrl = addTrailingSlashIfMissing(`${SITE_URL}/${slug}`);
         const canonicalUrl = dlv(
@@ -68,7 +72,11 @@ export class SnootyArticle implements Article {
             meta['updated-date'],
             dateFormatOptions
         );
-        this.authors = meta.author;
+        // All Snooty images are hosted on-site
+        this.authors = meta.author.map(a => ({
+            ...a,
+            isInternalReference: true,
+        }));
         this.contentAST = contentAST;
         this.description = getNestedText(meta['meta-description']);
         this.headingNodes = findSectionHeadings(
@@ -77,7 +85,7 @@ export class SnootyArticle implements Article {
             'heading',
             1
         );
-        this.image = meta['atf-image'];
+        this.image = pathPrefix + meta['atf-image'];
         this.languages = mapTagTypeToUrl(meta.languages, 'language');
         this.products = mapTagTypeToUrl(meta.products, 'product');
         this.publishedDate = formattedPublishedDate;

--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -34,7 +34,7 @@ const renderArticle = article => (
     <ArticleCard
         to={article.slug}
         key={article._id}
-        image={withPrefix(article.image)}
+        image={article.image}
         tags={[...article.products, ...article.languages, ...article.tags]}
         title={article.title}
         badge="article"

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -90,8 +90,6 @@ const Article = props => {
     const tagList = [...products, ...languages, ...tags];
     const articleUrl = addTrailingSlashIfMissing(`${siteUrl}/${slug}`);
 
-    const articleImage = withPrefix(image);
-
     return (
         <Layout includeCanonical={false}>
             <SEO
@@ -111,11 +109,11 @@ const Article = props => {
                 description={metaDescription}
                 publishedDate={publishedDate}
                 modifiedDate={updatedDate}
-                imageUrl={articleImage}
+                imageUrl={image}
                 authors={authors}
             />
             <BlogPostTitleArea
-                articleImage={articleImage}
+                articleImage={image}
                 authors={authors}
                 breadcrumb={articleBreadcrumbs}
                 originalDate={publishedDate}

--- a/src/utils/get-featured-card-fields.js
+++ b/src/utils/get-featured-card-fields.js
@@ -1,6 +1,3 @@
-import { getNestedValue } from './get-nested-value';
-import { withPrefix } from 'gatsby';
-
 const generateTrackingParam = page => `?tck=feat${page}`;
 
 export const getFeaturedCardFields = (article, page) => {


### PR DESCRIPTION
[Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/CI/devhub/jordanstapinski/DEVHUB-585-image-internal/)

This PR fixes a bug in migrating to the `Article` interface where `withPrefix` was being applied inappropriately. Now we use it at build time for assets.