### PR TITLE
Fix safari article overlay

### DIFF
--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -81,7 +81,7 @@ const Container = styled('div')`
     padding: 0 ${size.default};
 
     @media ${screenSize.largeAndUp} {
-        grid-template-rows: unset;
+        grid-template-rows: auto;
         padding: 0;
         grid-template-areas:
             'rating rating rating'
@@ -138,7 +138,7 @@ const Article = props => {
             {
                 label: title,
                 target: slug,
-            }
+            },
         ];
         if (type && type.length) {
             breadcrumb.splice(2, 0, {


### PR DESCRIPTION
[Staging](https://docs-mongodborg-staging.corp.mongodb.com/CI/devhub/jordanstapinski/fix-safari-grid/)

This PR fixes a bug on Safari (I'm not sure when it was introduced) relating to Rate this Article on Safari. I noticed sometimes the rate this article overlays the content of the article. We have the first image, when we want to have the second. This PR updates a CSS property that is not inferred on Safari desktop only (but looks fine elsewhere).

<img width="824" alt="Screen Shot 2021-06-15 at 9 58 28 AM" src="https://user-images.githubusercontent.com/9064401/122066003-61040380-cdc0-11eb-94e5-f13f1432e9a6.png">
<img width="784" alt="Screen Shot 2021-06-15 at 9 58 54 AM" src="https://user-images.githubusercontent.com/9064401/122066006-619c9a00-cdc0-11eb-883f-3fd108b971f5.png">
