### PR TITLE
DEVHUB-709: Remove Snooty Articles with an identical Slug in Strapi

### DIFF
--- a/cypress/integration/article.js
+++ b/cypress/integration/article.js
@@ -5,6 +5,7 @@ const ARTICLE_WITH_ATTRIBUTION_LINK_URL =
     '/article/build-newsletter-website-mongodb-data-platform/';
 const EXPECTED_ATTRIBUTION_LINK =
     'https://www.mongodb.com/cloud/atlas/signup?tck%3Ddevhub-build-newsletter-website-mongodb-data-platform';
+const ARTICLE_DUPLICATED_IN_STRAPI = '/how-to/hapijs-nodejs-driver';
 
 // Article with no og description or og type (test meta description fallback)
 const ARTICLE_WITH_MINIMAL_OG_URL =
@@ -249,7 +250,7 @@ describe('Sample Article Page', () => {
             });
         });
         it('should render Strapi content should it have the same slug as Snooty content', () => {
-            cy.visit('/how-to/hapijs-node-driver').then(() => {
+            cy.visit(ARTICLE_DUPLICATED_IN_STRAPI).then(() => {
                 cy.contains('Strapi HapiJS Article');
             });
         });

--- a/cypress/integration/article.js
+++ b/cypress/integration/article.js
@@ -248,5 +248,10 @@ describe('Sample Article Page', () => {
                 cy.contains('Some C++ code');
             });
         });
+        it('should render Strapi content should it have the same slug as Snooty content', () => {
+            cy.visit('/how-to/hapijs-node-driver').then(() => {
+                cy.contains('Strapi HapiJS Article');
+            });
+        });
     });
 });

--- a/cypress/integration/article.js
+++ b/cypress/integration/article.js
@@ -249,10 +249,10 @@ describe('Sample Article Page', () => {
                 cy.contains('Some C++ code');
             });
         });
-        it('should render Strapi content should it have the same slug as Snooty content', () => {
-            cy.visit(ARTICLE_DUPLICATED_IN_STRAPI).then(() => {
-                cy.contains('Strapi HapiJS Article');
-            });
+    });
+    it('should render Strapi content should it have the same slug as Snooty content', () => {
+        cy.visit(ARTICLE_DUPLICATED_IN_STRAPI).then(() => {
+            cy.contains('Strapi HapiJS Article');
         });
     });
 });

--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -12,6 +12,7 @@ import { createClientSideRedirects } from './src/utils/setup/create-client-side-
 import { aggregateItemsWithTagType } from './src/utils/setup/aggregate-items-with-tag-type';
 import { aggregateAuthorInformation } from './src/utils/setup/aggregate-author-information';
 import { createTagPageType } from './src/utils/setup/create-tag-page-type';
