### PR TITLE
DEVHUB-660: Default to H2 and above for TOC

### DIFF
--- a/src/utils/find-section-headings.js
+++ b/src/utils/find-section-headings.js
@@ -3,7 +3,8 @@ export const findSectionHeadings = (
     key,
     value,
     maxDepth,
-    minDepth = 1
+    minDepth = 1,
+    minHeadingSize = 2
 ) => {
     const results = [];
     const searchNode = (node, sectionDepth) => {
@@ -21,7 +22,12 @@ export const findSectionHeadings = (
             };
             const lastElement = results[results.length - 1];
             if (!lastElement || sectionDepth <= lastElement.depth) {
-                results.push(newNode);
+                // Strapi includes a field called `depth` for a heading
+                // i.e. depth = 2 --> H2, etc.
+                // For TOC we only want H2 and above by default
+                if (!node.depth || node.depth <= minHeadingSize) {
+                    results.push(newNode);
+                }
             } else {
                 lastElement.children.push(newNode);
             }


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-660/)
[JIRA](https://jira.mongodb.org/browse/DEVHUB-660)

This PR updates logic for Strapi headings in which we only want H2 and larger to show on the TOC. Previously we were showing any heading. This does not impact Snooty articles.