### PR TITLE
DEVHUB-715: Use relative links where appropriate for the footer

### DIFF
--- a/src/components/dev-hub/global-footer.js
+++ b/src/components/dev-hub/global-footer.js
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { css, useTheme } from '@emotion/react';
 import { fontSize, lineHeight, screenSize, size } from './theme';
 import MongodbLogoIcon from './icons/mongodb-logo';
-import Link from './link';
+import Link from '../Link';
 import FacebookIcon from './icons/facebook-icon';
 import TwitterIcon from './icons/twitter-icon';
 import LinkedIn from './icons/linkedin';
@@ -202,7 +202,7 @@ const ListItem = styled('li')`
 `;
 const getLinksList = (link, isListType) => (
     <ListItem isListType={isListType} key={link.url}>
-        <FooterLink href={link.url}>{link.name}</FooterLink>
+        <FooterLink to={link.url}>{link.name}</FooterLink>
     </ListItem>
 );
 export default () => {
@@ -213,7 +213,7 @@ export default () => {
                 <LogoContainer>
                     <FooterLink
                         css={iconstyles(theme)}
-                        href="https://www.mongodb.com/"
+                        to="https://www.mongodb.com/"
                     >
                         <MongodbLogoIcon css={logoStyles} />
                     </FooterLink>


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DEVHUB-715)
[Staging Link](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-715/)

This PR fixes a bug for mongodb.com/developer where the footer was using an absolute link instead of a relative one. This means the DevHub link on the footer went to mongodb.com and not mongodb.com/developer. This PR swaps which link we are using to one that checks if a link is external or internal before determining the appropriate target location.