### PR TITLE
[July 15th] DEVHUB-753: Remove Forums from DevHub Sitemap, Update Links

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -56,7 +56,7 @@ module.exports = {
         {
             resolve: 'gatsby-plugin-sitemap',
             options: {
-                output: '/sitemap-pages.xml',
+                output: '/sitemap.xml',
                 // Exclude paths we are using the noindex tag on
                 exclude: [
                     '/language/*',

--- a/gatsby-config.prod-new.js
+++ b/gatsby-config.prod-new.js
@@ -52,7 +52,7 @@ module.exports = {
         },
         {
             resolve: 'gatsby-plugin-sitemap',
-            output: '/sitemap-pages.xml',
+            output: '/sitemap.xml',
             options: {
                 // Exclude paths we are using the noindex tag on
                 exclude: [

--- a/gatsby-config.prod.js
+++ b/gatsby-config.prod.js
@@ -52,7 +52,7 @@ module.exports = {
         },
         {
             resolve: 'gatsby-plugin-sitemap',
-            output: '/sitemap-pages.xml',
+            output: '/sitemap.xml',
             options: {
                 // Exclude paths we are using the noindex tag on
                 exclude: [

--- a/src/constants.js
+++ b/src/constants.js
@@ -35,4 +35,5 @@ export const STITCH_AUTH_APP_ID = 'devhubauthentication-lidpq';
 export const FEEDBACK_APP_ID = 'feedback-ihion';
 
 export const SITE_URL = 'https://developer.mongodb.com';
-export const FORUMS_URL = `${SITE_URL}/community/forums`;
+export const OLD_SUBDOMAIN_FORUMS_URL = `${SITE_URL}/community/forums/`;
+export const FORUMS_URL = `https://www.mongodb.com/community/forums/`;

--- a/src/utils/make-link-internal-if-applicable.js
+++ b/src/utils/make-link-internal-if-applicable.js
@@ -1,6 +1,6 @@
 import { withPrefix } from 'gatsby';
 import { addTrailingSlashIfMissing } from './add-trailing-slash-if-missing';
-import { SITE_URL, FORUMS_URL } from '~src/constants';
+import { SITE_URL, OLD_SUBDOMAIN_FORUMS_URL } from '~src/constants';
 import { isLinkForImage } from '~utils/is-link-for-image';
 
 export const makeLinkInternalIfApplicable = (link, includePrefix = false) => {
@@ -8,7 +8,7 @@ export const makeLinkInternalIfApplicable = (link, includePrefix = false) => {
         return link;
     }
     const linkIncludesDevHub = link.includes(SITE_URL);
-    const linkGoesToForums = link.includes(FORUMS_URL);
+    const linkGoesToForums = link.includes(OLD_SUBDOMAIN_FORUMS_URL);
     if (linkIncludesDevHub && !linkGoesToForums) {
         const linkWithoutSiteUrl = link.replace(SITE_URL, '');
         // Forums is technically "external" from an app standpoint, so we leave

--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-  <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-    <sitemap>
-      <loc>https://developer.mongodb.com/sitemap-pages.xml</loc>
-    </sitemap>
-    <sitemap>
-      <loc>https://developer.mongodb.com/community/forums/sitemap.xml</loc>
-    </sitemap>
-  </sitemapindex>

--- a/tests/utils/make-link-internal-if-applicable.test.js
+++ b/tests/utils/make-link-internal-if-applicable.test.js
@@ -1,5 +1,5 @@
 import { makeLinkInternalIfApplicable } from '~utils/make-link-internal-if-applicable';
-import { FORUMS_URL, SITE_URL } from '~src/constants';
+import { OLD_SUBDOMAIN_FORUMS_URL, SITE_URL } from '~src/constants';
 
 it('should parse internal links and add a trailing slash if needed', () => {
     expect(makeLinkInternalIfApplicable(null)).toBe(null);
@@ -9,7 +9,7 @@ it('should parse internal links and add a trailing slash if needed', () => {
     const internalArticleSlugTrailingSlash = `${internalArticleSlug}/`;
     const fullArticleLink = `${SITE_URL}${internalArticleSlug}`;
 
-    const forumsLink = `${FORUMS_URL}/u/foo`;
+    const forumsLink = `${OLD_SUBDOMAIN_FORUMS_URL}/u/foo`;
     const externalLink = 'https://google.com';
 
     // Check common case


### PR DESCRIPTION
[Staging Link Sitemap](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-753/sitemap.xml)

This PR removes the community forums sitemap from DevHub's sitemap.xml and as a result, removes the existing sitemap index. This won't be merged until the forums is set to move on July 15th.

This also updates links on DevHub (minus the nav) to point to the new forums location