### PR TITLE
Null Check Author Images from Strapi

### DIFF
--- a/src/utils/setup/transform-author-strapi-data.js
+++ b/src/utils/setup/transform-author-strapi-data.js
@@ -1,5 +1,5 @@
 export const transformAuthorStrapiData = author => ({
     ...author,
-    author_image: author.image.url,
-    image: author.image.url,
+    author_image: author.image && author.image.url,
+    image: author.image && author.image.url,
 });


### PR DESCRIPTION
In Strapi, we would fail a build if an author was provided without an image. This should not happen. Here we null check properly.