### PR TITLE
DEVHUB-625: Use consistent spacing for text elements on modals

### DIFF
--- a/src/components/dev-hub/feedback/feedback-form.js
+++ b/src/components/dev-hub/feedback/feedback-form.js
@@ -21,6 +21,13 @@ const IconContainer = styled('div')`
     }
 `;
 
+const SpacedOutText = styled('div')`
+    margin-bottom: ${size.mediumLarge};
+    @media ${screenSize.upToMedium} {
+        margin-bottom: ${size.large};
+    }
+`;
+
 const StyledButtonContainer = styled('div')`
     display: flex;
     justify-content: center;
@@ -50,7 +57,6 @@ const StyledButton = styled(Button)`
 `;
 
 const StyledDescription = styled(P)`
-    display: inline-block;
     font-family: Akzidenz;
     font-size: ${fontSize.small};
     line-height: ${lineHeight.small};
@@ -68,10 +74,14 @@ const FeedbackForm = ({ icon, ratingFlow = {}, onSubmit }) => {
             }}
         >
             {icon && <IconContainer>{icon}</IconContainer>}
-            {title && <StyledH5 collapse>{title}</StyledH5>}
-            {description && (
-                <StyledDescription>{description}</StyledDescription>
-            )}
+            <SpacedOutText>
+                {title && <StyledH5 collapse>{title}</StyledH5>}
+                {description && (
+                    <StyledDescription collapse>
+                        {description}
+                    </StyledDescription>
+                )}
+            </SpacedOutText>
 
             <CMSForm form={ratingFlow} />
 


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-625-inconsistent/)

This PR makes a change to the layout of the feedback form where we remove the `inline-block` display from the `description` and instead use a `div` to assign margin to the bottom. We noticed using the inline option was causing the space between the title and description to become inconsistent if the description spanned multiple lines.