### PR TITLE
DEVHUB-665: Don't clear stars if is last modal

### DIFF
--- a/src/components/ArticleRatingContext.js
+++ b/src/components/ArticleRatingContext.js
@@ -27,14 +27,19 @@ const initialState = {
 const ratingReducer = (state, { type, value }) => {
     let nextState = { isClicked: false, stars: [...initialState.stars] };
     switch (type) {
+        // Fallthrough here is expected
         case STAR_ACTIONS.FIVE:
             nextState.stars[4] = true;
+        // eslint-disable-next-line no-fallthrough
         case STAR_ACTIONS.FOUR:
             nextState.stars[3] = true;
+        // eslint-disable-next-line no-fallthrough
         case STAR_ACTIONS.THREE:
             nextState.stars[2] = true;
+        // eslint-disable-next-line no-fallthrough
         case STAR_ACTIONS.TWO:
             nextState.stars[1] = true;
+        // eslint-disable-next-line no-fallthrough
         case STAR_ACTIONS.ONE:
             nextState.stars[0] = true;
             break;

--- a/src/components/dev-hub/feedback/feedback-container.js
+++ b/src/components/dev-hub/feedback/feedback-container.js
@@ -120,9 +120,11 @@ const FeedbackContainer = ({ starRatingFlow, articleMeta, closeModal }) => {
     //Sent form information and refresh rating logic
     const onCloseModalHandler = useCallback(() => {
         updateFeedback(formState);
-        ratingDispatch(STAR_ACTIONS.CLEAR);
+        if (!isLastModal) {
+            ratingDispatch(STAR_ACTIONS.CLEAR);
+        }
         closeModal();
-    }, [closeModal, formState, ratingDispatch, updateFeedback]);
+    }, [closeModal, formState, isLastModal, ratingDispatch, updateFeedback]);
 
     return isActiveModal ? (
         <Modal


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-665/)
[JIRA](https://jira.mongodb.org/browse/DEVHUB-665)

This PR changes the behavior of the last modal (confirmation) which allows the modal close behavior and the CTA button behavior to be the same. We will keep the star rating showing so long as they get to the last modal regardless of how they close out of it.

I also added some ESLint ignores for the fallthrough logic since it is intentional.