### PR TITLE
Community Champions - Set champion background colour

### DIFF
--- a/src/pages/community-champions.js
+++ b/src/pages/community-champions.js
@@ -568,6 +568,7 @@ const ChampionTitleText = styled(P3)`
 const ChampionProfilePicture = styled(ProfileImage)`
     margin-bottom: ${size.default};
     div {
+        background-color: ${({ theme }) => theme.colorMap.devWhite};
         background-size: cover;
     }
 `;


### PR DESCRIPTION
## Links:

-   [Staging Link](https://docs-mongodbcom-staging.corp.mongodb.com/CI/devhub/sophia.li/set-champion-background-colour/community-champions/)

## Description:

-  I noticed one of the champion photos had a transparent background, so the gradient shows through like this:

<img width="225" alt="Screen Shot 2021-07-16 at 3 22 58 PM" src="https://user-images.githubusercontent.com/46455728/125998652-6b97cb30-8089-417b-b65e-859f04afb656.png">

- This PR sets the background colour to white (colour confirmed by Mike 🙂). I think this will make it easier for us in the future if we get more champion photos with transparent backgrounds as we won't have to ask people for new photos each time. Lmk what you think!

## Testing

- Check out Leandro's photo and verify the background is white.

## What types of outside events need to happen for this PR?

-   [ ] Documentation Updates
-   [ ] Product Review
-   [ ] Design Review
-   [ ] Release Note Update (only for deployments)
