### PR TITLE
DEVHUB-625: Remove Modal Border, Add Last Modal Padding

### DIFF
--- a/src/components/dev-hub/feedback/feedback-container.js
+++ b/src/components/dev-hub/feedback/feedback-container.js
@@ -39,12 +39,12 @@ const modalStyles = css`
     min-width: ${MODAL_WIDTH};
 
     @media ${screenSize.upToMedium} {
+        border: none;
         height: 100%;
-        min-width: unset;
         max-width: unset;
-        width: 100%;
-        border-radius: 0;
+        min-width: unset;
         padding: 0;
+        width: 100%;
     }
 `;
 

--- a/src/components/dev-hub/feedback/feedback-container.js
+++ b/src/components/dev-hub/feedback/feedback-container.js
@@ -40,6 +40,7 @@ const modalStyles = css`
 
     @media ${screenSize.upToMedium} {
         border: none;
+        border-radius: 0;
         height: 100%;
         max-width: unset;
         min-width: unset;

--- a/src/components/dev-hub/feedback/feedback-final-step.js
+++ b/src/components/dev-hub/feedback/feedback-final-step.js
@@ -5,16 +5,24 @@ import Button from '~components/dev-hub/button';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import {
+    colorMap,
     fontSize,
     lineHeight,
+    screenSize,
     size,
-    colorMap,
 } from '~components/dev-hub/theme';
 import { FORUMS_URL } from '~src/constants';
 
 const changeColorOnHover = theme => css`
     &:hover {
         color: ${theme.colorMap.devWhite};
+    }
+`;
+
+const StyledContainer = styled('div')`
+    padding: 0 ${size.medium};
+    @media ${screenSize.upToMedium} {
+        padding: 0 40px;
     }
 `;
 
@@ -29,7 +37,16 @@ const StyledLink = styled(Link)`
 
 const StyledTitle = styled(H5)`
     margin-bottom: ${size.mediumLarge};
-    max-width: 50%;
+    /*
+        Hardcoding this in since 364px is the width with padding, we need more than
+        what 50% would give
+    */
+    max-width: 180px;
+    @media ${screenSize.upToMedium} {
+        margin-bottom: ${size.xsmall};
+        /* Font size decreases so we have to adjust max width */
+        max-width: 170px;
+    }
 `;
 
 const StyledDescription = styled(P)`
@@ -47,7 +64,7 @@ const StyledButtonContainer = styled('div')`
 `;
 
 const FeedbackFinalStep = ({ incrementStep }) => (
-    <>
+    <StyledContainer>
         <StyledTitle>We appreciate your feedback.</StyledTitle>
         <StyledDescription>
             We'd love to chat with you and answer your questions in our online{' '}
@@ -62,7 +79,7 @@ const FeedbackFinalStep = ({ incrementStep }) => (
                 Close
             </Button>
         </StyledButtonContainer>
-    </>
+    </StyledContainer>
 );
 
 export default memo(FeedbackFinalStep);


### PR DESCRIPTION
[Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-625-modal-styling/)
[Figma](https://www.figma.com/file/3p41Tj1q8K5T5wZzOMOiff/DevHub---Sentiment-Score?node-id=193%3A256)

This PR makes some changes to the style of the feedback modal. Specifically:
- Removes the border from the modal on mobile as it is full screen
- Adds padding to the last modal to be consistent with the other modals before