### PR TITLE
DEVHUB-625: Add Stars to Mobile Design

### DIFF
--- a/src/components/ArticleRating.js
+++ b/src/components/ArticleRating.js
@@ -10,31 +10,26 @@ import {
     STAR_ACTIONS,
 } from '~components/ArticleRatingContext';
 
-const StyledContainerTop = styled.div`
-    span {
-        text-align: end;
-    }
-
-    @media ${screenSize.upToMedium} {
+const StyledContainerTop = styled('div')`
+    @media ${screenSize.upToLarge} {
+        padding-top: ${size.large};
         a:last-child {
             margin-right: 0;
         }
-        padding-top: ${size.large};
         span {
-            text-align: unset;
+            text-align: start;
         }
     }
 `;
 
-const StyledContainerBottom = styled.div`
+const StyledContainerBottom = styled('div')`
     background-color: ${colorMap.devBlack};
     border-radius: ${size.xsmall};
     border: 1px solid ${colorMap.greyDarkThree};
     padding: ${size.mediumLarge};
 
-    @media ${screenSize.mediumAndUp} {
-        padding-left: ${size.large};
-        padding: 15px;
+    @media ${screenSize.largeAndUp} {
+        padding: ${size.default};
     }
 `;
 

--- a/src/components/ArticleRating.js
+++ b/src/components/ArticleRating.js
@@ -16,9 +16,6 @@ const StyledContainerTop = styled('div')`
         a:last-child {
             margin-right: 0;
         }
-        span {
-            text-align: start;
-        }
     }
 `;
 

--- a/src/components/ArticleRating.js
+++ b/src/components/ArticleRating.js
@@ -19,6 +19,10 @@ const StyledContainerTop = styled.div`
         a:last-child {
             margin-right: 0;
         }
+        padding-top: ${size.large};
+        span {
+            text-align: unset;
+        }
     }
 `;
 

