### PR TITLE
DEVHUB-596: Cleanup Title and Link

### DIFF
--- a/src/components/dev-hub/layout.js
+++ b/src/components/dev-hub/layout.js
@@ -95,7 +95,7 @@ export default ({ children, includeCanonical = true }) => {
                         type="application/opensearchdescription+xml"
                         rel="search"
                         href="https://developer.mongodb.com/opensearch.xml"
-                        title="Search MongoDB Developer Hub"
+                        title="MongoDB Developer Hub"
                     />
                     <link
                         rel="shortcut icon"

--- a/static/opensearch.xml
+++ b/static/opensearch.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
-    <ShortName>Search MongoDB Developer Hub</ShortName>
-    <LongName>Search of MongoDB Developer Hub Content</LongName>
+    <ShortName>MongoDB Developer Hub</ShortName>
+    <LongName>MongoDB Developer Hub Content</LongName>
     <Description>Code, content, tutorials, programs and community to enable developers of all skill levels on the MongoDB Data Platform which includes Atlas, Realm, Compass, Data Lake and more. Whether you're coding in Java, JavaScript, C#, Python, Node, Go or looking for how this fits with IOT, AI, ML - join or follow us here.</Description>
     <Contact>sitesearch@mongodb.com</Contact>
     <Developer>MongoDB, Inc.</Developer>
     <Image height="32" width="32" type="image/x-icon">https://docs.mongodb.com/favicon.ico</Image>
     <Url type="application/opensearchdescription+xml" rel="self" template="https://developer.mongodb.com/opensearch.xml"/>
-    <Url type="text/html" method="get" template="https://developer.mongodb.com/learn/?text={searchTerms}"/>
+    <Url type="text/html" method="get" template="https://developer.mongodb.com/learn/?content=Articles&text={searchTerms}#main"/>
 </OpenSearchDescription>


### PR DESCRIPTION
No Staging Needed

This PR cleans two small things for the Open Search Description implementation.
- Removes "Search" from the title as the browser adds it for us
- updates the link to use the `#main` anchor ID