### PR TITLE
DEVHUB-666: Add Leading Slashes to Feedback Slugs

### DIFF
--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -11,6 +11,7 @@ import ArticleSeries from '../components/dev-hub/article-series';
 import { getTagPageUriComponent } from '../utils/get-tag-page-uri-component';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 import ContentsMenu from '../components/dev-hub/contents-menu';
+import { addLeadingSlashIfMissing } from '../utils/add-leading-slash-if-missing';
 import { addTrailingSlashIfMissing } from '../utils/add-trailing-slash-if-missing';
 import ArticleSchema from '../components/dev-hub/article-schema';
 import BlogShareLinks from '../components/dev-hub/blog-share-links';
@@ -124,7 +125,10 @@ const Article = props => {
         },
         ...rest
     } = props;
-    const meta = { authors, slug: addTrailingSlashIfMissing(slug), title };
+    const slugWithAllSlashes = addLeadingSlashIfMissing(
+        addTrailingSlashIfMissing(slug)
+    );
+    const meta = { authors, slug: slugWithAllSlashes, title };
     const { siteUrl } = useSiteMetadata();
     const articleBreadcrumbs = [
         { label: 'Home', target: '/' },

--- a/src/utils/add-leading-slash-if-missing.js
+++ b/src/utils/add-leading-slash-if-missing.js
@@ -1,0 +1,6 @@
+export const addLeadingSlashIfMissing = url => {
+    if (url && url.match(/^\//)) {
+        return url;
+    }
+    return `/${url}`;
+};

--- a/tests/utils/add-leading-slash-if-missing.test.js
+++ b/tests/utils/add-leading-slash-if-missing.test.js
@@ -1,0 +1,33 @@
+import { addLeadingSlashIfMissing } from '../../src/utils/add-leading-slash-if-missing';
+
+it('should add leading slashes to links if they are missing', () => {
+    const linkWithoutSlash = 'foo.bar';
+    const linkWithSlash = `/${linkWithoutSlash}`;
+    expect(addLeadingSlashIfMissing(linkWithSlash)).toBe(linkWithSlash);
+
+    // Should ignore anything without a slash
+    expect(addLeadingSlashIfMissing(linkWithoutSlash)).toBe(linkWithSlash);
+
+    // Should handle null/empty inputs
+    expect(addLeadingSlashIfMissing('')).toBe('/');
+});
+
+it('should add leading slashes to URLs which have additional params appropriately', () => {
+    const link = 'foo.bar';
+    const linkWithLeadingSlash = `/${link}`;
+    const linkWithQueryParams = `${link}?content=true`;
+    const linkWithQueryParamsSlash = `${linkWithLeadingSlash}?content=true`;
+    const linkWithQueryParamsAndAnchor = `${link}?content=true#main`;
+    const linkWithQueryParamsAndAnchorSlash = `${linkWithLeadingSlash}?content=true#main`;
+    const linkWithAnchor = `${link}#main`;
+    const linkWithAnchorSlash = `${linkWithLeadingSlash}#main`;
+
+    expect(addLeadingSlashIfMissing(link)).toBe(linkWithLeadingSlash);
+    expect(addLeadingSlashIfMissing(linkWithQueryParams)).toBe(
+        linkWithQueryParamsSlash
+    );
+    expect(addLeadingSlashIfMissing(linkWithQueryParamsAndAnchor)).toBe(
+        linkWithQueryParamsAndAnchorSlash
+    );
+    expect(addLeadingSlashIfMissing(linkWithAnchor)).toBe(linkWithAnchorSlash);
+});


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-666-leading/)

This PR adds leading slashes to the slugs recorded for DevHub Feedback to be consistent with the metrics that show for us in Google Analytics. I would have liked to update all of the slugs for Articles but the `slugTitleMapping` has these. A separate feature will be added to ensure leading and trailing slashes for all slugs.