--- a/src/components/dev-hub/feedback/feedback-container.js
+++ b/src/components/dev-hub/feedback/feedback-container.js
@@ -8,11 +8,13 @@ import React, {
 import PropTypes from 'prop-types';
 import { graphql, useStaticQuery } from 'gatsby';
 import { css } from '@emotion/react';
+import styled from '@emotion/styled';
 import Modal from '~components/dev-hub/modal';
 import FeedbackFinalStep from '~components/dev-hub/feedback/feedback-final-step';
 import getStarRatingFlow from '~components/dev-hub/feedback/helpers/getStarRatingFlow';
 import FeedbackForm from '~components/dev-hub/feedback/feedback-form';
 import useFeedback from '~hooks/use-feedback';
+import StarRatingList from './star-rating-list';
 import { FeedbackFormContext } from '~components/dev-hub/feedback/feedback-context';
 import {
     ArticleRatingContext,
@@ -20,7 +22,7 @@ import {
     STAR_RATING_FLOW,
 } from '~components/ArticleRatingContext';
 import BalloonsIcon from '~components/dev-hub/icons/balloons-icon';
-import { screenSize } from '~components/dev-hub/theme';
+import { screenSize, size } from '~components/dev-hub/theme';
 
 const feedbackItems = graphql`
     query FeedbackItems {
@@ -42,6 +44,27 @@ const modalStyles = css`
         max-width: unset;
         width: 100%;
         border-radius: 0;
+        padding: 0;
+    }
+`;
+
+const headingStyles = css`
+    @media ${screenSize.upToMedium} {
+        padding: ${size.default};
+    }
+`;
+
+const StyledStarRatingList = styled(StarRatingList)`
+    background-color: ${({ theme }) => theme.colorMap.devBlack};
+    margin-top: -${size.xlarge};
+    margin-bottom: ${size.large};
+    /* padding top is the size of the X on the modal (default) + 2*medium padding around it */
+    /* Hardcoding 40px as that is a specific ask */
+    padding: calc(${size.medium} + ${size.medium} + ${size.default}) 0
+        ${size.large} 40px;
+    width: 100%;
+    @media ${screenSize.mediumAndUp} {
+        display: none;
     }
 `;
 
@@ -108,12 +131,14 @@ const FeedbackContainer = ({ starRatingFlow, articleMeta, closeModal }) => {
             isOpenToStart
             verticallyCenter
             contentStyle={modalStyles}
+            headingStyles={headingStyles}
             dialogMobileContainerStyle={{
                 height: '100%',
                 padding: 0,
                 width: '100%',
             }}
         >
+            <StyledStarRatingList />
             {isLastModal ? (
                 <FeedbackFinalStep incrementStep={incrementStepHandler} />
             ) : (

--- a/src/components/dev-hub/feedback/feedback-container.js
+++ b/src/components/dev-hub/feedback/feedback-container.js
@@ -56,8 +56,7 @@ const headingStyles = css`
 
 const StyledStarRatingList = styled(StarRatingList)`
     background-color: ${({ theme }) => theme.colorMap.devBlack};
-    margin-top: -${size.xlarge};
-    margin-bottom: ${size.large};
+    margin: -${size.xlarge} 0 ${size.large};
     /* padding top is the size of the X on the modal (default) + 2*medium padding around it */
     /* Hardcoding 40px as that is a specific ask */
     padding: calc(${size.medium} + ${size.medium} + ${size.default}) 0

--- a/src/components/dev-hub/feedback/feedback-form.js
+++ b/src/components/dev-hub/feedback/feedback-form.js
@@ -32,6 +32,10 @@ const StyledForm = styled('form')`
     > label {
         margin: ${size.default} 0;
     }
+    @media ${screenSize.upToMedium} {
+        /* Hardcoding 40px as that is a specific ask */
+        padding: 0 40px;
+    }
 `;
 
 const StyledH5 = styled(H5)`

--- a/src/components/dev-hub/feedback/star-rating-list.js
+++ b/src/components/dev-hub/feedback/star-rating-list.js
@@ -1,0 +1,98 @@
+import React, { useContext } from 'react';
+import styled from '@emotion/styled';
+import { screenSize, size } from '../theme';
+import StarIcon from '../icons/star-icon';
+import { ArticleRatingContext } from '~components/ArticleRatingContext';
+
+const StyledStarsContainer = styled('div')`
+    align-items: center;
+    display: flex;
+
+    @media ${screenSize.mediumAndUp} {
+        margin-left: 28px;
+    }
+`;
+
+const StyledStarContainer = styled('div')`
+    margin-right: ${size.mediumLarge};
+    padding: 0;
+
+    align-items: center;
+    display: inline-flex;
+    justify-content: center;
+
+    svg {
+        height: ${size.mediumLarge};
+        width: ${size.mediumLarge};
+    }
+
+    @media ${screenSize.mediumAndUp} {
+        margin: ${({ isActive }) => (isActive ? '0' : '0 4px')};
+        padding: 4px;
+        svg {
+            height: auto;
+            width: auto;
+        }
+    }
+`;
+
+const StarRatingList = ({ ...props }) => {
+    const state = useContext(ArticleRatingContext);
+    const { ratingState } = state;
+    return (
+        <StyledStarsContainer {...props}>
+            <StyledStarContainer>
+                <StarIcon
+                    isActive={ratingState.stars[0]}
+                    name="first-star"
+                    size={ratingState.stars[0] && size.mediumLarge}
+                >
+                    <stop offset="0%" stopColor="#D34F94" />
+                    <stop offset="100%" stopColor="#D95B8F" />
+                </StarIcon>
+            </StyledStarContainer>
+            <StyledStarContainer>
+                <StarIcon
+                    isActive={ratingState.stars[1]}
+                    name="second-star"
+                    size={ratingState.stars[1] && size.mediumLarge}
+                >
+                    <stop offset="0%" stopColor="#D95B8F" />
+                    <stop offset="100%" stopColor="#E06D88" />
+                </StarIcon>
+            </StyledStarContainer>
+            <StyledStarContainer>
+                <StarIcon
+                    name="third-star"
+                    isActive={ratingState.stars[2]}
+                    size={ratingState.stars[2] && size.mediumLarge}
+                >
+                    <stop offset="0%" stopColor="#E06D88" />
+                    <stop offset="100%" stopColor="#E47983" />
+                </StarIcon>
+            </StyledStarContainer>
+            <StyledStarContainer>
+                <StarIcon
+                    isActive={ratingState.stars[3]}
+                    name="fourth-star"
+                    size={ratingState.stars[3] && size.mediumLarge}
+                >
+                    <stop offset="0%" stopColor="#E47983" />
+                    <stop offset="100%" stopColor="#F09677" />
+                </StarIcon>
+            </StyledStarContainer>
+            <StyledStarContainer>
+                <StarIcon
+                    isActive={ratingState.stars[4]}
+                    name="fifth-star"
+                    size={ratingState.stars[4] && size.mediumLarge}
+                >
+                    <stop offset="0%" stopColor="#F09677" />
+                    <stop offset="100%" stopColor="#F7A76F" />
+                </StarIcon>
+            </StyledStarContainer>
+        </StyledStarsContainer>
+    );
+};
+
+export default StarRatingList;

--- a/src/components/dev-hub/modal.js
+++ b/src/components/dev-hub/modal.js
@@ -30,6 +30,7 @@ const Heading = styled('header')`
     justify-content: flex-end;
     line-height: ${size.xsmall};
     margin-bottom: ${size.xsmall};
+    ${({ headingStyles }) => headingStyles};
 `;
 
 const ModalDialog = styled('div')`
@@ -52,8 +53,8 @@ const CloseButtonWrapper = styled('div')`
     font-weight: bold;
 `;
 
-const ModalClose = ({ closeModalOnEnter, deactivateModal }) => (
-    <Heading aria-label="close">
+const ModalClose = ({ closeModalOnEnter, deactivateModal, headingStyles }) => (
+    <Heading aria-label="close" headingStyles={headingStyles}>
         <CloseButtonWrapper
             tabIndex="0"
             onClick={deactivateModal}
@@ -92,6 +93,7 @@ export const Modal = ({
     // Dialog Container Style must be an object because of the react-aria-modal library styling
     dialogContainerStyle,
     dialogMobileContainerStyle,
+    headingStyles,
     onCloseModal,
     title,
     triggerComponent,
@@ -157,6 +159,7 @@ export const Modal = ({
                     <ModalClose
                         closeModalOnEnter={closeModalOnEnter}
                         deactivateModal={deactivateModal}
+                        headingStyles={headingStyles}
                     />
                     {children}
                 </ModalDialog>

--- a/src/components/dev-hub/modal.js
+++ b/src/components/dev-hub/modal.js
@@ -123,7 +123,9 @@ export const Modal = ({
         ...dialogMobileContainerStyle,
     };
     const [isActive, setIsActive] = useState(isOpenToStart);
-    const isMobile = useMedia(screenSize.upToMedium);
+    const defaultMobileState = null;
+    const isMobile = useMedia(screenSize.upToMedium, defaultMobileState);
+    const canDecideIfIsMobile = isMobile !== defaultMobileState;
     const activateModal = () => setIsActive(true);
     const deactivateModal = () => {
         onCloseModal && onCloseModal();
@@ -165,7 +167,10 @@ export const Modal = ({
                 </ModalDialog>
             </AriaModal>
         );
-
+    // The below line is due to SSR/Weird Media Query use
+    // Since this requires a re-render, we delay any rendering until this is done
+    // This prevents a jarring mobile experience
+    if (!canDecideIfIsMobile) return null;
     if (triggerComponent) {
         return (
             <>

--- a/src/components/dev-hub/star-rating.js
+++ b/src/components/dev-hub/star-rating.js
@@ -89,21 +89,22 @@ const StarRating = ({ clickHandlers }) => {
         !ratingState.isClicked && ratingDispatch(STAR_ACTIONS.CLEAR);
     }, [ratingDispatch, ratingState.isClicked]);
 
+    const onOpenFeedback = useCallback(
+        (index, starActionsNumber) => () => {
+            onHoverHandler(starActionsNumber);
+            onClickHandler(clickHandlers[index]);
+        },
+        [clickHandlers, onClickHandler, onHoverHandler]
+    );
+
     return (
         <StyledContainer>
             <StyledTitle>Rate this article</StyledTitle>
             <StyledStarsContainer onMouseLeave={onLeaveHandler}>
                 <StyledButton
-                    onClick={e => {
-                        e.stopPropagation();
-                        onHoverHandler(STAR_ACTIONS.ONE);
-                        onClickHandler(clickHandlers[0]);
-                    }}
+                    onClick={onOpenFeedback(0, STAR_ACTIONS.ONE)}
                     onMouseEnter={() => onHoverHandler(STAR_ACTIONS.ONE)}
-                    onTouchEnd={() => {
-                        onHoverHandler(STAR_ACTIONS.ONE);
-                        onClickHandler(clickHandlers[0]);
-                    }}
+                    onTouchEnd={onOpenFeedback(0, STAR_ACTIONS.ONE)}
                     isActive={ratingState.stars[0]}
                 >
                     <StarIcon
@@ -117,15 +118,9 @@ const StarRating = ({ clickHandlers }) => {
                 </StyledButton>
                 <StyledButton
                     isActive={ratingState.stars[1]}
-                    onClick={() => {
-                        onHoverHandler(STAR_ACTIONS.TWO);
-                        onClickHandler(clickHandlers[1]);
-                    }}
+                    onClick={onOpenFeedback(1, STAR_ACTIONS.TWO)}
                     onMouseEnter={() => onHoverHandler(STAR_ACTIONS.TWO)}
-                    onTouchEnd={() => {
-                        onHoverHandler(STAR_ACTIONS.TWO);
-                        onClickHandler(clickHandlers[1]);
-                    }}
+                    onTouchEnd={onOpenFeedback(1, STAR_ACTIONS.TWO)}
                 >
                     <StarIcon
                         isActive={ratingState.stars[1]}
@@ -138,15 +133,9 @@ const StarRating = ({ clickHandlers }) => {
                 </StyledButton>
                 <StyledButton
                     isActive={ratingState.stars[2]}
-                    onClick={() => {
-                        onHoverHandler(STAR_ACTIONS.THREE);
-                        onClickHandler(clickHandlers[2]);
-                    }}
-                    onTouchEnd={() => {
-                        onHoverHandler(STAR_ACTIONS.THREE);
-                        onClickHandler(clickHandlers[2]);
-                    }}
+                    onClick={onOpenFeedback(2, STAR_ACTIONS.THREE)}
                     onMouseEnter={() => onHoverHandler(STAR_ACTIONS.THREE)}
+                    onTouchEnd={onOpenFeedback(2, STAR_ACTIONS.THREE)}
                 >
                     <StarIcon
                         name="third-star"
@@ -159,15 +148,9 @@ const StarRating = ({ clickHandlers }) => {
                 </StyledButton>
                 <StyledButton
                     isActive={ratingState.stars[3]}
-                    onClick={() => {
-                        onHoverHandler(STAR_ACTIONS.FOUR);
-                        onClickHandler(clickHandlers[3]);
-                    }}
-                    onTouchEnd={() => {
-                        onHoverHandler(STAR_ACTIONS.FOUR);
-                        onClickHandler(clickHandlers[3]);
-                    }}
+                    onClick={onOpenFeedback(3, STAR_ACTIONS.FOUR)}
                     onMouseEnter={() => onHoverHandler(STAR_ACTIONS.FOUR)}
+                    onTouchEnd={onOpenFeedback(3, STAR_ACTIONS.FOUR)}
                 >
                     <StarIcon
                         isActive={ratingState.stars[3]}
@@ -180,15 +163,9 @@ const StarRating = ({ clickHandlers }) => {
                 </StyledButton>
                 <StyledButton
                     isActive={ratingState.stars[4]}
-                    onClick={() => {
-                        onHoverHandler(STAR_ACTIONS.FIVE);
-                        onClickHandler(clickHandlers[4]);
-                    }}
-                    onTouchEnd={() => {
-                        onHoverHandler(STAR_ACTIONS.FIVE);
-                        onClickHandler(clickHandlers[4]);
-                    }}
+                    onClick={onOpenFeedback(4, STAR_ACTIONS.FIVE)}
                     onMouseEnter={() => onHoverHandler(STAR_ACTIONS.FIVE)}
+                    onTouchEnd={onOpenFeedback(4, STAR_ACTIONS.FIVE)}
                 >
                     <StarIcon
                         isActive={ratingState.stars[4]}

--- a/src/components/dev-hub/star-rating.js
+++ b/src/components/dev-hub/star-rating.js
@@ -94,11 +94,16 @@ const StarRating = ({ clickHandlers }) => {
             <StyledTitle>Rate this article</StyledTitle>
             <StyledStarsContainer onMouseLeave={onLeaveHandler}>
                 <StyledButton
-                    onClick={() => {
+                    onClick={e => {
+                        e.stopPropagation();
                         onHoverHandler(STAR_ACTIONS.ONE);
                         onClickHandler(clickHandlers[0]);
                     }}
                     onMouseEnter={() => onHoverHandler(STAR_ACTIONS.ONE)}
+                    onTouchEnd={() => {
+                        onHoverHandler(STAR_ACTIONS.ONE);
+                        onClickHandler(clickHandlers[0]);
+                    }}
                     isActive={ratingState.stars[0]}
                 >
                     <StarIcon
@@ -117,6 +122,10 @@ const StarRating = ({ clickHandlers }) => {
                         onClickHandler(clickHandlers[1]);
                     }}
                     onMouseEnter={() => onHoverHandler(STAR_ACTIONS.TWO)}
+                    onTouchEnd={() => {
+                        onHoverHandler(STAR_ACTIONS.TWO);
+                        onClickHandler(clickHandlers[1]);
+                    }}
                 >
                     <StarIcon
                         isActive={ratingState.stars[1]}
@@ -130,6 +139,10 @@ const StarRating = ({ clickHandlers }) => {
                 <StyledButton
                     isActive={ratingState.stars[2]}
                     onClick={() => {
+                        onHoverHandler(STAR_ACTIONS.THREE);
+                        onClickHandler(clickHandlers[2]);
+                    }}
+                    onTouchEnd={() => {
                         onHoverHandler(STAR_ACTIONS.THREE);
                         onClickHandler(clickHandlers[2]);
                     }}
@@ -150,6 +163,10 @@ const StarRating = ({ clickHandlers }) => {
                         onHoverHandler(STAR_ACTIONS.FOUR);
                         onClickHandler(clickHandlers[3]);
                     }}
+                    onTouchEnd={() => {
+                        onHoverHandler(STAR_ACTIONS.FOUR);
+                        onClickHandler(clickHandlers[3]);
+                    }}
                     onMouseEnter={() => onHoverHandler(STAR_ACTIONS.FOUR)}
                 >
                     <StarIcon
@@ -164,6 +181,10 @@ const StarRating = ({ clickHandlers }) => {
                 <StyledButton
                     isActive={ratingState.stars[4]}
                     onClick={() => {
+                        onHoverHandler(STAR_ACTIONS.FIVE);
+                        onClickHandler(clickHandlers[4]);
+                    }}
+                    onTouchEnd={() => {
                         onHoverHandler(STAR_ACTIONS.FIVE);
                         onClickHandler(clickHandlers[4]);
                     }}

--- a/src/components/dev-hub/star-rating.js
+++ b/src/components/dev-hub/star-rating.js
@@ -23,7 +23,7 @@ const StyledButton = styled(Button)`
         width: ${size.mediumLarge};
     }
 
