### PR TITLE
DEVHUB-686: Add fallback for strapi publication state

### DIFF
--- a/src/utils/setup/map-publication-state-to-array.js
+++ b/src/utils/setup/map-publication-state-to-array.js
@@ -5,7 +5,10 @@ const mapPublicationStateToArray = arr =>
     arr.map(name => ({
         name,
         api: {
-            qs: { _publicationState: process.env.STRAPI_PUBLICATION_STATE },
+            qs: {
+                _publicationState:
+                    process.env.STRAPI_PUBLICATION_STATE || 'live',
+            },
         },
     }));
 


### PR DESCRIPTION
This PR adds a fallback for pulling publication state so it defaults to `live`. This was the behavior on the fork and may persist on the autobuilder (the `env` var may not have been supplied since the default was `live` if omitted)

No staging link really necessary