### PR TITLE
DEVHUB-664: Add useViewport hook for mobile

### DIFF
--- a/src/components/dev-hub/feedback/feedback-container.js
+++ b/src/components/dev-hub/feedback/feedback-container.js
@@ -23,6 +23,7 @@ import {
 } from '~components/ArticleRatingContext';
 import BalloonsIcon from '~components/dev-hub/icons/balloons-icon';
 import { screenSize, size } from '~components/dev-hub/theme';
+import useViewport from '~hooks/use-viewport';
 
 const feedbackItems = graphql`
     query FeedbackItems {
@@ -127,6 +128,8 @@ const FeedbackContainer = ({ starRatingFlow, articleMeta, closeModal }) => {
         closeModal();
     }, [closeModal, formState, isLastModal, ratingDispatch, updateFeedback]);
 
+    useViewport();
+
     return isActiveModal ? (
         <Modal
             onCloseModal={onCloseModalHandler}
@@ -135,7 +138,7 @@ const FeedbackContainer = ({ starRatingFlow, articleMeta, closeModal }) => {
             contentStyle={modalStyles}
             headingStyles={headingStyles}
             dialogMobileContainerStyle={{
-                height: '100%',
+                height: '100vh',
                 padding: 0,
                 width: '100%',
             }}

--- a/src/hooks/use-viewport.js
+++ b/src/hooks/use-viewport.js
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+
+const useViewport = () => {
+    useEffect(() => {
+        const viewport = document.querySelector('meta[name=viewport]');
+        viewport.setAttribute(
+            'content',
+            viewport.content + ', height=' + window.innerHeight
+        );
+    }, []);
+};
+
+export default useViewport;


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-664/)
[JIRA](https://jira.mongodb.org/browse/DEVHUB-664)

This PR add a new hook called `useViewport` which allows us to properly set full heights on mobile where keyboards, etc could interfere with a percentage height. Using a proper viewport correctly solves the problem. The feedback modal should be full height on all sizes/platforms now (tested with an Android emulator)