### PR TITLE
DEVHUB-651: Add Table, TableRow, and TableCell support for Strapi

### DIFF
--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -45,6 +45,9 @@ import Subscript from './Subscript';
 import Superscript from './Superscript';
 import SubstitutionReference from './SubstitutionReference';
 import Tabs from './dev-hub/tabs';
+import Table from './Table';
+import TableCell from './TableCell';
+import TableRow from './TableRow';
 import Target from './Target';
 import Text from './Text';
 import TitleReference from './TitleReference';
@@ -121,6 +124,9 @@ export default class ComponentFactory extends Component {
             substitution_reference: SubstitutionReference,
             superscript: Superscript,
             tabs: Tabs,
+            table: Table,
+            tableCell: TableCell,
+            tableRow: TableRow,
             target: Target,
             text: Text,
             title_reference: TitleReference,

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import ComponentFactory from './ComponentFactory';
+import { getNestedValue } from '../utils/get-nested-value';
+import styled from '@emotion/styled';
+import { colorMap, size } from '../components/dev-hub/theme';
+
+const StyledTable = styled('table')`
+    border: 1px solid ${colorMap.greyLightTwo};
+    border-collapse: collapse;
+    margin: ${size.default} 0;
+    table-layout: fixed;
+    th,
+    td {
+        padding: ${size.small};
+        border: 1px solid ${colorMap.greyLightTwo};
+    }
+`;
+
+const TableContainer = styled('div')`
+    overflow-x: auto;
+`;
+
+const AlignedTH = styled('th')`
+    text-align: ${({ alignment }) => alignment};
+`;
+
+const TableHeading = ({ align, headingRow }) => (
+    <thead valign="bottom">
+        <tr>
+            {headingRow.map((column, colIndex) => (
+                <AlignedTH alignment={align[colIndex]} key={colIndex}>
+                    <ComponentFactory
+                        nodeData={getNestedValue(['children', 0], column)}
+                    />
+                </AlignedTH>
+            ))}
+        </tr>
+    </thead>
+);
+
+const Table = ({ nodeData: { align, children } }) => {
+    if (children && children.length) {
+        const headingRow = children[0] && children[0].children;
+        const otherRows = children.slice(1);
+        return (
+            <TableContainer>
+                <StyledTable>
+                    <TableHeading align={align} headingRow={headingRow} />
+                    {otherRows.map((data, i) => (
+                        <ComponentFactory
+                            nodeData={{ align, ...data }}
+                            key={i}
+                        />
+                    ))}
+                </StyledTable>
+            </TableContainer>
+        );
+    }
+};
+
+export default Table;

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -1,8 +1,12 @@
 import React from 'react';
 import ComponentFactory from './ComponentFactory';
-import { getNestedValue } from '../utils/get-nested-value';
+import { getNestedValue } from '~utils/get-nested-value';
 import styled from '@emotion/styled';
-import { colorMap, size } from '../components/dev-hub/theme';
+import { colorMap, size } from '~components/dev-hub/theme';
+
+const AlignedTH = styled('th')`
+    text-align: ${({ alignment }) => alignment};
+`;
 
 const StyledTable = styled('table')`
     border: 1px solid ${colorMap.greyLightTwo};
@@ -20,10 +24,6 @@ const TableContainer = styled('div')`
     overflow-x: auto;
 `;
 
-const AlignedTH = styled('th')`
-    text-align: ${({ alignment }) => alignment};
-`;
-
 const TableHeading = ({ align, headingRow }) => (
     <thead valign="bottom">
         <tr>
@@ -39,14 +39,15 @@ const TableHeading = ({ align, headingRow }) => (
 );
 
 const Table = ({ nodeData: { align, children } }) => {
-    if (children && children.length) {
-        const headingRow = children[0] && children[0].children;
+    if (children?.length) {
+        const headingRow = children[0]?.children || [];
         const otherRows = children.slice(1);
         return (
             <TableContainer>
                 <StyledTable>
                     <TableHeading align={align} headingRow={headingRow} />
                     {otherRows.map((data, i) => (
+                        // Pass the align array so we can apply alignment in TableCell
                         <ComponentFactory
                             nodeData={{ align, ...data }}
                             key={i}

--- a/src/components/TableCell.js
+++ b/src/components/TableCell.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import ComponentFactory from './ComponentFactory';
+
+const AlignedTD = styled('td')`
+    text-align: ${({ alignment }) => alignment};
+`;
+
+const TableCell = ({ nodeData: { align, children, index } }) => {
+    const alignmentOption = align && index !== null && align[index];
+    return (
+        <AlignedTD alignment={alignmentOption}>
+            {children.map((column, colIndex) => (
+                <ComponentFactory nodeData={column} key={colIndex} />
+            ))}
+        </AlignedTD>
+    );
+};
+
+export default TableCell;

--- a/src/components/TableRow.js
+++ b/src/components/TableRow.js
@@ -5,6 +5,7 @@ const TableRow = ({ nodeData: { align, children } }) => (
     <tr>
         {children.map((column, index) => (
             <ComponentFactory
+                // Pass the align array so we can apply alignment in TableCell
                 nodeData={{ align, index, ...column }}
                 key={index}
             />

--- a/src/components/TableRow.js
+++ b/src/components/TableRow.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import ComponentFactory from './ComponentFactory';
+
+const TableRow = ({ nodeData: { align, children } }) => (
+    <tr>
+        {children.map((column, index) => (
+            <ComponentFactory
+                nodeData={{ align, index, ...column }}
+                key={index}
+            />
+        ))}
+    </tr>
+);
+
+export default TableRow;


### PR DESCRIPTION
[Staging (article with table)](https://docs-mongodbcom-staging.corp.mongodb.com/CI/devhub/jordanstapinski/DEVHUB-651/how-to/realm-test/#fourth-heading)
[JIRA](https://jira.mongodb.org/browse/DEVHUB-651)

This PR adds support for three new directives which are Strapi-exclusive to use tables. The Snooty `ListTable` concept really doesn't map well to the Markdown concept of a Table. Also, these tables support embedding images, inline code, etc!

This is not in production use yet, the above article is just one for testing Strapi rendering.