### PR TITLE
Remove unused debug param since signature changed

### DIFF
--- a/src/classes/strapi-article.ts
+++ b/src/classes/strapi-article.ts
@@ -38,8 +38,7 @@ export class StrapiArticle implements Article {
             'type',
             'heading',
             2,
-            -1,
-            true
+            -1
         );
         this.image = mappedArticle.image;
         this.languages = mapTagTypeToUrl(


### PR DESCRIPTION
This PR fixes a bug where we had an extra old param for the heading nodes. Removing this fixes TOC for Strapi articles.