### PR TITLE
Deploy, June 23 2021

### DIFF
--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -49,3 +49,8 @@ jobs:
               with:
                   name: cypress-screenshots
                   path: cypress/screenshots
+            - name: Run Lighthouse
+              uses: treosh/lighthouse-ci-action@v7
+              with:
+                  configPath: './lighthouserc.json'
+                  runs: 2

--- a/cypress/integration/strapi-article.js
+++ b/cypress/integration/strapi-article.js
@@ -1,0 +1,11 @@
+const STRAPI_ARTICLE = '/how-to/hapijs-nodejs-driver/';
+const PROD_STRAPI_ARTICLE_URL = `https://developer.mongodb.com${STRAPI_ARTICLE}`;
+
+describe('Sample Strapi Article', () => {
+    it('should have a default canonical URL', () => {
+        cy.visit(STRAPI_ARTICLE).then(() => {
+            cy.contains('Strapi HapiJS Article');
+            cy.checkCanonicalUrlValue(`${PROD_STRAPI_ARTICLE_URL}`);
+        });
+    });
+});

--- a/gatsby-config.prod-new.js
+++ b/gatsby-config.prod-new.js
@@ -10,7 +10,7 @@ require('dotenv').config({
 const metadata = getMetadata();
 
 module.exports = {
-    pathPrefix: 'developer',
+    pathPrefix: '/developer',
     plugins: [
         'gatsby-plugin-react-helmet',
         'gatsby-plugin-emotion',

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,21 @@
+{
+    "ci": {
+        "collect": {
+            "url": [
+                "http://localhost/",
+                "http://localhost/article/3-things-to-know-switch-from-sql-mongodb/"
+            ],
+            "staticDistDir": "./public"
+        },
+        "assert": {
+            "assertions": {
+                "categories:accessibility": ["error", { "minScore": 0.85 }],
+                "categories:best-practices": ["error", { "minScore": 0.75 }],
+                "categories:performance": ["warn", { "minScore": 0.75 }],
+                "categories:seo": ["error", { "minScore": 0.8 }],
+                "dom-size": ["warn", { "maxNumericValue": 1000 }],
+                "first-contentful-paint": ["error", { "maxNumericValue": 4500 }]
+            }
+        }
+    }
+}

--- a/src/classes/search-article-result.ts
+++ b/src/classes/search-article-result.ts
@@ -3,6 +3,9 @@ import { Article } from '../interfaces/article';
 import { ArticleCategory } from '../types/article-category';
 import { ArticleSEO } from '../types/article-seo';
 import { mapTagTypeToUrl } from '../utils/map-tag-type-to-url';
+import { withPrefix } from 'gatsby';
+
+const isInternalFile = file => /^\//.test(file);
 
 export class SearchArticleResult implements Article {
     _id: String;
@@ -37,7 +40,8 @@ export class SearchArticleResult implements Article {
         // We don't need below for cards
         //@ts-ignore
         this.SEO = {};
-        this.image = result['atf-image'];
+        const image = result['atf-image'];
+        this.image = isInternalFile(image) ? withPrefix(image) : image;
         this.title = dlv(result.title, [0, 'value'], result.slug);
         this.tags = mapTagTypeToUrl(result.tags, 'tag');
         this.type = result.type;

--- a/src/components/dev-hub/global-footer.js
+++ b/src/components/dev-hub/global-footer.js
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { css, useTheme } from '@emotion/react';
 import { fontSize, lineHeight, screenSize, size } from './theme';
 import MongodbLogoIcon from './icons/mongodb-logo';
-import Link from './link';
+import Link from '../Link';
 import FacebookIcon from './icons/facebook-icon';
 import TwitterIcon from './icons/twitter-icon';
 import LinkedIn from './icons/linkedin';
@@ -202,7 +202,7 @@ const ListItem = styled('li')`
 `;
 const getLinksList = (link, isListType) => (
     <ListItem isListType={isListType} key={link.url}>
-        <FooterLink href={link.url}>{link.name}</FooterLink>
+        <FooterLink to={link.url}>{link.name}</FooterLink>
     </ListItem>
 );
 export default () => {
@@ -213,7 +213,7 @@ export default () => {
                 <LogoContainer>
                     <FooterLink
                         css={iconstyles(theme)}
-                        href="https://www.mongodb.com/"
+                        to="https://www.mongodb.com/"
                     >
                         <MongodbLogoIcon css={logoStyles} />
                     </FooterLink>

--- a/src/utils/generate-path-prefix.js
+++ b/src/utils/generate-path-prefix.js
@@ -17,6 +17,7 @@ const generatePathPrefix = ({
         return `/${pathPrefix}`;
     }
 
+    const userForPathPrefix = process.env.GATSBY_STAGING_USER || user;
     let prefix = '';
     if (commitHash) prefix += `${commitHash}`;
     if (patchId) prefix += `/${patchId}`;
@@ -26,7 +27,7 @@ const generatePathPrefix = ({
     // be present in the URL's path prefix in order to be mut-compatible.
     //
     // TODO: Simplify this logic when Snooty development is staged in integration environment
-    const base = `${project}/${user}`;
+    const base = `${project}/${userForPathPrefix}`;
     const path = process.env.GATSBY_SNOOTY_DEV
         ? `/${prefix}/${parserBranch}/${base}/${snootyBranch}`
         : `/${prefix}/${base}/${parserBranch}`;

--- a/src/utils/transform-article-strapi-data.js
+++ b/src/utils/transform-article-strapi-data.js
@@ -1,5 +1,7 @@
 import { transformAuthorStrapiData } from './setup/transform-author-strapi-data';
 import { parseMarkdownToAST } from './setup/parse-markdown-to-ast';
+import { SITE_URL } from '../constants';
+import { addTrailingSlashIfMissing } from '../utils/add-trailing-slash-if-missing';
 
 const typeMap = {
     Article: 'article',
@@ -14,6 +16,7 @@ export const transformArticleStrapiData = article => {
     const transformedAuthors = authors.map(transformAuthorStrapiData);
     const parsedContent = parseMarkdownToAST(article.content);
     const SEOObject = article.SEO || {};
+    const fullSlug = `${typeMap[inferredType]}${article.slug}`;
     return {
         ...article,
         authors: transformedAuthors,
@@ -30,7 +33,9 @@ export const transformArticleStrapiData = article => {
               }))
             : [],
         SEO: {
-            canonicalUrl: SEOObject.canonical_url,
+            canonicalUrl:
+                SEOObject.canonical_url ||
+                addTrailingSlashIfMissing(`${SITE_URL}/${fullSlug}`),
             metaDescription: SEOObject.meta_description,
             og: {
                 description: SEOObject.og_description,
@@ -47,7 +52,7 @@ export const transformArticleStrapiData = article => {
                 title: SEOObject.twitter_title,
             },
         },
-        slug: `${typeMap[inferredType]}${article.slug}`,
+        slug: fullSlug,
         tags: article.tags.map(t => t.tag),
         type: typeMap[inferredType],
     };


### PR DESCRIPTION
[Staging Job](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=60d35205a1eeec1fdc25578f)
[Staging Link](http://docs-devhub-staging.s3-website-us-east-1.amazonaws.com/03e261b/devhub/docsworker-xlarge/june-23-2021/)
[Release Notes](https://wiki.corp.mongodb.com/display/DEVREL/Developer+Hub+Release+Notes)

```
staging using branch origin/staging
production using branch origin/master

changes in staging but not production:
cf83bc1c DEVHUB-710: Use withPrefix for Search Images (#875)
0c9c0ce5 DEVHUB-715: Use relative links where appropriate for the footer (#874)
f8cfd00e DEVHUB-706: Add Canonical URL Fallback for Strapi Articles (#869)
ebf6963e Add new ENV option for username customization for staging links (#870)
76f4f1d1 Add Google Lighthouse Tooling into Github Actions CI (#859)
```