### PR TITLE
DEVHUB-710: Use withPrefix for Search Images

### DIFF
--- a/gatsby-config.prod-new.js
+++ b/gatsby-config.prod-new.js
@@ -10,7 +10,7 @@ require('dotenv').config({
 const metadata = getMetadata();
 
 module.exports = {
-    pathPrefix: 'developer',
+    pathPrefix: '/developer',
     plugins: [
         'gatsby-plugin-react-helmet',
         'gatsby-plugin-emotion',

--- a/src/classes/search-article-result.ts
+++ b/src/classes/search-article-result.ts
@@ -3,6 +3,9 @@ import { Article } from '../interfaces/article';
 import { ArticleCategory } from '../types/article-category';
 import { ArticleSEO } from '../types/article-seo';
 import { mapTagTypeToUrl } from '../utils/map-tag-type-to-url';
+import { withPrefix } from 'gatsby';
+
+const isInternalFile = file => /^\//.test(file);
 
 export class SearchArticleResult implements Article {
     _id: String;
@@ -37,7 +40,8 @@ export class SearchArticleResult implements Article {
         // We don't need below for cards
         //@ts-ignore
         this.SEO = {};
-        this.image = result['atf-image'];
+        const image = result['atf-image'];
+        this.image = isInternalFile(image) ? withPrefix(image) : image;
         this.title = dlv(result.title, [0, 'value'], result.slug);
         this.tags = mapTagTypeToUrl(result.tags, 'tag');
         this.type = result.type;


### PR DESCRIPTION
[Staging Search on Learn Page](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-710/learn/?content=Articles&text=world)
[Existing new domain search](https://www.mongodb.com/developer/learn/?content=Articles&text=world#main)

This PR fixes a bug where internal images from a search were not being applied with the `pathPrefix`, meaning instead of loading an image from `/developer/images/img` we were looking at `/images/img` which fails.

The solution was to see if an image file is local (starts with a slash) and if so, apply Gatsby's `withPrefix` function to tack on either `/developer` for the new domain or something else for a different build.

To verify, check out the staging link and see the images load whereas on .com/developer they do not!