### PR TITLE
DEVHUB-653: Properly render anchor tags from Strapi

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -35,6 +35,14 @@ const Link = React.forwardRef(
                 </DevHubLink>
             );
         }
+        if (anchor) {
+            // We don't want any target="_blank" to apply
+            return (
+                <DevHubLink ref={ref} href={to} {...other} target="_self">
+                    {children}
+                </DevHubLink>
+            );
+        }
         return (
             <DevHubLink ref={ref} href={to} {...other}>
                 {children}


### PR DESCRIPTION
[Staging Article](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-653/)
[JIRA](https://jira.mongodb.org/browse/DEVHUB-653)

This PR fixes anchor tags from Strapi. We had a case in `Link` to check for an anchor but we didn't explicitly remove any `target="_blank"` and so this was giving some wonky effects.