### PR TITLE
DEVHUB-706: Add Canonical URL Fallback for Strapi Articles

### DIFF
--- a/cypress/integration/strapi-article.js
+++ b/cypress/integration/strapi-article.js
@@ -1,0 +1,11 @@
+const STRAPI_ARTICLE = '/how-to/hapijs-nodejs-driver/';
+const PROD_STRAPI_ARTICLE_URL = `https://developer.mongodb.com${STRAPI_ARTICLE}`;
+
+describe('Sample Strapi Article', () => {
+    it('should have a default canonical URL', () => {
+        cy.visit(STRAPI_ARTICLE).then(() => {
+            cy.contains('Strapi HapiJS Article');
+            cy.checkCanonicalUrlValue(`${PROD_STRAPI_ARTICLE_URL}`);
+        });
+    });
+});

--- a/src/utils/transform-article-strapi-data.js
+++ b/src/utils/transform-article-strapi-data.js
@@ -1,5 +1,7 @@
 import { transformAuthorStrapiData } from './setup/transform-author-strapi-data';
 import { parseMarkdownToAST } from './setup/parse-markdown-to-ast';
+import { SITE_URL } from '../constants';
+import { addTrailingSlashIfMissing } from '../utils/add-trailing-slash-if-missing';
 
 const typeMap = {
     Article: 'article',
@@ -14,6 +16,7 @@ export const transformArticleStrapiData = article => {
     const transformedAuthors = authors.map(transformAuthorStrapiData);
     const parsedContent = parseMarkdownToAST(article.content);
     const SEOObject = article.SEO || {};
+    const fullSlug = `${typeMap[inferredType]}${article.slug}`;
     return {
         ...article,
         authors: transformedAuthors,
@@ -30,7 +33,9 @@ export const transformArticleStrapiData = article => {
               }))
             : [],
         SEO: {
-            canonicalUrl: SEOObject.canonical_url,
+            canonicalUrl:
+                SEOObject.canonical_url ||
+                addTrailingSlashIfMissing(`${SITE_URL}/${fullSlug}`),
             metaDescription: SEOObject.meta_description,
             og: {
                 description: SEOObject.og_description,
@@ -47,7 +52,7 @@ export const transformArticleStrapiData = article => {
                 title: SEOObject.twitter_title,
             },
         },
-        slug: `${typeMap[inferredType]}${article.slug}`,
+        slug: fullSlug,
         tags: article.tags.map(t => t.tag),
         type: typeMap[inferredType],
     };


### PR DESCRIPTION
[Staging Strapi Article](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-706/how-to/build-ci-cd-pipelines-realm-apps-github-actions/)
[JIRA](https://jira.mongodb.org/browse/DEVHUB-706)
[What is a canonical URL?](https://yoast.com/what-is-a-canonical-url/) (For more context, we had an SEO suggestion that every page should have a canonical URL, defaulting to itself)

This PR changes behavior of articles from Strapi to add a fallback canonical URL if one is not supplied. The canonical URL is an HTML tag with `rel="canonical"` we can see if we inspect the DOM. Previouly, we had no fallback and just let the options be from Strapi be our source of truth absolutely.