### PR TITLE
DEVHUB-218: Support Banners from Strapi

### DIFF
--- a/cypress/integration/top-banner.js
+++ b/cypress/integration/top-banner.js
@@ -1,0 +1,26 @@
+const TOP_BANNER = "[data-test='top-banner']";
+const TEST_DESKTOP_SRC =
+    'https://mongodb-devhub-cms.s3.us-west-1.amazonaws.com/dot_live_banner_desktop_216ff89791.png';
+const TEST_MOBILE_SRC =
+    'https://mongodb-devhub-cms.s3.us-west-1.amazonaws.com/dot_live_banner_mobile_bed7287154.png';
+const TEST_LINK = 'https://developer.mongodb.com/';
+
+describe('Top Banner', () => {
+    it('should properly render the top banner', () => {
+        cy.visit('/');
+        cy.get(TOP_BANNER).should('have.prop', 'href').and('eq', TEST_LINK);
+        cy.get(TOP_BANNER).within(() => {
+            cy.get('img')
+                .should('have.prop', 'src')
+                .and('eq', TEST_DESKTOP_SRC);
+        });
+    });
+    it('should be mobile responsive', () => {
+        cy.viewport('iphone-5');
+        cy.get(TOP_BANNER).should('have.prop', 'href').and('eq', TEST_LINK);
+        cy.get(TOP_BANNER).within(() => {
+            cy.get('img').should('have.prop', 'src').and('eq', TEST_MOBILE_SRC);
+        });
+        cy.viewport(1280, 660);
+    });
+});

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -32,6 +32,7 @@ module.exports = {
                 singleTypes: [
                     'feedback-rating-flow',
                     'student-spotlight-featured',
+                    'top-banner',
                     'top-nav',
                 ],
                 publicationState: process.env.STRAPI_PUBLICATION_STATE,

--- a/gatsby-config.prod.js
+++ b/gatsby-config.prod.js
@@ -29,6 +29,7 @@ module.exports = {
                 singleTypes: [
                     'feedback-rating-flow',
                     'student-spotlight-featured',
+                    'top-banner',
                     'top-nav',
                 ],
                 publicationState: process.env.STRAPI_PUBLICATION_STATE,

--- a/src/components/dev-hub/layout.js
+++ b/src/components/dev-hub/layout.js
@@ -10,6 +10,7 @@ import { Helmet } from 'react-helmet';
 import GlobalNav from './global-nav';
 import GlobalFooter from './global-footer';
 import { darkTheme, fontSize, lineHeight, screenSize, size } from './theme';
+import TopBanner from './top-banner';
 
 import '../../styles/font.css';
 import 'typeface-fira-mono';
@@ -99,6 +100,7 @@ export default ({ children, includeCanonical = true }) => {
                     )}
                 </Helmet>
                 <Global styles={style} />
+                <TopBanner />
                 <GlobalNav />
                 <TabProvider>
                     <Main>{children}</Main>

--- a/src/components/dev-hub/top-banner.tsx
+++ b/src/components/dev-hub/top-banner.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import dlv from 'dlv';
+import { useStaticQuery, graphql } from 'gatsby';
+import styled from '@emotion/styled';
+import useMedia from '~hooks/use-media';
+import Link from './link';
+import { screenSize, size } from './theme';
+
+const LiveImage = styled('img')`
+    border-radius: 0;
+    display: block;
+    height: auto;
+    margin-bottom: 0;
+    max-width: 100%;
+    @media ${screenSize.mediumAndUp} {
+        min-height: ${size.large};
+        object-fit: cover;
+    }
+`;
+
+const topBannerData = graphql`
+    query TopBannerData {
+        strapiTopBanner {
+            desktopBanner {
+                alternativeText
+                height
+                width
+                url
+            }
+            mobileBanner {
+                alternativeText
+                height
+                width
+                url
+            }
+            targetUrl
+        }
+    }
+`;
+
+const TopBanner = () => {
+    const data = useStaticQuery(topBannerData);
+    const topBannerNode = dlv(data, 'strapiTopBanner', null);
+    const isMobile = useMedia(screenSize.upToMedium, null);
+    if (
+        !topBannerNode ||
+        !topBannerNode.desktopBanner ||
+        !topBannerNode.mobileBanner
+    )
+        return null;
+    const src = isMobile
+        ? topBannerNode.mobileBanner
+        : topBannerNode.desktopBanner;
+    return (
+        <Link href={data.strapiTopBanner.target} target="_blank">
+            <LiveImage
+                alt={src.alternativeText}
+                src={src.url}
+                height={src.height}
+                width={src.width}
+            />
+        </Link>
+    );
+};
+
+export default TopBanner;

--- a/src/components/dev-hub/top-banner.tsx
+++ b/src/components/dev-hub/top-banner.tsx
@@ -52,7 +52,11 @@ const TopBanner = () => {
         ? topBannerNode.mobileBanner
         : topBannerNode.desktopBanner;
     return (
-        <Link href={data.strapiTopBanner.target} target="_blank">
+        <Link
+            data-test="top-banner"
+            href={data.strapiTopBanner.targetUrl}
+            target="_blank"
+        >
             <LiveImage
                 alt={src.alternativeText}
                 src={src.url}

--- a/src/utils/setup/schema-customization.js
+++ b/src/utils/setup/schema-customization.js
@@ -14,7 +14,10 @@ export const schemaCustomization = ({ actions }) => {
         tag: String
     }
     type CMSImage implements Node {
+        alternativeText: String
+        height: String
         url: String
+        width: String
     }
     type Related implements Node {
         label: String
@@ -61,6 +64,11 @@ export const schemaCustomization = ({ actions }) => {
     }
     type allStrapiClientSideRedirects implements Node {
         nodes: [StrapiClientSideRedirect]
+    }
+    type StrapiTopBanner implements Node {
+        desktopBanner: CMSImage
+        mobileBanner: CMSImage
+        targetUrl: String
     }
     `;
     createTypes(typeDefs);


### PR DESCRIPTION
[Staging Link (Mock Banner)](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-218/)

I expect tests to fail until the corresponding CMS change has been made.

This PR adds logic to consume a new Single Type called `TopBanner`. This has the images for the desktop/mobile banners as well as the target URL. This allows us to change banners in the CMS without any more code changes.