### PR TITLE
Correctly get Strapi preview URLs for social share

### DIFF
--- a/src/classes/strapi-article.ts
+++ b/src/classes/strapi-article.ts
@@ -53,7 +53,6 @@ export class StrapiArticle implements Article {
         );
         this.publishedDate = toISODate(mappedArticle.published_at);
         this.related = mappedArticle.related;
-        console.log(mappedArticle.SEO);
         this.SEO = mappedArticle.SEO;
         this.slug = mappedArticle.slug;
         this.tags = mapTagTypeToUrl(mappedArticle.tags, 'tag', true);

--- a/src/classes/strapi-article.ts
+++ b/src/classes/strapi-article.ts
@@ -53,6 +53,7 @@ export class StrapiArticle implements Article {
         );
         this.publishedDate = toISODate(mappedArticle.published_at);
         this.related = mappedArticle.related;
+        console.log(mappedArticle.SEO);
         this.SEO = mappedArticle.SEO;
         this.slug = mappedArticle.slug;
         this.tags = mapTagTypeToUrl(mappedArticle.tags, 'tag', true);

--- a/src/utils/transform-article-strapi-data.js
+++ b/src/utils/transform-article-strapi-data.js
@@ -34,7 +34,7 @@ export const transformArticleStrapiData = article => {
             metaDescription: SEOObject.meta_description,
             og: {
                 description: SEOObject.og_description,
-                image: SEOObject.og_image,
+                image: SEOObject.og_image && SEOObject.og_image.url,
                 title: article.name,
                 type: SEOObject.og_type,
                 url: SEOObject.og_url,
@@ -42,7 +42,7 @@ export const transformArticleStrapiData = article => {
             twitter: {
                 creator: SEOObject.twitter_creator,
                 description: SEOObject.twitter_description,
-                image: SEOObject.twitter_image,
+                image: SEOObject.twitter_image && SEOObject.twitter_image.url,
                 site: SEOObject.twitter_site,
                 title: SEOObject.twitter_title,
             },


### PR DESCRIPTION
[Staging Strapi Article
](https://docs-mongodbcom-staging.corp.mongodb.com/CI/devhub/jordanstapinski/use-image-url-social-share/how-to/realm-graphql-demo-custom-resolvers/)

This PR fixes a bug where we were not parsing the image URL for og and twitter images, meaning social share wouldn't render an image