### PR TITLE
Podcasts: Add Exposed Links for Social Sharing

### DIFF
--- a/src/components/dev-hub/article-share-footer.js
+++ b/src/components/dev-hub/article-share-footer.js
@@ -1,73 +1,34 @@
-import React, { useCallback } from 'react';
-import copy from 'copy-to-clipboard';
+import React from 'react';
 import styled from '@emotion/styled';
-import { getArticleShareLinks } from '../../utils/get-article-share-links';
 import BlogTagList from './blog-tag-list';
 import { screenSize, size } from './theme';
-import Link from './link';
-import Tooltip from './tooltip';
-import LinkIcon from './icons/link-icon';
-import LinkedIn from './icons/linkedin';
-import FacebookIcon from './icons/facebook-icon';
-import TwitterIcon from './icons/twitter-icon';
+import BlogShareLinks from './blog-share-links';
 
 const ArticleShareArea = styled('div')`
     border-top: 1px solid ${({ theme }) => theme.colorMap.greyDarkTwo};
     display: flex;
     justify-content: space-between;
     margin-bottom: ${size.large};
-    margin-top: ${size.xlarge};
+    margin-top: ${size.large};
     padding-top: ${size.medium};
-    @media ${screenSize.upToMedium} {
-        margin-top: ${size.large};
-    }
 `;
 
-const BlogShareLinks = styled('div')`
+const StyledBlogShareLinks = styled(BlogShareLinks)`
     /* The initial footer element is a span, so this works given the initial element does not have any margin applied to give spacing */
     a {
         margin-left: ${size.medium};
     }
 `;
 
-const ArticleShareFooter = ({ tags, title, url, tooltipText, ...props }) => {
-    const {
-        articleUrl,
-        facebookUrl,
-        linkedInUrl,
-        twitterUrl,
-    } = getArticleShareLinks(title, url);
-    const onCopyLink = useCallback(() => {
-        copy(articleUrl);
-    }, [articleUrl]);
-    return (
-        <ArticleShareArea {...props}>
-            <BlogTagList tags={tags} />
-            <BlogShareLinks data-test="article-share-links">
-                <Tooltip
-                    position="bottom"
-                    trigger={
-                        <Link onClick={onCopyLink}>
-                            <LinkIcon />
-                        </Link>
-                    }
-                >
-                    {tooltipText || 'Article link copied to clipboard!'}
-                </Tooltip>
-
-                <Link target="_blank" href={linkedInUrl}>
-                    <LinkedIn />
-                </Link>
-
-                <Link target="_blank" href={twitterUrl}>
-                    <TwitterIcon />
-                </Link>
-                <Link target="_blank" href={facebookUrl}>
-                    <FacebookIcon height="22" width="22" />
-                </Link>
-            </BlogShareLinks>
-        </ArticleShareArea>
-    );
-};
+const ArticleShareFooter = ({ tags, title, url, ...props }) => (
+    <ArticleShareArea {...props}>
+        <BlogTagList tags={tags} />
+        <StyledBlogShareLinks
+            title={title}
+            url={url}
+            data-test="article-share-links"
+        />
+    </ArticleShareArea>
+);
 
 export default ArticleShareFooter;

--- a/src/components/dev-hub/article-share-footer.js
+++ b/src/components/dev-hub/article-share-footer.js
@@ -5,6 +5,7 @@ import { size } from './theme';
 import BlogShareLinks from './blog-share-links';
 
 const ArticleShareArea = styled('div')`
+    align-items: center;
     border-top: 1px solid ${({ theme }) => theme.colorMap.greyDarkTwo};
     display: flex;
     justify-content: space-between;
@@ -14,6 +15,7 @@ const ArticleShareArea = styled('div')`
 `;
 
 const StyledBlogShareLinks = styled(BlogShareLinks)`
+    height: fit-content;
     /* The initial footer element is a span, so this works given the initial element does not have any margin applied to give spacing */
     a {
         margin-left: ${size.medium};

--- a/src/components/dev-hub/article-share-footer.js
+++ b/src/components/dev-hub/article-share-footer.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import BlogTagList from './blog-tag-list';
-import { screenSize, size } from './theme';
+import { size } from './theme';
 import BlogShareLinks from './blog-share-links';
 
 const ArticleShareArea = styled('div')`

--- a/src/components/dev-hub/article-share-footer.js
+++ b/src/components/dev-hub/article-share-footer.js
@@ -20,10 +20,11 @@ const StyledBlogShareLinks = styled(BlogShareLinks)`
     }
 `;
 
