### PR TITLE
DEVHUB-664: Use height: fit-content for zoomed in content

### DIFF
--- a/src/components/dev-hub/feedback/feedback-container.js
+++ b/src/components/dev-hub/feedback/feedback-container.js
@@ -42,7 +42,7 @@ const modalStyles = css`
     @media ${screenSize.upToMedium} {
         border: none;
         border-radius: 0;
-        height: 100%;
+        min-height: 100vh;
         max-width: unset;
         min-width: unset;
         padding: 0;
@@ -138,7 +138,8 @@ const FeedbackContainer = ({ starRatingFlow, articleMeta, closeModal }) => {
             contentStyle={modalStyles}
             headingStyles={headingStyles}
             dialogMobileContainerStyle={{
-                height: '100vh',
+                minHeight: '100vh',
+                height: 'fit-content',
                 padding: 0,
                 width: '100%',
             }}


### PR DESCRIPTION
[Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-664-zoom/)
[JIRA](https://jira.mongodb.org/browse/DEVHUB-664)

One last piece for the DevHub feedback. As a result of #832 we also needed to change the height to be min-height: 100vh and height: fit-content. This allows users who zoom in to also not have the bottom background cut off. The JIRA also was updated with a picture of the broken UI