### PR TITLE
DEVHUB-649: Add support for the charts directive

### DIFF
--- a/src/utils/setup/parse-markdown-to-ast.js
+++ b/src/utils/setup/parse-markdown-to-ast.js
@@ -40,13 +40,21 @@ export const parseMarkdownToAST = markdown => {
                     node.options = {};
                 }
                 break;
+            // Custom directive definitions go here
             case 'textDirective':
-                // Custom directive definitions go here
-                // Right now, this is just YouTube
-                node['argument'] = [{ value: node.attributes.vid }];
                 data['name'] = node.name;
                 node.type = node.name;
-                node.nodeData = data;
+                switch (node.name) {
+                    case 'youtube':
+                        node['argument'] = [{ value: node.attributes.vid }];
+                        node.nodeData = data;
+                        break;
+                    case 'charts':
+                        node.options = node.attributes;
+                        break;
+                    default:
+                        break;
+                }
                 break;
             default:
                 break;


### PR DESCRIPTION
This PR updates the parse MD to AST logic to adapt the forthcoming Chart option in Strapi to our existing front-end for rendering a MongoDB embedded chart. This also can be deployed independently of the Strapi change to add a Chart to the toolbar