### PR TITLE
DEVHUB-772: Only Listen for Search Keydown When Focused

### DIFF
--- a/src/components/dev-hub/searchbar/ExpandedSearchbar.js
+++ b/src/components/dev-hub/searchbar/ExpandedSearchbar.js
@@ -170,6 +170,7 @@ const ExpandedSearchbar = ({ isFocused, onChange, onMobileClose }) => {
     useEventListener('keydown', onKeyDown, {
         dependencies: [searchTextbox.current],
         element: searchTextbox.current,
+        enabled: isFocused,
     });
 
     const searchUrl = useMemo(

--- a/src/components/dev-hub/searchbar/Searchbar.js
+++ b/src/components/dev-hub/searchbar/Searchbar.js
@@ -253,6 +253,7 @@ const Searchbar = ({ isExpanded, setIsExpanded }) => {
                         }}
                     >
                         <ExpandedSearchbar
+                            isFocused={isFocused}
                             onMobileClose={onClose}
                             onChange={onSearchChange}
                         />


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DEVHUB-772)
[Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-772/)

This PR fixes some keyboard navigation behavior on DevHub. Previously, because of a key binding, readers could not scroll down on articles using arrow keys (up/down). This PR cleans up the event listener to only listen for these keys when the searchbar is focused on. To verify:

- Open the staging link
- Go to an article
- Try to scroll up/down using arrow keys
- Verify this does not work on production
- Search for something
- Press the down key and verify the first option is still highlighted