### PR TITLE
Update lodash for dependabot warning

### DIFF
--- a/plugins/gatsby-source-strapi/package.json
+++ b/plugins/gatsby-source-strapi/package.json
@@ -11,7 +11,7 @@
     "axios": "0.21.1",
     "gatsby-node-helpers": "^0.3.0",
     "gatsby-source-filesystem": "^3.3.0",
-    "lodash": "4.17.20",
+    "lodash": "^4.17.21",
     "pluralize": "8.0.0"
   },
   "_from": "gatsby-source-strapi@1.0.0-alpha.1"


### PR DESCRIPTION
This PR updates lodash as per the dependabot warning for our export of the gatsby-source-strapi plugin