### PR TITLE
DEVHUB-720: Swap site URLs for XML files generated

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -12,6 +12,8 @@ require('dotenv').config({
 
 const metadata = getMetadata();
 
+const SITE_URL = 'https://developer.mongodb.com';
+
 module.exports = {
     pathPrefix: generatePathPrefix(metadata),
     plugins: [
@@ -78,7 +80,7 @@ module.exports = {
             resolve: 'gatsby-plugin-feed',
             options: {
                 query: siteUrl,
-                feeds: [articleRssFeed, searchRssFeed],
+                feeds: [articleRssFeed(SITE_URL), searchRssFeed(SITE_URL)],
             },
         },
         'gatsby-plugin-meta-redirect', // this must be last
@@ -87,6 +89,6 @@ module.exports = {
         ...metadata,
         title: 'MongoDB Developer Hub',
         // This value must start with `https://` or the build fails
-        siteUrl: 'https://developer.mongodb.com',
+        siteUrl: SITE_URL,
     },
 };

--- a/gatsby-config.prod-new.js
+++ b/gatsby-config.prod-new.js
@@ -7,6 +7,8 @@ require('dotenv').config({
     path: '.env.production',
 });
 
+const SITE_URL = 'https://mongodb.com/developer';
+
 const metadata = getMetadata();
 
 module.exports = {
@@ -52,7 +54,7 @@ module.exports = {
         },
         {
             resolve: 'gatsby-plugin-sitemap',
-            output: '/sitemap-pages.xml',
+            output: '/sitemap.xml',
             options: {
                 // Exclude paths we are using the noindex tag on
                 exclude: [
@@ -63,6 +65,7 @@ module.exports = {
                     '/type/*',
                 ],
             },
+            resolvePagePath: () => '',
         },
         {
             resolve: 'gatsby-plugin-google-tagmanager',
@@ -75,7 +78,7 @@ module.exports = {
             resolve: 'gatsby-plugin-feed',
             options: {
                 query: siteUrl,
-                feeds: [articleRssFeed, searchRssFeed],
+                feeds: [articleRssFeed(SITE_URL), searchRssFeed(SITE_URL)],
             },
         },
         `gatsby-plugin-meta-redirect`, // this must be last
@@ -83,6 +86,6 @@ module.exports = {
     siteMetadata: {
         ...metadata,
         title: 'MongoDB Developer Hub',
-        siteUrl: 'https://mongodb.com/developer',
+        siteUrl: SITE_URL,
     },
 };

--- a/gatsby-config.prod-new.js
+++ b/gatsby-config.prod-new.js
@@ -64,8 +64,9 @@ module.exports = {
                     '/tag/*',
                     '/type/*',
                 ],
+                // This plugin uses the siteUrl AND prefix path, will still apply the prefix
+                resolveSiteUrl: () => 'https://mongodb.com/',
             },
-            resolvePagePath: () => '',
         },
         {
             resolve: 'gatsby-plugin-google-tagmanager',

--- a/gatsby-config.prod.js
+++ b/gatsby-config.prod.js
@@ -9,6 +9,8 @@ require('dotenv').config({
 
 const metadata = getMetadata();
 
+const SITE_URL = 'https://developer.mongodb.com';
+
 module.exports = {
     pathPrefix: '',
     plugins: [
@@ -75,7 +77,7 @@ module.exports = {
             resolve: 'gatsby-plugin-feed',
             options: {
                 query: siteUrl,
-                feeds: [articleRssFeed, searchRssFeed],
+                feeds: [articleRssFeed(SITE_URL), searchRssFeed(SITE_URL)],
             },
         },
         `gatsby-plugin-meta-redirect`, // this must be last
@@ -83,6 +85,6 @@ module.exports = {
     siteMetadata: {
         ...metadata,
         title: 'MongoDB Developer Hub',
-        siteUrl: 'https://developer.mongodb.com',
+        siteUrl: SITE_URL,
     },
 };

--- a/src/utils/setup/article-rss-feed.js
+++ b/src/utils/setup/article-rss-feed.js
@@ -1,9 +1,7 @@
 const { rssFeedArticleData } = require('../../queries/rss-feed-article-data');
 const { serializeRssData } = require('./serialize-rss-data');
 
-const siteUrl = 'https://developer.mongodb.com';
-
-const articleRssFeed = {
+const articleRssFeed = siteUrl => ({
     serialize: serializeRssData,
     query: rssFeedArticleData,
     output: '/rss.xml',
@@ -11,6 +9,6 @@ const articleRssFeed = {
     image_url: siteUrl + '/public/images/MongoDB_Leaf.svg',
     site_url: siteUrl,
     feed_url: siteUrl + '/rss.xml',
-};
+});
 
 module.exports = { articleRssFeed };

--- a/src/utils/setup/search-rss-feed.js
+++ b/src/utils/setup/search-rss-feed.js
@@ -3,15 +3,13 @@ const {
 } = require('../../queries/search-article-rss-data');
 const { serializeSearchRssData } = require('./serialize-search-rss-data');
 
-const siteUrl = 'https://developer.mongodb.com';
-
-const searchRssFeed = {
+const searchRssFeed = siteUrl => ({
     serialize: serializeSearchRssData,
     query: searchArticleRSSData,
     output: '/search-rss.xml',
     title: 'MongoDB Developer Hub (Expanded)',
     site_url: siteUrl,
     feed_url: siteUrl + '/search-rss.xml',
-};
+});
 
 module.exports = { searchRssFeed };


### PR DESCRIPTION
[Staging Link (built off of gatsby-config.prod-new.js) Sitemap](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-720/sitemap.xml)
[Staging Link (built off of gatsby-config.prod-new.js) RSS feed XML](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-720/rss.xml)
[Staging Link (built off of gatsby-config.prod-new.js) Search RSS feed XML](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-720/search-rss.xml)

This PR makes some build-time changes to prepare us for the domain swap. Specifically:
- We parameterize the /rss.xml and /search-rss.xml files to take the appropriate site url into account. These should now have a consistent URL
- We fix a bug where the sitemap had mongodb.com/developer/developer/... by using the `gatsby-plugin-sitemap` `resolveSiteUrl` option to drop a `/developer` since it seems to use both