### PR TITLE
Add Google Lighthouse Tooling into Github Actions CI

### DIFF
--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -52,7 +52,5 @@ jobs:
             - name: Run Lighthouse
               uses: treosh/lighthouse-ci-action@v3
               with:
-                  uploadArtifacts: false
-                  temporaryPublicStorage: true
                   configPath: './lighthouserc.json'
-                  runs: 3
+                  runs: 2

--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -50,7 +50,7 @@ jobs:
                   name: cypress-screenshots
                   path: cypress/screenshots
             - name: Run Lighthouse
-              uses: treosh/lighthouse-ci-action@v3
+              uses: treosh/lighthouse-ci-action@v7
               with:
                   configPath: './lighthouserc.json'
                   runs: 2

--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -49,3 +49,10 @@ jobs:
               with:
                   name: cypress-screenshots
                   path: cypress/screenshots
+            - name: Run Lighthouse
+              uses: treosh/lighthouse-ci-action@v3
+              with:
+                  uploadArtifacts: false
+                  temporaryPublicStorage: true
+                  configPath: './lighthouserc.json'
+                  runs: 3

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,22 @@
+{
+    "ci": {
+        "collect": {
+            "url": ["http://localhost/"],
+            "staticDistDir": "./public"
+        },
+        "assert": {
+            "assertions": {
+                "categories:accessibility": ["error", { "minScore": 0.85 }],
+                "categories:best-practices": ["error", { "minScore": 0.8 }],
+                "categories:performance": ["error", { "minScore": 0.75 }],
+                "categories:seo": ["warn", { "minScore": 1 }],
+                "dom-size": ["warn", { "maxNumericValue": 1000 }],
+                "first-contentful-paint": [
+                    "error",
+                    { "maxNumericValue": 4500 }
+                ],
+                "interactive": ["error", { "maxNumericValue": 5000 }]
+            }
+        }
+    }
+}

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -3,7 +3,6 @@
         "collect": {
             "url": [
                 "http://localhost/",
-                "http://localhost/learn/",
                 "http://localhost/article/3-things-to-know-switch-from-sql-mongodb/"
             ],
             "staticDistDir": "./public"

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -11,7 +11,7 @@
             "assertions": {
                 "categories:accessibility": ["error", { "minScore": 0.85 }],
                 "categories:best-practices": ["error", { "minScore": 0.75 }],
-                "categories:performance": ["error", { "minScore": 0.75 }],
+                "categories:performance": ["warn", { "minScore": 0.75 }],
                 "categories:seo": ["error", { "minScore": 0.8 }],
                 "dom-size": ["warn", { "maxNumericValue": 1000 }],
                 "first-contentful-paint": ["error", { "maxNumericValue": 4500 }]

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,21 +1,21 @@
 {
     "ci": {
         "collect": {
-            "url": ["http://localhost/"],
+            "url": [
+                "http://localhost/",
+                "http://localhost/learn/",
+                "http://localhost/article/3-things-to-know-switch-from-sql-mongodb/"
+            ],
             "staticDistDir": "./public"
         },
         "assert": {
             "assertions": {
                 "categories:accessibility": ["error", { "minScore": 0.85 }],
-                "categories:best-practices": ["error", { "minScore": 0.8 }],
+                "categories:best-practices": ["error", { "minScore": 0.75 }],
                 "categories:performance": ["error", { "minScore": 0.75 }],
-                "categories:seo": ["warn", { "minScore": 1 }],
+                "categories:seo": ["error", { "minScore": 0.8 }],
                 "dom-size": ["warn", { "maxNumericValue": 1000 }],
-                "first-contentful-paint": [
-                    "error",
-                    { "maxNumericValue": 4500 }
-                ],
-                "interactive": ["error", { "maxNumericValue": 5000 }]
+                "first-contentful-paint": ["error", { "maxNumericValue": 4500 }]
             }
         }
     }


### PR DESCRIPTION
This PR adds a change to our GitHub actions CI testing to add testing two URLs with Google Lighthouse. [This plugin](https://github.com/treosh/lighthouse-ci-action) allows us to identify web performance metrics which can be used to judge the overall health of the site and prevent significant regression.

Google Lighthouse, if you are unfamiliar, is a tool which monitors overall site health and performance in specific areas. It also helps with Search Engine rankings (kind of). You can read up on it [here](https://developers.google.com/web/tools/lighthouse)!