+import { removeDuplicatedArticles } from './src/utils/setup/remove-duplicated-articles';
 import { getMetadata } from './src/utils/get-metadata';
 import {
     DOCUMENTS_COLLECTION,
@@ -153,7 +154,7 @@ export const createPages = async ({ actions, graphql }) => {
     const allSeries = filteredPageGroups(metadataDocument.pageGroups);
 
     const strapiArticleList = await getStrapiArticleListFromGraphql(graphql);
-    allArticles = snootyArticles.concat(strapiArticleList);
+    allArticles = removeDuplicatedArticles(snootyArticles, strapiArticleList);
 
     allArticles.forEach(article => {
         createArticlePage(

--- a/src/utils/fuzzy-slug-match.js
+++ b/src/utils/fuzzy-slug-match.js
@@ -1,0 +1,11 @@
+import { addLeadingSlashIfMissing } from './add-leading-slash-if-missing';
+import { addTrailingSlashIfMissing } from './add-trailing-slash-if-missing';
+
+const ensureLeadingAndTrailingSlashes = slug =>
+    addTrailingSlashIfMissing(addLeadingSlashIfMissing(slug));
+
+// Test slugs properly by ensuring trailing and leading slashes always for
+// correctness
+export const fuzzySlugMatch = (initialSlug, testSlug) =>
+    ensureLeadingAndTrailingSlashes(initialSlug) ===
+    ensureLeadingAndTrailingSlashes(testSlug);

--- a/src/utils/setup/remove-duplicated-articles.js
+++ b/src/utils/setup/remove-duplicated-articles.js
@@ -1,7 +1,9 @@
+import { fuzzySlugMatch } from '../fuzzy-slug-match';
+
 export const removeDuplicatedArticles = (snootyArticles, strapiArticles) => {
     // filter snooty articles where the slug matches a strapi one
     const filteredSnootyArticles = snootyArticles.filter(
-        ({ slug }) => !strapiArticles.find(a => a.slug === slug)
+        ({ slug }) => !strapiArticles.find(a => fuzzySlugMatch(a.slug, slug))
     );
     return filteredSnootyArticles.concat(strapiArticles);
 };

--- a/src/utils/setup/remove-duplicated-articles.js
+++ b/src/utils/setup/remove-duplicated-articles.js
@@ -1,0 +1,7 @@
+export const removeDuplicatedArticles = (snootyArticles, strapiArticles) => {
+    // filter snooty articles where the slug matches a strapi one
+    const filteredSnootyArticles = snootyArticles.filter(
+        ({ slug }) => !strapiArticles.find(a => a.slug === slug)
+    );
+    return filteredSnootyArticles.concat(strapiArticles);
+};

--- a/tests/utils/fuzzy-slug-match.test.js
+++ b/tests/utils/fuzzy-slug-match.test.js
@@ -1,0 +1,14 @@
+import { fuzzySlugMatch } from '../../src/utils/fuzzy-slug-match';
+
+it('should properly compare slugs by ensuring leading and trailing slashes', () => {
+    expect(fuzzySlugMatch('', '')).toBeTruthy();
+    expect(fuzzySlugMatch('foo', 'foo')).toBeTruthy();
+    expect(fuzzySlugMatch('/foo', 'foo')).toBeTruthy();
+    expect(fuzzySlugMatch('/foo', 'foo/')).toBeTruthy();
+    expect(fuzzySlugMatch('foo', 'bar')).toBeFalsy();
+    expect(fuzzySlugMatch('/foo', '/bar')).toBeFalsy();
+    expect(fuzzySlugMatch('/foo/', '/bar/')).toBeFalsy();
+    expect(fuzzySlugMatch('/foo/bar', '/bar')).toBeFalsy();
+    expect(fuzzySlugMatch('/foo/bar/', '/bar/foo')).toBeFalsy();
+    expect(fuzzySlugMatch('/foo/bar/', 'foo/bar')).toBeTruthy();
+});

--- a/tests/utils/remove-duplicated-articles.test.js
+++ b/tests/utils/remove-duplicated-articles.test.js
@@ -1,0 +1,62 @@
+import { removeDuplicatedArticles } from '../../src/utils/setup/remove-duplicated-articles';
+
+describe('Remove duplicated articles from Snooty and Strapi', () => {
+    let snootyArticles;
+    let strapiArticles;
+    let totalNumberOfArticles;
+    const snootyType = 'snooty';
+    const strapiType = 'strapi';
+    beforeEach(() => {
+        snootyArticles = [
+            { slug: '/how-to/do-something', type: snootyType },
+            { slug: '/quickstart/do-something', type: snootyType },
+        ];
+        strapiArticles = [{ slug: '/article/do-something', type: strapiType }];
+        totalNumberOfArticles = snootyArticles.length + strapiArticles.length;
+    });
+    it('should keep all articles if slugs are unique', () => {
+        const filteredArticles = removeDuplicatedArticles(
+            snootyArticles,
+            strapiArticles
+        );
+        expect(filteredArticles.length).toBe(totalNumberOfArticles);
+    });
+    it('should handle an empty case', () => {
+        const filteredArticles = removeDuplicatedArticles([], []);
+        expect(filteredArticles.length).toBe(0);
+    });
+    it('should remove an article from Snooty where a slug duped', () => {
+        // Add a new Strapi article, modify our count
+        strapiArticles.push({
+            slug: '/how-to/do-something',
+            type: strapiType,
+        });
+        totalNumberOfArticles += 1;
+        const filteredArticles = removeDuplicatedArticles(
+            snootyArticles,
+            strapiArticles
+        );
+        expect(filteredArticles.length).toBe(totalNumberOfArticles - 1);
+        const dedupedArticle = filteredArticles.find(
+            ({ slug }) => slug === '/how-to/do-something'
+        );
+        expect(dedupedArticle.type).toBe(strapiType);
+    });
+    it('should remove an article from Snooty where a slug was fuzzy-duped', () => {
+        // Add a new Strapi article with a trailing slash, modify our count
+        strapiArticles.push({
+            slug: '/how-to/do-something/',
+            type: strapiType,
+        });
+        totalNumberOfArticles += 1;
+        const filteredArticles = removeDuplicatedArticles(
+            snootyArticles,
+            strapiArticles
+        );
+        expect(filteredArticles.length).toBe(totalNumberOfArticles - 1);
+        const dedupedArticle = filteredArticles.find(
+            ({ slug }) => slug === '/how-to/do-something/'
+        );
+        expect(dedupedArticle.type).toBe(strapiType);
+    });
+});


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DEVHUB-709)

This PR fixes some nondeterministic logic that would occur when our writing team begins re-writing content from Snooty (aka the Github/rST way of writing content) in Strapi.

Should an article be created in Strapi with the same "slug" (or URL after the initial developer.mongodb.com), we would create two pages at the same slug in Gatsby, which is nondeterministic. To be safe, this PR adds a case to remove articles from Snooty which have an identical slug in Strapi to ensure we only create one such article page. The requirement is for us to "prefer" the Strapi article.

The actual logic just involves us performing a filter on articles coming from Snooty to see if any have a slug that "fuzzy" matches one in Strapi and if so, remove it. "Fuzzy" matching means the URL is identical without taking a leading or trailing slash into account, because writers may add it in Strapi. This allows us to perform a fair and correct comparison.

For testing, I added Jest unit tests for the logic and a small change to the UI tests. For the UI tests, I updated our Strapi test data to construct an article that has the same full "slug" as one in the test data from Snooty and checked that the Strapi article was the one being rendered.