### PR TITLE
Use Component Factory to compose styles

### DIFF
--- a/src/components/Emphasis.js
+++ b/src/components/Emphasis.js
@@ -1,8 +1,12 @@
 import React from 'react';
-import { getNestedValue } from '../utils/get-nested-value';
+import ComponentFactory from './ComponentFactory';
 
 const Emphasis = ({ nodeData }) => (
-    <em>{getNestedValue(['children', 0, 'value'], nodeData)}</em>
+    <em>
+        {nodeData.children.map((child, index) => (
+            <ComponentFactory nodeData={child} key={index} />
+        ))}
+    </em>
 );
 
 export default Emphasis;

--- a/src/components/Reference.js
+++ b/src/components/Reference.js
@@ -1,13 +1,15 @@
 import React from 'react';
 import Link from './Link';
-import { getNestedValue } from '~utils/get-nested-value';
+import ComponentFactory from './ComponentFactory';
 import { makeLinkInternalIfApplicable } from '~utils/make-link-internal-if-applicable';
 
 const Reference = ({ nodeData }) => {
     const link = makeLinkInternalIfApplicable(nodeData.refuri || nodeData.url);
     return (
         <Link className="reference" to={link} target="_blank">
-            {getNestedValue(['children', 0, 'value'], nodeData)}
+            {nodeData.children.map((child, index) => (
+                <ComponentFactory nodeData={child} key={index} />
+            ))}
         </Link>
     );
 };

--- a/src/components/Strong.js
+++ b/src/components/Strong.js
@@ -1,9 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { getNestedValue } from '../utils/get-nested-value';
+import ComponentFactory from './ComponentFactory';
 
 const Strong = ({ nodeData }) => (
-    <strong>{getNestedValue(['children', 0, 'value'], nodeData)}</strong>
+    <strong>
+        {nodeData.children.map((child, index) => (
+            <ComponentFactory nodeData={child} key={index} />
+        ))}
+    </strong>
 );
 
 Strong.propTypes = {

--- a/tests/unit/__snapshots__/Emphasis.test.js.snap
+++ b/tests/unit/__snapshots__/Emphasis.test.js.snap
@@ -2,6 +2,19 @@
 
 exports[`renders correctly 1`] = `
 <em>
-  Step 3
+  <ComponentFactory
+    key="0"
+    nodeData={
+      Object {
+        "position": Object {
+          "start": Object {
+            "line": 2,
+          },
+        },
+        "type": "text",
+        "value": "Step 3",
+      }
+    }
+  />
 </em>
 `;

--- a/tests/unit/__snapshots__/Strong.test.js.snap
+++ b/tests/unit/__snapshots__/Strong.test.js.snap
@@ -2,6 +2,19 @@
 
 exports[`renders correctly 1`] = `
 <strong>
-  first
+  <ComponentFactory
+    key="0"
+    nodeData={
+      Object {
+        "position": Object {
+          "start": Object {
+            "line": 0,
+          },
+        },
+        "type": "text",
+        "value": "first",
+      }
+    }
+  />
 </strong>
 `;


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/CI/devhub/jordanstapinski/use-factory-for-composition/)

This PR makes an improvement to how we render `emphasis` (italics), bold, and links. Previously, we assumed the initial child of this node was text. However, this may be a link, or some other node. As a result, we want to pass the node's children again through the component factory to compose all needed styles.