### PR TITLE
DEVHUB-772: Also Update when isFocused changes

### DIFF
--- a/src/components/dev-hub/searchbar/ExpandedSearchbar.js
+++ b/src/components/dev-hub/searchbar/ExpandedSearchbar.js
@@ -168,7 +168,7 @@ const ExpandedSearchbar = ({ isFocused, onChange, onMobileClose }) => {
     );
 
     useEventListener('keydown', onKeyDown, {
-        dependencies: [searchTextbox.current],
+        dependencies: [isFocused, searchTextbox.current],
         element: searchTextbox.current,
         enabled: isFocused,
     });


### PR DESCRIPTION
[Staging Link](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-772-dep/)

It seemed like the staging link I had before worked sporadically and when testing again we may have been missing something. When the site is built with static rendering we set `isFocused` to `false` by default and don't update the event listener correctly. [I looked at the source code](https://github.com/mongodb/leafygreen-ui/blob/dea88e7dfa12fb44fe5dc429b0c97b2ad61ba075/packages/hooks/src/useEventListener.ts#L73) and it seems like the right thing to do is to also add `isFocused` as a dependency so the hook is re-run.

tl;dr, should work for real now all the time.