### PR TITLE
Let inline Strapi elements be inline

### DIFF
--- a/src/components/dev-hub/raw-html.js
+++ b/src/components/dev-hub/raw-html.js
@@ -1,12 +1,17 @@
 import React from 'react';
 import sanitizeHtml from 'sanitize-html';
 
+const isInlineElement = html => html === '<br />';
+
 const RawHTML = ({ nodeData }) => {
     const { value } = nodeData;
     const sanitizedHTML = sanitizeHtml(value, {
         allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
         allowedAttributes: false,
     });
+    if (isInlineElement(sanitizedHTML)) {
+        return <span dangerouslySetInnerHTML={{ __html: sanitizedHTML }} />;
+    }
     return <div dangerouslySetInnerHTML={{ __html: sanitizedHTML }} />;
 };
 


### PR DESCRIPTION
[This PR for an Article](https://docs-mongodbcom-staging.corp.mongodb.com/CI/devhub/jordanstapinski/fix-inline-elements/how-to/realm-data-types/)
[Existing Article](http://docs-devhub-staging.s3-website-us-east-1.amazonaws.com/25c77c5/devhub/docsworker-xlarge/strapi/how-to/realm-data-types/)

This PR checks if someone in Strapi uses HTML that is just a line break. We only want to use `span` for this to be inline and not a `div` since that would make it a block with height. The ask is to remove breaks from `div` and make them a span.

Check out this PR for an article and that same article as it is now from Strapi to see the difference!