### PR TITLE
DEVHUB-666: Fix feedback missing title, authors, inconsistent slashes

### DIFF
--- a/src/components/dev-hub/feedback/feedback-container.js
+++ b/src/components/dev-hub/feedback/feedback-container.js
@@ -86,11 +86,11 @@ const FeedbackContainer = ({ starRatingFlow, articleMeta, closeModal }) => {
     const isLastModal = step === stepsCounter;
 
     useEffect(() => {
-        const { author, slug, title } = articleMeta;
+        const { authors, slug, title } = articleMeta;
         createFeedback({
-            authors: getAuthorsNames(author),
+            authors: getAuthorsNames(authors),
             slug,
-            title: title[0].value,
+            title,
             starRatingFlow,
         });
     }, [articleMeta, createFeedback, starRatingFlow]);

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -124,7 +124,7 @@ const Article = props => {
         },
         ...rest
     } = props;
-    const meta = { authors, slug, title };
+    const meta = { authors, slug: addTrailingSlashIfMissing(slug), title };
     const { siteUrl } = useSiteMetadata();
     const articleBreadcrumbs = [
         { label: 'Home', target: '/' },


### PR DESCRIPTION
[Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-666/)

After #792 we made some interface changes that were not properly updated on this feature branch to get the title and names for authors. This PR fixes those differences by getting `authors` instead of `author` and just uses `title` without needing to delve for a `value`