### PR TITLE
Community Champions - set up profile page template

### DIFF
--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -25,6 +25,7 @@ import { SnootyArticle } from './src/classes/snooty-article';
 import { createVideoPages } from './src/utils/setup/create-video-pages';
 import { fetchBuildTimeMedia } from './src/utils/setup/fetch-build-time-media';
 import { aggregateItemsByVideoType } from './src/utils/setup/aggregate-items-by-video-type';
+import { createCommunityChampionProfilePages } from './src/utils/setup/create-community-champion-profile-pages';
 
 const pluralizeIfNeeded = {
     author: 'authors',
@@ -207,6 +208,8 @@ export const createPages = async ({ actions, graphql }) => {
     await Promise.all(tagPages);
 
     await createVideoPages(createPage, allVideos, metadataDocument);
+
+    await createCommunityChampionProfilePages(createPage, graphql);
 };
 
 // Prevent errors when running gatsby build caused by browser packages run in a node environment.

--- a/src/queries/community-champions.js
+++ b/src/queries/community-champions.js
@@ -1,0 +1,30 @@
+export const communityChampions = `
+    query CommunityChampions {
+        allStrapiCommunityChampions(
+            sort: { fields: [firstName, middleName, lastName] }
+        ) {
+            nodes {
+                id
+                firstName
+                middleName
+                lastName
+                location
+                title
+                image {
+                    url
+                }
+                quote
+                languagesSpoken
+                bio
+                BlogsAndPublications {
+                  link
+                  title
+                }
+                Certifications {
+                  isDBAAssociateCertified
+                  isDeveloperAssociateCertified
+                }
+            }
+        }
+    }
+ `;

--- a/src/queries/community-champions.js
+++ b/src/queries/community-champions.js
@@ -1,10 +1,7 @@
 export const communityChampions = `
     query CommunityChampions {
-        allStrapiCommunityChampions(
-            sort: { fields: [firstName, middleName, lastName] }
-        ) {
+        allStrapiCommunityChampions {
             nodes {
-                id
                 firstName
                 middleName
                 lastName

--- a/src/templates/community-champion-profile.js
+++ b/src/templates/community-champion-profile.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import Breadcrumb from '~components/dev-hub/breadcrumb';
+import Layout from '~components/dev-hub/layout';
+import { fontSize, screenSize, size } from '~components/dev-hub/theme';
+
+const BREADCRUMB_BOTTOM_MARGIN = '40px';
+
+const ContentContainer = styled('div')`
+    padding: ${size.default} ${size.xxlarge};
+    @media ${screenSize.upToLarge} {
+        padding: ${size.mediumLarge} ${size.default};
+    }
+`;
+
+const StyledBreadcrumb = styled(Breadcrumb)`
+    line-height: 1;
+    margin-bottom: ${BREADCRUMB_BOTTOM_MARGIN};
+    > a {
+        font-size: ${fontSize.xsmall};
+    }
+    @media ${screenSize.upToLarge} {
+        margin-bottom: ${size.large};
+    }
+`;
+
+const CommunityChampionProfile = props => {
+    const {
+        pageContext: { champion, slug },
+    } = props;
+    const { firstName, middleName, lastName } = champion;
+    const fullName = [firstName, middleName, lastName].join(' ');
+    const championProfileBreadcrumbs = [
+        { label: 'Home', target: '/' },
+        {
+            label: 'MongoDB Community Champions',
+            target: '/community-champions',
+        },
+        {
+            label: `${fullName}`,
+            target: slug,
+        },
+    ];
+    return (
+        <Layout>
+            <ContentContainer>
+                <StyledBreadcrumb>
+                    {championProfileBreadcrumbs}
+                </StyledBreadcrumb>
+            </ContentContainer>
+        </Layout>
+    );
+};
+
+export default CommunityChampionProfile;

--- a/src/templates/community-champion-profile.js
+++ b/src/templates/community-champion-profile.js
@@ -6,6 +6,14 @@ import { fontSize, screenSize, size } from '~components/dev-hub/theme';
 
 const BREADCRUMB_BOTTOM_MARGIN = '40px';
 
+const CHAMPION_PROFILE_BREADCRUMBS_PREFIX = [
+    { label: 'Home', target: '/' },
+    {
+        label: 'MongoDB Community Champions',
+        target: '/community-champions',
+    },
+];
+
 const ContentContainer = styled('div')`
     padding: ${size.default} ${size.xxlarge};
     @media ${screenSize.upToLarge} {
@@ -30,17 +38,12 @@ const CommunityChampionProfile = props => {
     } = props;
     const { firstName, middleName, lastName } = champion;
     const fullName = [firstName, middleName, lastName].join(' ');
-    const championProfileBreadcrumbs = [
-        { label: 'Home', target: '/' },
-        {
-            label: 'MongoDB Community Champions',
-            target: '/community-champions',
-        },
+    const championProfileBreadcrumbs = CHAMPION_PROFILE_BREADCRUMBS_PREFIX.push(
         {
             label: `${fullName}`,
             target: slug,
-        },
-    ];
+        }
+    );
     return (
         <Layout>
             <ContentContainer>

--- a/src/templates/community-champion-profile.js
+++ b/src/templates/community-champion-profile.js
@@ -38,11 +38,13 @@ const CommunityChampionProfile = props => {
     } = props;
     const { firstName, middleName, lastName } = champion;
     const fullName = [firstName, middleName, lastName].join(' ');
-    const championProfileBreadcrumbs = CHAMPION_PROFILE_BREADCRUMBS_PREFIX.push(
-        {
-            label: `${fullName}`,
-            target: slug,
-        }
+    const championProfileBreadcrumbs = CHAMPION_PROFILE_BREADCRUMBS_PREFIX.concat(
+        [
+            {
+                label: `${fullName}`,
+                target: slug,
+            },
+        ]
     );
     return (
         <Layout>

--- a/src/utils/setup/create-community-champion-profile-pages.js
+++ b/src/utils/setup/create-community-champion-profile-pages.js
@@ -3,10 +3,7 @@ import { communityChampions } from '../../queries/community-champions';
 
 const createCommunityChampionProfilePage = (champion, createPage) => {
     const { firstName, lastName } = champion;
-    const encodedNameURIComponent = encodeURIComponent(
-        `${firstName.toLowerCase()}-${lastName.toLowerCase()}`
-    );
-    const slug = `/community-champions/${encodedNameURIComponent}`;
+    const slug = `/community-champions/${firstName.toLowerCase()}-${lastName.toLowerCase()}`;
     createPage({
         path: slug,
         component: path.resolve(

--- a/src/utils/setup/create-community-champion-profile-pages.js
+++ b/src/utils/setup/create-community-champion-profile-pages.js
@@ -1,9 +1,12 @@
 import path from 'path';
 import { communityChampions } from '../../queries/community-champions';
 
-const createCommunityChampionProfilePage = async (champion, createPage) => {
+const createCommunityChampionProfilePage = (champion, createPage) => {
     const { firstName, lastName } = champion;
-    const slug = `/community-champions/${firstName.toLowerCase()}-${lastName.toLowerCase()}`;
+    const encodedNameURIComponent = encodeURIComponent(
+        `${firstName.toLowerCase()}-${lastName.toLowerCase()}`
+    );
+    const slug = `/community-champions/${encodedNameURIComponent}`;
     createPage({
         path: slug,
         component: path.resolve(
@@ -27,8 +30,7 @@ export const createCommunityChampionProfilePages = async (
     graphql
 ) => {
     const championList = await getChampionListFromGraphql(graphql);
-    championList.forEach(
-        async champion =>
-            await createCommunityChampionProfilePage(champion, createPage)
+    championList.forEach(champion =>
+        createCommunityChampionProfilePage(champion, createPage)
     );
 };

--- a/src/utils/setup/create-community-champion-profile-pages.js
+++ b/src/utils/setup/create-community-champion-profile-pages.js
@@ -1,0 +1,34 @@
+import path from 'path';
+import { communityChampions } from '../../queries/community-champions';
+
+const createCommunityChampionProfilePage = async (champion, createPage) => {
+    const { firstName, lastName } = champion;
+    const slug = `/community-champions/${firstName.toLowerCase()}-${lastName.toLowerCase()}`;
+    createPage({
+        path: slug,
+        component: path.resolve(
+            `./src/templates/community-champion-profile.js`
+        ),
+        context: {
+            champion,
+            slug,
+        },
+    });
+};
+
+const getChampionListFromGraphql = async graphql => {
+    const championResp = await graphql(communityChampions);
+    const result = championResp.data.allStrapiCommunityChampions.nodes;
+    return result;
+};
+
+export const createCommunityChampionProfilePages = async (
+    createPage,
+    graphql
+) => {
+    const championList = await getChampionListFromGraphql(graphql);
+    championList.forEach(
+        async champion =>
+            await createCommunityChampionProfilePage(champion, createPage)
+    );
+};


### PR DESCRIPTION
## Links:

-   [JIRA Ticket](https://jira.mongodb.org/browse/DEVHUB-784)
-   [Staging Link](https://docs-mongodbcom-staging.corp.mongodb.com/CI/devhub/sophia.li/DEVHUB-784/community-champions/chris-dellaway/)

## Description:

-   This PR sets up the creation of Community Champion profile pages!

## Testing

-   Verify that there are pages at /community-champions/firstname-lastname for the champions shown at the bottom [here](https://docs-mongodbcom-staging.corp.mongodb.com/CI/devhub/sophia.li/DEVHUB-784/community-champions/). Profile pages currently only have breadcrumbs shown at the top.

## What types of outside events need to happen for this PR?

-   [ ] Documentation Updates
-   [ ] Product Review
-   [ ] Design Review
-   [ ] Release Note Update (only for deployments)
