### PR TITLE
DEVHUB-518: Remove legacy field from sitemap construction

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -64,7 +64,6 @@ module.exports = {
         {
             resolve: 'gatsby-plugin-sitemap',
             options: {
-                output: '/sitemap.xml',
                 // Exclude paths we are using the noindex tag on
                 exclude: [
                     '/language/*',

--- a/gatsby-config.prod-new.js
+++ b/gatsby-config.prod-new.js
@@ -60,7 +60,6 @@ module.exports = {
         },
         {
             resolve: 'gatsby-plugin-sitemap',
-            output: '/sitemap.xml',
             options: {
                 // Exclude paths we are using the noindex tag on
                 exclude: [

--- a/gatsby-config.prod.js
+++ b/gatsby-config.prod.js
@@ -60,7 +60,6 @@ module.exports = {
         },
         {
             resolve: 'gatsby-plugin-sitemap',
-            output: '/sitemap.xml',
             options: {
                 // Exclude paths we are using the noindex tag on
                 exclude: [

--- a/src/components/dev-hub/survey-banner.js
+++ b/src/components/dev-hub/survey-banner.js
@@ -92,7 +92,7 @@ const SurveyBanner = () => {
                 </SurveyButtonContainer>
             </SurveyContent>
             <CloseButtonContainer>
-                <IconButton onClick={closeSurveyBanner}>
+                <IconButton aria-label="Close" onClick={closeSurveyBanner}>
                     <XWithCircleIcon fill="#f9fbfa" />
                 </IconButton>
             </CloseButtonContainer>


### PR DESCRIPTION
## Links:

-   [JIRA Ticket](https://jira.mongodb.org/browse/DEVHUB-518)

## Description:

-   This PR removes a field that changed with the new Sitemap plugin update. `output` expects to be the path to a directory since a sitemap-index is now the default. [Docs](https://www.gatsbyjs.com/plugins/gatsby-plugin-sitemap/)
-   I also resolved a warning about a missing label for `IconButton` since these now are emphasized on build output

## Testing

-   /sitemap/sitemap-index.xml should work on a staging link

## What types of outside events need to happen for this PR?

-   [ ] Documentation Updates
-   [ ] Product Review
-   [ ] Design Review
-   [ ] Release Note Update (only for deployments)
