### PR TITLE
DEVHUB-670: Don't sort by date for search results

### DIFF
--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -84,6 +84,8 @@ export default React.memo(
         articles = articles || [];
         podcasts = podcasts || [];
 
+        // If we provide "all", we don't need to sort. We can assume any sorting
+        // has been done
         const fullContentList =
             all || sortCardsByDate(videos.concat(articles, podcasts));
 

--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -79,14 +79,13 @@ const renderContentTypeCard = (item, openAudio) => {
 };
 
 export default React.memo(
-    ({ videos, articles, podcasts, limit = CARD_LIST_LIMIT }) => {
+    ({ all, videos, articles, podcasts, limit = CARD_LIST_LIMIT }) => {
         videos = videos || [];
         articles = articles || [];
         podcasts = podcasts || [];
 
-        const fullContentList = sortCardsByDate(
-            videos.concat(articles, podcasts)
-        );
+        const fullContentList =
+            all || sortCardsByDate(videos.concat(articles, podcasts));
 
         const [activePodcast, setActivePodcast] = useState(false);
 

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -13,7 +13,6 @@ import { screenSize, size } from '../components/dev-hub/theme';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 import { buildQueryString, parseQueryString } from '../utils/query-string';
 import { getFeaturedCardFields } from '../utils/get-featured-card-fields';
-import { getTagLinksFromMeta } from '../utils/get-tag-links-from-meta';
 import { LearnPageTabs } from '../utils/learn-page-tabs';
 import useAllVideos from '../hooks/use-all-videos';
 import usePodcasts from '../hooks/use-podcasts';
@@ -363,7 +362,7 @@ export default ({
 
                 {showTextFilterResults ? (
                     textFilterResults.length ? (
-                        <CardList articles={textFilterResults} />
+                        <CardList all={textFilterResults} />
                     ) : (
                         <EmptyTextFilterResults />
                     )


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-670/)

This PR fixes a long-standing bug where search results on the learn page were being sorted by date. This was not present in the top searchbar. As a result of this PR, the searchbar is now in sync with the learn page.