### PR TITLE
Remove content AST, SEO from large page data files

### DIFF
--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -44,6 +44,8 @@ const slugContentMapping = {};
 
 let snootyArticles = [];
 let allArticles = [];
+// Create slimmer articles for tag pages
+let articlesWithoutContentAST = [];
 
 // stich client connection
 let stitchClient;
@@ -163,6 +165,12 @@ export const createPages = async ({ actions, graphql }) => {
         );
     });
 
+    articlesWithoutContentAST = allArticles.map(a => ({
+        ...a,
+        contentAST: [],
+        SEO: {},
+    }));
+
     await createClientSideRedirects(graphql, createRedirect);
 
     const tagPageDirectory = {};
@@ -170,11 +178,13 @@ export const createPages = async ({ actions, graphql }) => {
     tagTypes.forEach(type => {
         const isAuthorType = type === 'author';
         if (isAuthorType) {
-            tagPageDirectory[type] = aggregateAuthorInformation(allArticles);
+            tagPageDirectory[type] = aggregateAuthorInformation(
+                articlesWithoutContentAST
+            );
         } else {
             const mappedType = pluralizeIfNeeded[type];
             tagPageDirectory[type] = aggregateItemsWithTagType(
-                allArticles,
+                articlesWithoutContentAST,
                 mappedType,
                 type !== mappedType
             );
@@ -219,7 +229,7 @@ export const onCreatePage = async ({ page, actions }) =>
     handleCreatePage(
         page,
         actions,
-        allArticles,
+        articlesWithoutContentAST,
         homeFeaturedArticles,
         learnFeaturedArticles,
         excludedLearnPageArticles


### PR DESCRIPTION
[Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/CI/devhub/jordanstapinski/remove-content-ast/)

This PR removes content ASTs from page data files on learn/tag pages. This was bloating page-data files and causing a drop in PageSpeed.