### PR TITLE
Misc Strapi Parity Fixes

### DIFF
--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -123,8 +123,8 @@ const filteredPageGroups = allSeries => {
 
 export const createPages = async ({ actions, graphql }) => {
     const { createPage, createRedirect } = actions;
-    const [, metadataDocument, result] = await Promise.all([
-        saveAssetFiles(assets, stitchClient),
+    const [metadataDocument, result] = await Promise.all([
+        // saveAssetFiles(assets, stitchClient),
         stitchClient.callFunction('fetchDocument', [
             DB,
             METADATA_COLLECTION,

--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -123,8 +123,8 @@ const filteredPageGroups = allSeries => {
 
 export const createPages = async ({ actions, graphql }) => {
     const { createPage, createRedirect } = actions;
-    const [metadataDocument, result] = await Promise.all([
-        // saveAssetFiles(assets, stitchClient),
+    const [, metadataDocument, result] = await Promise.all([
+        saveAssetFiles(assets, stitchClient),
         stitchClient.callFunction('fetchDocument', [
             DB,
             METADATA_COLLECTION,

--- a/src/classes/snooty-article.ts
+++ b/src/classes/snooty-article.ts
@@ -2,7 +2,6 @@ import dlv from 'dlv';
 import { Article } from '../interfaces/article';
 import { ArticleCategory } from '../types/article-category';
 import { ArticleSEO } from '../types/article-seo';
-import { toDateString } from '../utils/format-dates';
 import { mapTagTypeToUrl } from '../utils/map-tag-type-to-url';
 import { getNestedText } from '../utils/get-nested-text';
 import { SITE_URL } from '../constants';
@@ -13,13 +12,6 @@ import { getRelevantSnootyNodeContent } from '../utils/setup/get-relevant-snooty
 import { getImageSrc } from '../utils/get-image-src';
 import { SnootyAuthor } from './snooty-author';
 import { withPrefix } from 'gatsby';
-
-const dateFormatOptions = {
-    month: 'short',
-    day: '2-digit',
-    year: 'numeric',
-    timeZone: 'UTC',
-};
 
 export class SnootyArticle implements Article {
     _id: String;

--- a/src/classes/snooty-article.ts
+++ b/src/classes/snooty-article.ts
@@ -62,15 +62,6 @@ export class SnootyArticle implements Article {
         );
         const metaDescription =
             metaDescriptionNode && getNestedText(metaDescriptionNode.children);
-        const formattedPublishedDate = toDateString(
-            meta.pubdate,
-            dateFormatOptions
-        );
-        const formattedUpdatedDate = toDateString(
-            meta['updated-date'],
-            dateFormatOptions
-        );
-        // All Snooty images are hosted on-site
         this.authors = meta.author.map(
             a => new SnootyAuthor(a, slugContentMapping)
         );
@@ -88,7 +79,7 @@ export class SnootyArticle implements Article {
         this.image = withPrefix(meta['atf-image'], pathPrefix);
         this.languages = mapTagTypeToUrl(meta.languages, 'language');
         this.products = mapTagTypeToUrl(meta.products, 'product');
-        this.publishedDate = formattedPublishedDate;
+        this.publishedDate = meta.pubdate;
         this.related = meta.related || [];
         this.SEO = {
             canonicalUrl,
@@ -117,6 +108,6 @@ export class SnootyArticle implements Article {
         this.tags = mapTagTypeToUrl(meta.tags, 'tag');
         this.title = dlv(meta.title, [0, 'value'], slug);
         this.type = meta.type;
-        this.updatedDate = formattedUpdatedDate;
+        this.updatedDate = meta['updated-date'];
     }
 }

--- a/src/classes/strapi-article.ts
+++ b/src/classes/strapi-article.ts
@@ -2,16 +2,10 @@ import { Article } from '../interfaces/article';
 import { ArticleCategory } from '../types/article-category';
 import { mapTagTypeToUrl } from '../utils/map-tag-type-to-url';
 import { ArticleSEO } from '../types/article-seo';
-import { toDateString } from '../utils/format-dates';
 import { transformArticleStrapiData } from '../utils/transform-article-strapi-data';
 import { StrapiAuthor } from './strapi-author';
 
-const dateFormatOptions = {
-    month: 'short',
-    day: '2-digit',
-    year: 'numeric',
-    timeZone: 'UTC',
-};
+const toISODate = date => date && new Date(date).toISOString().slice(0, 10);
 
 export class StrapiArticle implements Article {
     _id: String;
@@ -50,18 +44,12 @@ export class StrapiArticle implements Article {
             'product',
             true
         );
-        this.publishedDate = toDateString(
-            mappedArticle.published_at,
-            dateFormatOptions
-        );
+        this.publishedDate = toISODate(mappedArticle.published_at);
         this.SEO = mappedArticle.SEO;
         this.slug = mappedArticle.slug;
         this.tags = mapTagTypeToUrl(mappedArticle.tags, 'tag', true);
         this.title = mappedArticle.name;
         this.type = mappedArticle.type;
-        this.updatedDate = toDateString(
-            mappedArticle.updatedAt,
-            dateFormatOptions
-        );
+        this.updatedDate = toISODate(mappedArticle.updatedAt);
     }
 }

--- a/src/classes/strapi-article.ts
+++ b/src/classes/strapi-article.ts
@@ -4,6 +4,7 @@ import { mapTagTypeToUrl } from '../utils/map-tag-type-to-url';
 import { ArticleSEO } from '../types/article-seo';
 import { transformArticleStrapiData } from '../utils/transform-article-strapi-data';
 import { StrapiAuthor } from './strapi-author';
+import { findSectionHeadings } from '../utils/find-section-headings';
 
 const toISODate = date => date && new Date(date).toISOString().slice(0, 10);
 
@@ -32,7 +33,14 @@ export class StrapiArticle implements Article {
         );
         this.contentAST = [mappedArticle.contentAST];
         this.description = mappedArticle.description;
-        this.headingNodes = [{}];
+        this.headingNodes = findSectionHeadings(
+            mappedArticle.contentAST.children || [],
+            'type',
+            'heading',
+            2,
+            -1,
+            true
+        );
         this.image = mappedArticle.image;
         this.languages = mapTagTypeToUrl(
             mappedArticle.languages,

--- a/src/components/dev-hub/blog-post-title-area.js
+++ b/src/components/dev-hub/blog-post-title-area.js
@@ -2,9 +2,17 @@ import React from 'react';
 import styled from '@emotion/styled';
 import BlogTagList from './blog-tag-list';
 import { H2, P } from './text';
+import { toDateString } from '../../utils/format-dates';
 import { screenSize, fontSize, size } from './theme';
 import BylineBlock from './byline-block';
 import HeroBanner from './hero-banner';
+
+const dateFormatOptions = {
+    month: 'short',
+    day: '2-digit',
+    year: 'numeric',
+    timeZone: 'UTC',
+};
 
 const PostMetaLine = styled('div')`
     color: ${({ theme }) => theme.colorMap.greyLightThree};
@@ -50,10 +58,16 @@ const BlogPostTitleArea = ({
             <PostMetaLine>
                 <DateTextContainer>
                     {updatedDate && (
-                        <DateText collapse>Updated: {updatedDate} | </DateText>
+                        <DateText collapse>
+                            Updated:{' '}
+                            {toDateString(updatedDate, dateFormatOptions)} |{' '}
+                        </DateText>
                     )}
                     {originalDate && (
-                        <DateText collapse>Published: {originalDate}</DateText>
+                        <DateText collapse>
+                            Published:{' '}
+                            {toDateString(originalDate, dateFormatOptions)}
+                        </DateText>
                     )}
                 </DateTextContainer>
                 <BlogTagList tags={tags} />

--- a/src/components/dev-hub/blog-post-title-area.js
+++ b/src/components/dev-hub/blog-post-title-area.js
@@ -59,13 +59,13 @@ const BlogPostTitleArea = ({
                 <DateTextContainer>
                     {updatedDate && (
                         <DateText collapse>
-                            Updated:{' '}
-                            {toDateString(updatedDate, dateFormatOptions)} |{' '}
+                            Updated:
+                            {toDateString(updatedDate, dateFormatOptions)} |
                         </DateText>
                     )}
                     {originalDate && (
                         <DateText collapse>
-                            Published:{' '}
+                            Published:
                             {toDateString(originalDate, dateFormatOptions)}
                         </DateText>
                     )}

--- a/src/components/dev-hub/blog-post-title-area.js
+++ b/src/components/dev-hub/blog-post-title-area.js
@@ -59,13 +59,13 @@ const BlogPostTitleArea = ({
                 <DateTextContainer>
                     {updatedDate && (
                         <DateText collapse>
-                            Updated:
-                            {toDateString(updatedDate, dateFormatOptions)} |
+                            Updated:{' '}
+                            {toDateString(updatedDate, dateFormatOptions)} |{' '}
                         </DateText>
                     )}
                     {originalDate && (
                         <DateText collapse>
-                            Published:
+                            Published:{' '}
                             {toDateString(originalDate, dateFormatOptions)}
                         </DateText>
                     )}

--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -2,7 +2,6 @@ import React, { useCallback, useState } from 'react';
 import styled from '@emotion/styled';
 import Audio from './audio';
 import Card from './card';
-import { withPrefix } from 'gatsby';
 import Paginate from './paginate';
 import getTwitchThumbnail from '~utils/get-twitch-thumbnail';
 

--- a/src/components/pages/home/hero.js
+++ b/src/components/pages/home/hero.js
@@ -45,12 +45,8 @@ const StyledTopCard = styled(Card)`
 
 // TODO: Generalize as new content types are supported
 const FeaturedHomePageItem = ({ item }) => {
-    if (item.type === 'article') {
-        const { image, slug, title } = getFeaturedCardFields(item, 'home');
-        return (
-            <StyledTopCard image={image} to={slug} title={title} key={title} />
-        );
-    }
+    const { image, slug, title } = getFeaturedCardFields(item, 'home');
+    return <StyledTopCard image={image} to={slug} title={title} key={title} />;
 };
 
 const Hero = ({ featuredItems }) => (

--- a/src/utils/setup/find-articles-from-slugs.js
+++ b/src/utils/setup/find-articles-from-slugs.js
@@ -2,7 +2,6 @@ export const findArticleWithSlug = (allArticles, slug) => {
     const targetSlug = new RegExp(`^/?${slug}$`);
     const targetArticle = allArticles.find(x => x.slug.match(targetSlug));
     if (targetArticle) {
-        targetArticle['type'] = 'article';
         return targetArticle;
     }
 };


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/CI/devhub/jordanstapinski/use-iso-date/)

This PR addresses some fixes after moving to the `Article` interface:
1. Swaps article dates to use ISO Date format
2. Undoes some logic where we set type to `article` for items being featured
3. Adds TOC headings to articles