-    @media ${screenSize.mediumAndUp} {
+    @media ${screenSize.largeAndUp} {
         margin: ${({ isActive }) => (isActive ? '0' : '0 4px')};
         padding: 4px;
         svg {
@@ -37,7 +37,7 @@ const StyledContainer = styled('div')`
     display: flex;
     flex-direction: column;
 
-    @media ${screenSize.mediumAndUp} {
+    @media ${screenSize.largeAndUp} {
         align-items: center;
         flex-direction: row;
         min-height: ${size.large};
@@ -51,7 +51,7 @@ const StyledTitle = styled('span')`
     line-height: ${lineHeight.micro};
     margin-bottom: ${size.default};
 
-    @media ${screenSize.mediumAndUp} {
+    @media ${screenSize.largeAndUp} {
         flex-direction: row;
         margin-bottom: 0;
     }
@@ -61,7 +61,7 @@ const StyledStarsContainer = styled('div')`
     align-items: center;
     display: flex;
 
-    @media ${screenSize.mediumAndUp} {
+    @media ${screenSize.largeAndUp} {
         margin-left: 28px;
     }
 `;

--- a/src/components/dev-hub/star-rating.js
+++ b/src/components/dev-hub/star-rating.js
@@ -94,7 +94,10 @@ const StarRating = ({ clickHandlers }) => {
             <StyledTitle>Rate this article</StyledTitle>
             <StyledStarsContainer onMouseLeave={onLeaveHandler}>
                 <StyledButton
-                    onClick={() => onClickHandler(clickHandlers[0])}
+                    onClick={() => {
+                        onHoverHandler(STAR_ACTIONS.ONE);
+                        onClickHandler(clickHandlers[0]);
+                    }}
                     onMouseEnter={() => onHoverHandler(STAR_ACTIONS.ONE)}
                     isActive={ratingState.stars[0]}
                 >
@@ -109,7 +112,10 @@ const StarRating = ({ clickHandlers }) => {
                 </StyledButton>
                 <StyledButton
                     isActive={ratingState.stars[1]}
-                    onClick={() => onClickHandler(clickHandlers[1])}
+                    onClick={() => {
+                        onHoverHandler(STAR_ACTIONS.TWO);
+                        onClickHandler(clickHandlers[1]);
+                    }}
                     onMouseEnter={() => onHoverHandler(STAR_ACTIONS.TWO)}
                 >
                     <StarIcon
@@ -123,7 +129,10 @@ const StarRating = ({ clickHandlers }) => {
                 </StyledButton>
                 <StyledButton
                     isActive={ratingState.stars[2]}
-                    onClick={() => onClickHandler(clickHandlers[2])}
+                    onClick={() => {
+                        onHoverHandler(STAR_ACTIONS.THREE);
+                        onClickHandler(clickHandlers[2]);
+                    }}
                     onMouseEnter={() => onHoverHandler(STAR_ACTIONS.THREE)}
                 >
                     <StarIcon
@@ -137,7 +146,10 @@ const StarRating = ({ clickHandlers }) => {
                 </StyledButton>
                 <StyledButton
                     isActive={ratingState.stars[3]}
-                    onClick={() => onClickHandler(clickHandlers[3])}
+                    onClick={() => {
+                        onHoverHandler(STAR_ACTIONS.FOUR);
+                        onClickHandler(clickHandlers[3]);
+                    }}
                     onMouseEnter={() => onHoverHandler(STAR_ACTIONS.FOUR)}
                 >
                     <StarIcon
@@ -151,7 +163,10 @@ const StarRating = ({ clickHandlers }) => {
                 </StyledButton>
                 <StyledButton
                     isActive={ratingState.stars[4]}
-                    onClick={() => onClickHandler(clickHandlers[4])}
+                    onClick={() => {
+                        onHoverHandler(STAR_ACTIONS.FIVE);
+                        onClickHandler(clickHandlers[4]);
+                    }}
                     onMouseEnter={() => onHoverHandler(STAR_ACTIONS.FIVE)}
                 >
                     <StarIcon

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -38,6 +38,9 @@ const ArticleContent = styled('article')`
     max-width: ${size.maxContentWidth};
     padding-left: ${size.small};
     padding-right: ${size.small};
+    @media ${screenSize.upToMedium} {
+        padding: 0;
+    }
     @media ${screenSize.upToLarge} {
         margin: 0 auto;
     }
@@ -71,12 +74,18 @@ const Container = styled('div')`
     justify-content: center;
 
     grid-template-areas:
-        'icons icons rating'
+        'icons icons icons'
+        'rating rating rating'
         'article article article'
         'article article article'
         'article article article';
 
+    padding-left: ${size.small};
+    padding-right: ${size.small};
+
     @media ${screenSize.largeAndUp} {
+        padding-left: 0;
+        padding-right: 0;
         grid-template-areas:
             'rating rating rating'
             'icons article article'
@@ -87,11 +96,11 @@ const Container = styled('div')`
 
 const StyledRating = styled(ArticleRating)`
     grid-area: rating;
-    justify-self: end;
     margin: 0 ${size.default} ${size.large} 0;
 
     @media ${screenSize.mediumAndUp} {
         margin: 0 6px ${size.small} 6px;
+        justify-self: end;
     }
 
     @media ${screenSize.largeAndUp} {

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -80,12 +80,10 @@ const Container = styled('div')`
         'article article article'
         'article article article';
 
-    padding-left: ${size.small};
-    padding-right: ${size.small};
+    padding: 0 ${size.small};
 
     @media ${screenSize.largeAndUp} {
-        padding-left: 0;
-        padding-right: 0;
+        padding: 0;
         grid-template-areas:
             'rating rating rating'
             'icons article article'
@@ -100,11 +98,11 @@ const StyledRating = styled(ArticleRating)`
 
     @media ${screenSize.mediumAndUp} {
         margin: 0 6px ${size.small} 6px;
-        justify-self: end;
     }
 
     @media ${screenSize.largeAndUp} {
         margin-bottom: ${size.large};
+        justify-self: end;
     }
 `;
 

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -69,7 +69,7 @@ const Container = styled('div')`
     grid-auto-rows: auto;
     grid-template-columns: auto;
     justify-content: center;
-    grid-template-rows: 16px auto;
+    grid-template-rows: ${size.medium} auto;
     grid-template-areas:
         'icons icons icons'
         'rating rating rating'

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -36,13 +36,10 @@ const StyledBlogShareLinks = styled(BlogShareLinks)`
 const ArticleContent = styled('article')`
     grid-area: article;
     max-width: ${size.maxContentWidth};
-    padding-left: ${size.small};
-    padding-right: ${size.small};
-    @media ${screenSize.upToMedium} {
-        padding: 0;
-    }
+    padding: 0 ${size.small};
     @media ${screenSize.upToLarge} {
         margin: 0 auto;
+        padding: 0;
     }
 `;
 
@@ -60,7 +57,7 @@ const Icons = styled('div')`
         }
     }
     @media ${screenSize.upToLarge} {
-        margin: 0 0 0 ${size.small};
+        margin: 0;
         span:not(:first-of-type) {
             margin-left: ${size.small};
         }
@@ -72,7 +69,7 @@ const Container = styled('div')`
     grid-auto-rows: auto;
     grid-template-columns: auto;
     justify-content: center;
-
+    grid-template-rows: 16px auto;
     grid-template-areas:
         'icons icons icons'
         'rating rating rating'
@@ -80,9 +77,10 @@ const Container = styled('div')`
         'article article article'
         'article article article';
 
-    padding: 0 ${size.small};
+    padding: 0 ${size.default};
 
     @media ${screenSize.largeAndUp} {
+        grid-template-rows: unset;
         padding: 0;
         grid-template-areas:
             'rating rating rating'
@@ -96,12 +94,8 @@ const StyledRating = styled(ArticleRating)`
     grid-area: rating;
     margin: 0 ${size.default} ${size.large} 0;
 
-    @media ${screenSize.mediumAndUp} {
-        margin: 0 6px ${size.small} 6px;
-    }
-
     @media ${screenSize.largeAndUp} {
-        margin-bottom: ${size.large};
+        margin: 0 6px ${size.large} 6px;
         justify-self: end;
     }
 `;


### PR DESCRIPTION
This PR cleans up some UX related to the devhub feedback project, namely:
- Fixes a bug where touching a star on iOS would fail to do anything
- Adds the stars on mobile to the modal
- Cleans up the iPad layout
- Fixes a bug where the modal would flash the desktop variant on mobile before changing to mobile