### PR TITLE
DEVHUB-218: Center Banner on Large Screens

### DIFF
--- a/src/components/dev-hub/top-banner.tsx
+++ b/src/components/dev-hub/top-banner.tsx
@@ -10,11 +10,10 @@ const LiveImage = styled('img')`
     border-radius: 0;
     display: block;
     height: auto;
-    margin-bottom: 0;
+    margin: 0 auto;
     max-width: 100%;
     @media ${screenSize.mediumAndUp} {
         min-height: ${size.large};
-        object-fit: cover;
     }
 `;
 


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DEVHUB-218)
[Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-218-center/)

This PR changes the banner to center on large screens (as a result of wanting to use img height/width tags)

Before:
![Screen Shot 2021-06-01 at 1 00 18 PM](https://user-images.githubusercontent.com/9064401/120364593-7450a280-c2db-11eb-8f33-fc9f3032498d.png)


After:
![Screen Shot 2021-06-01 at 1 07 00 PM](https://user-images.githubusercontent.com/9064401/120364612-79155680-c2db-11eb-9e75-0872c4678ac8.png)
