### PR TITLE
Add new ENV option for username customization for staging links

### DIFF
--- a/src/utils/generate-path-prefix.js
+++ b/src/utils/generate-path-prefix.js
@@ -17,6 +17,7 @@ const generatePathPrefix = ({
         return `/${pathPrefix}`;
     }
 
+    const userForPathPrefix = process.env.GATSBY_STAGING_USER || user;
     let prefix = '';
     if (commitHash) prefix += `${commitHash}`;
     if (patchId) prefix += `/${patchId}`;
@@ -26,7 +27,7 @@ const generatePathPrefix = ({
     // be present in the URL's path prefix in order to be mut-compatible.
     //
     // TODO: Simplify this logic when Snooty development is staged in integration environment
-    const base = `${project}/${user}`;
+    const base = `${project}/${userForPathPrefix}`;
     const path = process.env.GATSBY_SNOOTY_DEV
         ? `/${prefix}/${parserBranch}/${base}/${snootyBranch}`
         : `/${prefix}/${base}/${parserBranch}`;


### PR DESCRIPTION
This PR adds support for a new environment variable which we can use which allows us to separate which username we use to get reStructuredText content from which username we use for a staging link. This allows us to properly build and stage the platform.

To test:
- Open .env.production
- Add a new line `GATSBY_STAGING_USER=<your computer username, such as sophia.li>`
- run `npm run clean; npm run build; make stage`
- The site should build and stage, with all images/fonts looking good