### PR TITLE
DEPLOY DEVHUB-649: Add support for the charts directive (#805)

### DIFF
--- a/src/utils/setup/parse-markdown-to-ast.js
+++ b/src/utils/setup/parse-markdown-to-ast.js
@@ -40,13 +40,21 @@ export const parseMarkdownToAST = markdown => {
                     node.options = {};
                 }
                 break;
+            // Custom directive definitions go here
             case 'textDirective':
-                // Custom directive definitions go here
-                // Right now, this is just YouTube
-                node['argument'] = [{ value: node.attributes.vid }];
                 data['name'] = node.name;
                 node.type = node.name;
-                node.nodeData = data;
+                switch (node.name) {
+                    case 'youtube':
+                        node['argument'] = [{ value: node.attributes.vid }];
+                        node.nodeData = data;
+                        break;
+                    case 'charts':
+                        node.options = node.attributes;
+                        break;
+                    default:
+                        break;
+                }
                 break;
             default:
                 break;


### PR DESCRIPTION
[Staging Link](http://docs-devhub-staging.s3-website-us-east-1.amazonaws.com/8b11548/devhub/docsworker-xlarge/may-11-21/)
[Staging Job](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=609aa3d8e34a64024ac7c373)
[Release Notes](https://wiki.corp.mongodb.com/display/DEVREL/Developer+Hub+Release+Notes)

```
staging using branch origin/staging
production using branch origin/master

changes in staging but not production:
b2d24ee5 DEVHUB-649: Add support for the charts directive (#805)
```