### PR TITLE
Add a title tag to community champions

### DIFF
--- a/src/pages/community-champions.js
+++ b/src/pages/community-champions.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Helmet } from 'react-helmet';
 import styled from '@emotion/styled';
 import dlv from 'dlv';
 import { useStaticQuery, graphql } from 'gatsby';
@@ -27,6 +28,7 @@ import {
     screenSize,
     size,
 } from '~components/dev-hub/theme';
+import { useSiteMetadata } from '~hooks/use-site-metadata';
 import BannerImage from '~images/community-champions/champions-badge.svg';
 import BannerImageWithSpace from '~images/community-champions/champions-badge-w-space.svg';
 import PartnerWithMongoDBImage from '~images/community-champions/partner-with-mongodb.jpg';
@@ -673,9 +675,13 @@ const communityChampionBreadcrumbs = [
 ];
 
 const CommunityChampions = () => {
+    const metadata = useSiteMetadata();
     const useBannerImageWithSpace = useMedia(screenSize.upToSmall);
     return (
         <Layout>
+            <Helmet>
+                <title>Community Champions - {metadata.title}</title>
+            </Helmet>
             <StyledHeroBanner
                 /* On phones, we will use the banner image with space on the sides so it doesn't appear too big */
                 background={


### PR DESCRIPTION
## Links:

-   JIRA Ticket N/A
-   [Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/CI/devhub/jordanstapinski/add-champions-title/community-champions/)

## Description:

-   This PR adds a `<title>` tag to the entry page. This tag is good for SEO as well as a nice improvement by putting something other than the URL in the tab for the page.
-   `react-helmet` is a library which puts any children into the `head` of the HTML page created to keep metadata organized

## Testing

-   Check that in the browser tab there is a reasonable title

## What types of outside events need to happen for this PR?

-   [ ] Documentation Updates
-   [ ] Product Review
-   [ ] Design Review
-   [ ] Release Note Update (only for deployments)
