### PR TITLE
DEVHUB-518: Resolve Named Export Warnings

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -11,7 +11,8 @@ const Container = styled('div')`
     margin: ${size.xlarge} auto;
     text-align: center;
 `;
-export default () => (
+
+const FourZeroFour = () => (
     <Layout includeCanonical={false}>
         <Helmet>
             <title>404 | MongoDB Developer Hub</title>
@@ -25,3 +26,5 @@ export default () => (
         </Container>
     </Layout>
 );
+
+export default FourZeroFour;

--- a/src/pages/academia/educators.js
+++ b/src/pages/academia/educators.js
@@ -8,7 +8,7 @@ import {
     ProgramBenefits,
 } from '../../components/pages/educators';
 
-export default () => {
+const EducatorsPage = () => {
     const metadata = useSiteMetadata();
     return (
         <Layout>
@@ -21,3 +21,5 @@ export default () => {
         </Layout>
     );
 };
+
+export default EducatorsPage;

--- a/src/pages/code-for-good.js
+++ b/src/pages/code-for-good.js
@@ -190,7 +190,7 @@ const HeaderActionsContainer = styled('div')`
     padding-top: ${size.large};
 `;
 
-export default () => {
+const OFishPage = () => {
     const metadata = useSiteMetadata();
     const codeForGoodBreadcrumbs = [
         { label: 'Home', target: '/' },
@@ -341,3 +341,5 @@ export default () => {
         </Layout>
     );
 };
+
+export default OFishPage;

--- a/src/pages/community/events.js
+++ b/src/pages/community/events.js
@@ -23,7 +23,7 @@ const breadcrumbs = [
     { label: 'Events', target: '/community/events' },
 ];
 
-export default () => {
+const CommunityEvents = () => {
     const [events, error, isLoading] = useEventData();
 
     const metadata = useSiteMetadata();
@@ -56,3 +56,5 @@ export default () => {
         </Layout>
     );
 };
+
+export default CommunityEvents;

--- a/src/pages/community/index.js
+++ b/src/pages/community/index.js
@@ -72,7 +72,7 @@ const CommunityHeroBanner = styled(HeroBanner)`
     }
 `;
 
-export default () => {
+const CommunityPage = () => {
     const { title } = useSiteMetadata();
     return (
         <Layout>
@@ -109,3 +109,5 @@ export default () => {
         </Layout>
     );
 };
+
+export default CommunityPage;

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -187,7 +187,7 @@ const FeaturedArticles = ({ articles }) => {
     );
 };
 
-export default ({
+const LearnPage = ({
     location,
     navigate,
     pageContext: {
@@ -370,3 +370,5 @@ export default ({
         </Layout>
     );
 };
+
+export default LearnPage;


### PR DESCRIPTION
## Links:

-   [JIRA Ticket](https://jira.mongodb.org/browse/DEVHUB-518)
-   [Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-518-warnings/)

## Description:

-   This ticket addresses some Gatsby v3 development warnings where we had some pages not using named exports. Named exports are the following pattern:
```
const Page = () => {};

export default Page;
```

whereas we did
```
export default () => {}
```

This let's Gatsby preserve page state a bit better on a hot reload (and addresses some verbose warnings!)

## Testing

-   These pages should still work

## What types of outside events need to happen for this PR?

-   [ ] Documentation Updates
-   [ ] Product Review
-   [ ] Design Review
-   [ ] Release Note Update (only for deployments)
