### PR TITLE
WIP DEVHUB-684: Strapi Featured Articles

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -31,6 +31,7 @@ module.exports = {
                 contentTypes: ['articles', 'client-side-redirects', 'projects'],
                 singleTypes: [
                     'featured-home-page-articles',
+                    'featured-learn-page-articles',
                     'feedback-rating-flow',
                     'student-spotlight-featured',
                     'top-banner',

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -30,6 +30,7 @@ module.exports = {
                 apiURL: process.env.STRAPI_URL,
                 contentTypes: ['articles', 'client-side-redirects', 'projects'],
                 singleTypes: [
+                    'featured-home-page-articles',
                     'feedback-rating-flow',
                     'student-spotlight-featured',
                     'top-banner',

--- a/gatsby-config.prod.js
+++ b/gatsby-config.prod.js
@@ -27,6 +27,7 @@ module.exports = {
                 apiURL: process.env.STRAPI_URL,
                 contentTypes: ['articles', 'client-side-redirects', 'projects'],
                 singleTypes: [
+                    'featured-home-page-articles',
                     'feedback-rating-flow',
                     'student-spotlight-featured',
                     'top-banner',

--- a/gatsby-config.prod.js
+++ b/gatsby-config.prod.js
@@ -28,6 +28,7 @@ module.exports = {
                 contentTypes: ['articles', 'client-side-redirects', 'projects'],
                 singleTypes: [
                     'featured-home-page-articles',
+                    'featured-learn-page-articles',
                     'feedback-rating-flow',
                     'student-spotlight-featured',
                     'top-banner',

--- a/src/queries/featured-home-page-articles.js
+++ b/src/queries/featured-home-page-articles.js
@@ -1,0 +1,10 @@
+export const featuredHomePageArticles = `
+  query homePageArticles {
+    strapiFeaturedHomePageArticles {
+      firstArticle
+      secondArticle
+      thirdArticle
+      fourthArticle
+    }
+  }
+`;

--- a/src/queries/featured-learn-page-articles.js
+++ b/src/queries/featured-learn-page-articles.js
@@ -1,0 +1,9 @@
+export const featuredLearnPageArticles = `
+  query learnPageArticles {
+    strapiFeaturedLearnPageArticles {
+      mainArticle
+      secondaryArticle
+      tertiaryArticle
+    }
+  }
+`;

--- a/src/utils/setup/find-articles-from-slugs.js
+++ b/src/utils/setup/find-articles-from-slugs.js
@@ -1,6 +1,15 @@
+import { addLeadingSlashIfMissing } from '../add-leading-slash-if-missing';
+import { addTrailingSlashIfMissing } from '../add-trailing-slash-if-missing';
+
 export const findArticleWithSlug = (allArticles, slug) => {
-    const targetSlug = new RegExp(`^/?${slug}$`);
-    const targetArticle = allArticles.find(x => x.slug.match(targetSlug));
+    const targetSlug = addLeadingSlashIfMissing(
+        addTrailingSlashIfMissing(slug)
+    );
+    const targetArticle = allArticles.find(
+        x =>
+            addLeadingSlashIfMissing(addTrailingSlashIfMissing(x.slug)) ===
+            targetSlug
+    );
     if (targetArticle) {
         return targetArticle;
     }


### PR DESCRIPTION
This PR will be un-drafted and merged once we are ready to swap this functionality from Snooty to Strapi.

This PR, [in conjunction with the corresponding CMS change](https://github.com/10gen/devhub-cms/pull/40), will move control of featured articles on the home and learn page from Snooty to Strapi. The front-end pulls in two new Strapi single-types `featuredHomePageArticles` and `featuredLearnPageArticles` and swaps them in for what Snooty was populating.

We also upgraded the `findArticleWithSlug` check to ensure all elements have trailing and leading slashes, since this was not checked before.