-const ArticleShareFooter = ({ tags, title, url, ...props }) => (
+const ArticleShareFooter = ({ tags, title, tooltipText, url, ...props }) => (
     <ArticleShareArea {...props}>
         <BlogTagList tags={tags} />
         <StyledBlogShareLinks
+            tooltipText={tooltipText}
             title={title}
             url={url}
             data-test="article-share-links"

--- a/src/components/dev-hub/blog-share-links.js
+++ b/src/components/dev-hub/blog-share-links.js
@@ -19,7 +19,7 @@ const BlogShareContainer = styled('div')`
     display: flex;
 `;
 
-const BlogShareLink = styled(Link)`
+export const BlogShareLink = styled(Link)`
     display: inline-block;
     height: ${size.default};
     line-height: ${size.default};

--- a/src/components/dev-hub/blog-share-links.js
+++ b/src/components/dev-hub/blog-share-links.js
@@ -29,6 +29,7 @@ const BlogShareLinks = ({
     iconSize = size.default,
     tags,
     title,
+    tooltipText,
     url,
     ...props
 }) => {
@@ -51,7 +52,7 @@ const BlogShareLinks = ({
                     </BlogShareLink>
                 }
             >
-                Article link copied to clipboard!
+                {tooltipText || 'Article link copied to clipboard!'}
             </StyledTooltip>
 
             <BlogShareLink target="_blank" href={linkedInUrl}>

--- a/src/components/dev-hub/blog-share-links.js
+++ b/src/components/dev-hub/blog-share-links.js
@@ -1,0 +1,71 @@
+import React, { useCallback } from 'react';
+import copy from 'copy-to-clipboard';
+import styled from '@emotion/styled';
+import { getArticleShareLinks } from '../../utils/get-article-share-links';
+import { size } from './theme';
+import LinkIcon from './icons/link-icon';
+import LinkedIn from './icons/linkedin';
+import FacebookIcon from './icons/facebook-icon';
+import TwitterIcon from './icons/twitter-icon';
+import Link from './link';
+import Tooltip from './tooltip';
+
+const BlogShareContainer = styled('div')`
+    display: flex;
+`;
+
+const BlogShareLink = styled(Link)`
+    display: inline-block;
+    height: ${size.default};
+    line-height: ${size.default};
+    width: ${size.default};
+`;
+
+const StyledTooltip = styled(Tooltip)`
+    line-height: ${size.default};
+`;
+
+const BlogShareLinks = ({
+    iconSize = size.default,
+    tags,
+    title,
+    url,
+    ...props
+}) => {
+    const {
+        articleUrl,
+        facebookUrl,
+        linkedInUrl,
+        twitterUrl,
+    } = getArticleShareLinks(title, url);
+    const onCopyLink = useCallback(() => {
+        copy(articleUrl);
+    }, [articleUrl]);
+    return (
+        <BlogShareContainer {...props}>
+            <StyledTooltip
+                position="right"
+                trigger={
+                    <BlogShareLink onClick={onCopyLink}>
+                        <LinkIcon height={iconSize} width={iconSize} />
+                    </BlogShareLink>
+                }
+            >
+                Article link copied to clipboard!
+            </StyledTooltip>
+
+            <BlogShareLink target="_blank" href={linkedInUrl}>
+                <LinkedIn height={iconSize} width={iconSize} />
+            </BlogShareLink>
+
+            <BlogShareLink target="_blank" href={twitterUrl}>
+                <TwitterIcon height={iconSize} width={iconSize} />
+            </BlogShareLink>
+            <BlogShareLink target="_blank" href={facebookUrl}>
+                <FacebookIcon height={iconSize} width={iconSize} />
+            </BlogShareLink>
+        </BlogShareContainer>
+    );
+};
+
+export default BlogShareLinks;

--- a/src/components/dev-hub/blog-share-links.js
+++ b/src/components/dev-hub/blog-share-links.js
@@ -63,16 +63,20 @@ const BlogShareLinks = ({
 
     return (
         <BlogShareContainer {...props}>
-            <BlogShareLink onClick={onCopyLink} css={showCopyMessage && hide}>
-                <LinkIcon height={iconSize} width={iconSize} />
-            </BlogShareLink>
-
             <BlogShareLink
+                consistentHoverColor={showCopyMessage}
                 onClick={onCopyLink}
-                css={!showCopyMessage && hide}
-                consistentHoverColor={true}
             >
-                <SuccessIcon height={iconSize} width={iconSize} />
+                <LinkIcon
+                    css={showCopyMessage && hide}
+                    height={iconSize}
+                    width={iconSize}
+                />
+                <SuccessIcon
+                    css={!showCopyMessage && hide}
+                    height={iconSize}
+                    width={iconSize}
+                />
             </BlogShareLink>
 
             <BlogShareLink target="_blank" href={linkedInUrl}>

--- a/src/components/dev-hub/blog-share-links.js
+++ b/src/components/dev-hub/blog-share-links.js
@@ -1,14 +1,19 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import copy from 'copy-to-clipboard';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { getArticleShareLinks } from '../../utils/get-article-share-links';
 import { size } from './theme';
+import SuccessIcon from './icons/success';
 import LinkIcon from './icons/link-icon';
 import LinkedIn from './icons/linkedin';
 import FacebookIcon from './icons/facebook-icon';
 import TwitterIcon from './icons/twitter-icon';
 import Link from './link';
-import Tooltip from './tooltip';
+
+const hide = css`
+    display: none;
+`;
 
 const BlogShareContainer = styled('div')`
     display: flex;
@@ -19,10 +24,16 @@ const BlogShareLink = styled(Link)`
     height: ${size.default};
     line-height: ${size.default};
     width: ${size.default};
-`;
-
-const StyledTooltip = styled(Tooltip)`
-    line-height: ${size.default};
+    cursor: pointer;
+    path {
+        fill: ${({ theme }) => theme.colorMap.greyLightTwo};
+    }
+    &:hover {
+        path {
+            fill: ${({ consistentHoverColor, theme }) =>
+                !consistentHoverColor && theme.colorMap.devWhite};
+        }
+    }
 `;
 
 const BlogShareLinks = ({
@@ -39,21 +50,30 @@ const BlogShareLinks = ({
         linkedInUrl,
         twitterUrl,
     } = getArticleShareLinks(title, url);
-    const onCopyLink = useCallback(() => {
-        copy(articleUrl);
-    }, [articleUrl]);
+    const [showCopyMessage, setShowCopyMessage] = useState(false);
+    const onCopyLink = useCallback(
+        e => {
+            e.preventDefault();
+            copy(articleUrl);
+            setShowCopyMessage(true);
+            setTimeout(() => setShowCopyMessage(false), 2000);
+        },
+        [articleUrl]
+    );
+
     return (
         <BlogShareContainer {...props}>
-            <StyledTooltip
-                position="right"
-                trigger={
-                    <BlogShareLink onClick={onCopyLink}>
-                        <LinkIcon height={iconSize} width={iconSize} />
-                    </BlogShareLink>
-                }
+            <BlogShareLink onClick={onCopyLink} css={showCopyMessage && hide}>
+                <LinkIcon height={iconSize} width={iconSize} />
+            </BlogShareLink>
+
+            <BlogShareLink
+                onClick={onCopyLink}
+                css={!showCopyMessage && hide}
+                consistentHoverColor={true}
             >
-                {tooltipText || 'Article link copied to clipboard!'}
-            </StyledTooltip>
+                <SuccessIcon height={iconSize} width={iconSize} />
+            </BlogShareLink>
 
             <BlogShareLink target="_blank" href={linkedInUrl}>
                 <LinkedIn height={iconSize} width={iconSize} />

--- a/src/components/dev-hub/contents-menu.js
+++ b/src/components/dev-hub/contents-menu.js
@@ -79,7 +79,7 @@ const ContentsMenu = ({ title, headingNodes, ...props }) => {
             hasGradientBorder
             isOpen={isOpen}
             setIsOpen={setIsOpen}
-            position={'right'}
+            position="right"
             trigger={
                 <HoverTooltip
                     trigger={

--- a/src/components/dev-hub/controlled-tooltip.js
+++ b/src/components/dev-hub/controlled-tooltip.js
@@ -4,7 +4,10 @@ import { css } from '@emotion/react';
 import Popover from 'react-tiny-popover';
 import { animationSpeed, layer, size } from './theme';
 
-const ControlledTooltipWrapper = styled('span')`
+const ControlledTooltipWrapper = styled('div')`
+    display: inline-block;
+    line-height: ${size.default};
+    height: ${size.default};
     /* Article sets these values */
     padding: 0 !important;
 `;
@@ -211,8 +214,11 @@ const Content = styled('div')`
         getArrowStyles(hasGradientBorder, position, theme)}
 `;
 
-const Trigger = styled('span')`
+const Trigger = styled('div')`
     cursor: pointer;
+    line-height: ${size.default};
+    display: inline-block;
+    height: ${size.default};
 `;
 
 // This logic was pulled from 'react-tiny-popover' (see = https://github.com/alexkatz/react-tiny-popover/blob/3928cfa67a57676f32d5f04b3e1decb8c31db544/src/Popover.tsx#L316-L352)
@@ -279,6 +285,7 @@ const ControlledTooltip = ({
     contentStyle,
     isOpen,
     setIsOpen,
+    ...props
 }) => {
     const ref = useRef(null);
 
@@ -305,7 +312,7 @@ const ControlledTooltip = ({
           };
 
     return (
-        <ControlledTooltipWrapper ref={ref}>
+        <ControlledTooltipWrapper ref={ref} {...props}>
             <Popover
                 contentLocation={contentLocation(TOOLTIP_DISTANCE)}
                 content={

--- a/src/components/dev-hub/hover-tooltip.js
+++ b/src/components/dev-hub/hover-tooltip.js
@@ -8,13 +8,13 @@ import { size } from './theme';
  * @property {node} props.trigger
  * @property {string} props.text
  */
-const HoverTooltip = ({ trigger, text }) => (
+const HoverTooltip = ({ position = 'bottom', trigger, text }) => (
     <Tooltip
         contentStyle={css`
             padding: ${size.tiny};
         `}
         displayOnHover
-        position="bottom"
+        position={position}
         trigger={trigger}
     >
         <P4 collapse>{text}</P4>

--- a/src/components/dev-hub/icons/link-icon.js
+++ b/src/components/dev-hub/icons/link-icon.js
@@ -8,7 +8,7 @@ const LinkIcon = ({ color, ...props }) => {
         <svg
             aria-label="Link"
             height="20"
-            viewBox="0 0 515 515"
+            viewBox="0 0 540 500"
             width="20"
             {...props}
         >

--- a/src/components/dev-hub/icons/linkedin.js
+++ b/src/components/dev-hub/icons/linkedin.js
@@ -7,8 +7,8 @@ const LinkedIn = ({ color, ...props }) => {
     return (
         <svg
             aria-label="LinkedIn"
-            width="20"
-            height="20"
+            width="16"
+            height="16"
             viewBox="0 0 635 540"
             {...props}
         >

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -51,6 +51,14 @@ const Container = styled('div')`
         justify-content: center;
     }
 `;
+const SpacedShareMenu = styled(ShareMenu)`
+    margin-left: ${size.default};
+    @media ${screenSize.largeAndUp} {
+        margin-left: 0;
+        margin-top: ${size.default};
+    }
+`;
+
 const Article = props => {
     const {
         pageContext: {
@@ -128,7 +136,7 @@ const Article = props => {
                         height={size.default}
                         width={size.default}
                     />
-                    <ShareMenu
+                    <SpacedShareMenu
                         title={title}
                         url={articleUrl}
                         height={size.default}

--- a/src/templates/podcast.js
+++ b/src/templates/podcast.js
@@ -7,7 +7,9 @@ import Layout from '~components/dev-hub/layout';
 import PodcastJumbotron from '~components/dev-hub/podcast-jumbotron';
 import SEO from '~components/dev-hub/SEO';
 import ShareFooter from '~components/dev-hub/article-share-footer';
-import BlogShareLinks from '../components/dev-hub/blog-share-links';
+import BlogShareLinks, {
+    BlogShareLink,
+} from '../components/dev-hub/blog-share-links';
 import { P } from '~components/dev-hub/text';
 import { addTrailingSlashIfMissing } from '~utils/add-trailing-slash-if-missing';
 import { useSiteMetadata } from '~hooks/use-site-metadata';
@@ -98,7 +100,7 @@ const StyledBlogShareLinks = styled(BlogShareLinks)`
 
 const StyledFooter = styled(ShareFooter)`
     /* Target the copy link, although it is below some divs */
-    div > a:first-of-type {
+    ${BlogShareLink}:first-of-type {
         margin-left: 0;
     }
 `;

--- a/src/templates/podcast.js
+++ b/src/templates/podcast.js
@@ -98,7 +98,7 @@ const StyledBlogShareLinks = styled(BlogShareLinks)`
 
 const StyledFooter = styled(ShareFooter)`
     /* Target the copy link, although it is below some divs */
-    div > div > a {
+    div > a:first-of-type {
         margin-left: 0;
     }
 `;

--- a/src/templates/podcast.js
+++ b/src/templates/podcast.js
@@ -83,7 +83,7 @@ const StyledPlayer = styled(AudioPlayer)`
 const StyledBlogShareLinks = styled(BlogShareLinks)`
     flex-direction: column;
     align-items: center;
-    > * {
+    > :not(:first-child) {
         margin-top: ${size.medium};
     }
     @media ${screenSize.upToLarge} {
@@ -93,6 +93,13 @@ const StyledBlogShareLinks = styled(BlogShareLinks)`
             margin-top: 0;
             margin-left: ${size.mediumLarge};
         }
+    }
+`;
+
+const StyledFooter = styled(ShareFooter)`
+    /* Target the copy link, although it is below some divs */
+    div > div > a {
+        margin-left: 0;
     }
 `;
 
@@ -163,7 +170,7 @@ const Podcast = ({
                 <Content>
                     <StyledPlayer podcast={podcastUrl} />
                     <StyledParagraph>{description}</StyledParagraph>
-                    <ShareFooter
+                    <StyledFooter
                         title={title}
                         tooltipText={TOOLTIP_TEXT}
                         url={pageUrl}

--- a/src/templates/podcast.js
+++ b/src/templates/podcast.js
@@ -164,6 +164,7 @@ const Podcast = ({
                     <StyledBlogShareLinks
                         position="right"
                         title={title}
+                        tooltipText={TOOLTIP_TEXT}
                         url={pageUrl}
                     />
                 </Icons>

--- a/src/templates/podcast.js
+++ b/src/templates/podcast.js
@@ -1,19 +1,16 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-
 import ArticleSchema from '~components/dev-hub/article-schema';
 import AudioPlayer from '~components/dev-hub/podcast-player/audio-player';
 import Layout from '~components/dev-hub/layout';
 import PodcastJumbotron from '~components/dev-hub/podcast-jumbotron';
 import SEO from '~components/dev-hub/SEO';
 import ShareFooter from '~components/dev-hub/article-share-footer';
-import ShareMenu from '~components/dev-hub/share-menu';
+import BlogShareLinks from '../components/dev-hub/blog-share-links';
 import { P } from '~components/dev-hub/text';
-
 import { addTrailingSlashIfMissing } from '~utils/add-trailing-slash-if-missing';
 import { useSiteMetadata } from '~hooks/use-site-metadata';
-
 import { lineHeight, screenSize, size } from '~components/dev-hub/theme';
 import { toDateString } from '~utils/format-dates';
 import { dateFormatOptions } from '~src/constants';
@@ -83,6 +80,22 @@ const StyledPlayer = styled(AudioPlayer)`
     }
 `;
 
+const StyledBlogShareLinks = styled(BlogShareLinks)`
+    flex-direction: column;
+    align-items: center;
+    > * {
+        margin-top: ${size.medium};
+    }
+    @media ${screenSize.upToLarge} {
+        display: inline-flex;
+        flex-direction: row;
+        > * {
+            margin-top: 0;
+            margin-left: ${size.mediumLarge};
+        }
+    }
+`;
+
 const Podcast = ({
     pageContext: {
         data: {
@@ -141,11 +154,10 @@ const Podcast = ({
             />
             <Container>
                 <Icons>
-                    <ShareMenu
-                        height={size.default}
+                    <StyledBlogShareLinks
+                        position="right"
                         title={title}
                         url={pageUrl}
-                        width={size.default}
                     />
                 </Icons>
                 <Content>

--- a/src/templates/podcast.js
+++ b/src/templates/podcast.js
@@ -81,17 +81,17 @@ const StyledPlayer = styled(AudioPlayer)`
 `;
 
 const StyledBlogShareLinks = styled(BlogShareLinks)`
-    flex-direction: column;
     align-items: center;
+    flex-direction: column;
     > :not(:first-child) {
         margin-top: ${size.medium};
     }
     @media ${screenSize.upToLarge} {
         display: inline-flex;
         flex-direction: row;
-        > * {
-            margin-top: 0;
+        > :not(:first-child) {
             margin-left: ${size.mediumLarge};
+            margin-top: 0;
         }
     }
 `;


### PR DESCRIPTION
[Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/add-exposed-links/)

This PR mimics #804 to expose the links on the sides for the podcast pages. I also made sure to keep the tooltip text customizable. This way, if this project is ready for production first it can be deployed without the need for the devhub feedback project to be ready.