### PR TITLE
DEVHUB-789: Gracefully Handle Unsupported Lanagues in Codeblocks

### DIFF
--- a/src/components/dev-hub/codeblock.js
+++ b/src/components/dev-hub/codeblock.js
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import Code from '@leafygreen-ui/code';
+import { determineCorrectLeafygreenLanguage } from '~utils/determine-correct-leafygreen-language';
 import { lineHeight, size } from './theme';
 import CopyButton, { COPY_BUTTON_WIDTH } from './copy-button';
 
@@ -82,8 +83,7 @@ const CodeBlock = ({
     const numDigits = useMemo(() => Math.floor(Math.log10(numLines) + 1), [
         numLines,
     ]);
-    // Leafy expects 'csp' as 'cs'
-    const language = lang === 'csp' ? 'cs' : lang || 'none';
+    const language = determineCorrectLeafygreenLanguage(lang);
     return (
         <CodeContainer>
             <StyledCode

--- a/src/utils/determine-correct-leafygreen-language.js
+++ b/src/utils/determine-correct-leafygreen-language.js
@@ -1,0 +1,23 @@
+import { Language } from '@leafygreen-ui/code';
+
+const SUPPORTED_LANGUAGES = new Set(Object.values(Language));
+
+export const determineCorrectLeafygreenLanguage = inputLang => {
+    let language = !!inputLang ? inputLang.toLowerCase() : 'none';
+    if (language === 'html' || language === 'toml') {
+        // Seem to be supported but not in the Language export from LG
+        return language;
+    } else if (language === 'csp') {
+        // LG expects 'csp' as 'cs'
+        language = 'cs';
+    } else if (language === 'sh') {
+        language = 'shell';
+    } else if (!SUPPORTED_LANGUAGES.has(language)) {
+        // Language is not supported formally by LG, set to none to avoid errors
+        const warningMessage = `Warning: Language ${language} is not supported. Defaulting to "none"`;
+        console.warn(warningMessage);
+        console.log(warningMessage);
+        language = 'none';
+    }
+    return language;
+};

--- a/tests/utils/determine-correct-leafygreen-language.test.js
+++ b/tests/utils/determine-correct-leafygreen-language.test.js
@@ -1,0 +1,23 @@
+import { determineCorrectLeafygreenLanguage } from '../../src/utils/determine-correct-leafygreen-language';
+
+const NONE = 'none';
+
+it('should correctly determine code langauges to use with LG', () => {
+    const logFn = console.warn;
+    const warnFn = console.warn;
+    // Mock console functions to suppress output and allow for testing
+    console.log = jest.fn();
+    console.warn = jest.fn();
+    expect(determineCorrectLeafygreenLanguage('')).toBe(NONE);
+    expect(determineCorrectLeafygreenLanguage('react')).toBe(NONE);
+    // We should warn if an unsupported language is provided and log to build output
+    expect(console.log).toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalled();
+
+    expect(determineCorrectLeafygreenLanguage('sh')).toBe('shell');
+    expect(determineCorrectLeafygreenLanguage('csp')).toBe('cs');
+    expect(determineCorrectLeafygreenLanguage('html')).toBe('html');
+    expect(determineCorrectLeafygreenLanguage('toml')).toBe('toml');
+    console.log = logFn;
+    console.warn = warnFn;
+});


### PR DESCRIPTION
## Links:

-   [JIRA Ticket](https://jira.mongodb.org/browse/DEVHUB-789)
-   [Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-789/)

## Description:

-   This PR improves the Codeblock logic to be more resilient if passed a language highlight option which is not supported. The idea is that we check from leafygreen (LG) if a language is supported and, if not, using `none` and throwing a warning.

## Testing

-   I added automated testing for the updated logic
-   Codeblocks in the staging link should still be highlighted

## What types of outside events need to happen for this PR?

-   [ ] Documentation Updates
-   [ ] Product Review
-   [ ] Design Review
-   [ ] Release Note Update (only for deployments)
