### PR TITLE
DEVHUB-625: Use old check UX for copy, change hover color

### DIFF
--- a/cypress/integration/article.js
+++ b/cypress/integration/article.js
@@ -65,10 +65,12 @@ describe('Sample Article Page', () => {
     it('should have links to share content on social media', () => {
         cy.get('[data-test="article-share-links"]').within(() => {
             cy.get('a').each((link, index) => {
-                // Index 0 is the copy to clipboard functionality
+                // Index 0 is the copy to clipboard functionality and 1 is the
+                // check box
                 // TODO: UI test clipboard link copy
-                if (index !== 0) {
-                    const url = SOCIAL_URLS[index - 1];
+                const copyDOMOffset = 2;
+                if (index >= copyDOMOffset) {
+                    const url = SOCIAL_URLS[index - copyDOMOffset];
                     cy.wrap(link).should('have.prop', 'href', url);
                 }
             });

--- a/src/components/dev-hub/blog-share-links.js
+++ b/src/components/dev-hub/blog-share-links.js
@@ -1,14 +1,19 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import copy from 'copy-to-clipboard';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { getArticleShareLinks } from '../../utils/get-article-share-links';
 import { size } from './theme';
+import SuccessIcon from './icons/success';
 import LinkIcon from './icons/link-icon';
 import LinkedIn from './icons/linkedin';
 import FacebookIcon from './icons/facebook-icon';
 import TwitterIcon from './icons/twitter-icon';
 import Link from './link';
-import Tooltip from './tooltip';
+
+const hide = css`
+    display: none;
+`;
 
 const BlogShareContainer = styled('div')`
     display: flex;
@@ -19,10 +24,16 @@ const BlogShareLink = styled(Link)`
     height: ${size.default};
     line-height: ${size.default};
     width: ${size.default};
-`;
-
-const StyledTooltip = styled(Tooltip)`
-    line-height: ${size.default};
+    cursor: pointer;
+    path {
+        fill: ${({ theme }) => theme.colorMap.greyLightTwo};
+    }
+    &:hover {
+        path {
+            fill: ${({ consistentHoverColor, theme }) =>
+                !consistentHoverColor && theme.colorMap.devWhite};
+        }
+    }
 `;
 
 const BlogShareLinks = ({
@@ -38,21 +49,30 @@ const BlogShareLinks = ({
         linkedInUrl,
         twitterUrl,
     } = getArticleShareLinks(title, url);
-    const onCopyLink = useCallback(() => {
-        copy(articleUrl);
-    }, [articleUrl]);
+    const [showCopyMessage, setShowCopyMessage] = useState(false);
+    const onCopyLink = useCallback(
+        e => {
+            e.preventDefault();
+            copy(articleUrl);
+            setShowCopyMessage(true);
+            setTimeout(() => setShowCopyMessage(false), 2000);
+        },
+        [articleUrl]
+    );
+
     return (
         <BlogShareContainer {...props}>
-            <StyledTooltip
-                position="right"
-                trigger={
-                    <BlogShareLink onClick={onCopyLink}>
-                        <LinkIcon height={iconSize} width={iconSize} />
-                    </BlogShareLink>
-                }
+            <BlogShareLink onClick={onCopyLink} css={showCopyMessage && hide}>
+                <LinkIcon height={iconSize} width={iconSize} />
+            </BlogShareLink>
+
+            <BlogShareLink
+                onClick={onCopyLink}
+                css={!showCopyMessage && hide}
+                consistentHoverColor={true}
             >
-                Article link copied to clipboard!
-            </StyledTooltip>
+                <SuccessIcon height={iconSize} width={iconSize} />
+            </BlogShareLink>
 
             <BlogShareLink target="_blank" href={linkedInUrl}>
                 <LinkedIn height={iconSize} width={iconSize} />


### PR DESCRIPTION
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-625-exposed-links/)

This PR updates the UX for copying a link from the article share on the side. This reverts the behavior to what we have on production which is to swap to a check mark which looks like the following:
![Screen Shot 2021-05-18 at 5 13 48 PM](https://user-images.githubusercontent.com/9064401/118724704-ecf43100-b7fc-11eb-98a1-fc80ccb35091.png)

We also added hover states to the icons to change the color as we had in PROD.