### PR TITLE
DEVHUB-542: Add new config file for subdomain consolidation

### DIFF
--- a/gatsby-config.prod-new.js
+++ b/gatsby-config.prod-new.js
@@ -1,0 +1,88 @@
+const { siteUrl } = require('./src/queries/site-url');
+const { getMetadata } = require('./src/utils/get-metadata');
+const { articleRssFeed } = require('./src/utils/setup/article-rss-feed');
+const { searchRssFeed } = require('./src/utils/setup/search-rss-feed');
+
+require('dotenv').config({
+    path: '.env.production',
+});
+
+const metadata = getMetadata();
+
+module.exports = {
+    pathPrefix: 'developer',
+    plugins: [
+        'gatsby-plugin-react-helmet',
+        'gatsby-plugin-emotion',
+        'gatsby-plugin-force-trailing-slashes',
+        {
+            resolve: 'gatsby-plugin-webpack-bundle-analyser-v2',
+            options: {
+                disable: true,
+            },
+        },
+        {
+            resolve: `gatsby-source-strapi`,
+            options: {
+                apiURL: process.env.STRAPI_URL,
+                contentTypes: ['articles', 'client-side-redirects', 'projects'],
+                singleTypes: [
+                    'feedback-rating-flow',
+                    'student-spotlight-featured',
+                    'top-banner',
+                    'top-nav',
+                ],
+                publicationState: process.env.STRAPI_PUBLICATION_STATE,
+            },
+        },
+        {
+            resolve: `gatsby-plugin-alias-imports`,
+            options: {
+                alias: {
+                    '~src': 'src',
+                    '~components': 'src/components',
+                    '~hooks': 'src/hooks',
+                    '~images': 'src/images',
+                    '~pages': 'src/pages',
+                    '~utils': 'src/utils',
+                    '~tests': 'tests',
+                },
+                extensions: ['js'],
+            },
+        },
+        {
+            resolve: 'gatsby-plugin-sitemap',
+            output: '/sitemap-pages.xml',
+            options: {
+                // Exclude paths we are using the noindex tag on
+                exclude: [
+                    '/language/*',
+                    '/product/*',
+                    '/storybook ',
+                    '/tag/*',
+                    '/type/*',
+                ],
+            },
+        },
+        {
+            resolve: 'gatsby-plugin-google-tagmanager',
+            options: {
+                id: 'GTM-GDFN',
+                includeInDevelopment: false,
+            },
+        },
+        {
+            resolve: 'gatsby-plugin-feed',
+            options: {
+                query: siteUrl,
+                feeds: [articleRssFeed, searchRssFeed],
+            },
+        },
+        `gatsby-plugin-meta-redirect`, // this must be last
+    ],
+    siteMetadata: {
+        ...metadata,
+        title: 'MongoDB Developer Hub',
+        siteUrl: 'https://mongodb.com/developer',
+    },
+};


### PR DESCRIPTION
No staging

To prepare for the upcoming subdomain consolidation, we will need the production config to have a prefix of `/developer`. This way, internal linking works as expected with the subdomain.

Without this, we would just keep linking to mongodb.com/article/... instead of mongodb.com/developer/article.