### PR TITLE
Swap Article Series Source to Strapi (#913)

### DIFF
--- a/cypress/integration/strapi-article.js
+++ b/cypress/integration/strapi-article.js
@@ -1,11 +1,30 @@
+const STRAPI_SERIES_TITLE = 'Strapi Series';
 const STRAPI_ARTICLE = '/how-to/hapijs-nodejs-driver/';
 const PROD_STRAPI_ARTICLE_URL = `https://www.mongodb.com/developer${STRAPI_ARTICLE}`;
+const SERIES_SECOND_ARTICLE = '/article/map-terms-concepts-sql-mongodb/';
 
 describe('Sample Strapi Article', () => {
     it('should have a default canonical URL', () => {
         cy.visit(STRAPI_ARTICLE).then(() => {
             cy.contains('Strapi HapiJS Article');
             cy.checkCanonicalUrlValue(`${PROD_STRAPI_ARTICLE_URL}`);
+        });
+    });
+
+    it('should support a series of articles', () => {
+        // Check series title
+        cy.get('[data-test="series"]').within(() => {
+            cy.contains(STRAPI_SERIES_TITLE);
+            cy.get('a').should('have.length', 2);
+            // Check other one goes to article
+            cy.get('a')
+                .first()
+                .should('have.prop', 'href')
+                .and('include', STRAPI_ARTICLE);
+            cy.get('a')
+                .eq(1)
+                .should('have.prop', 'href')
+                .and('include', SERIES_SECOND_ARTICLE);
         });
     });
 });

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -35,6 +35,7 @@ module.exports = {
                 apiURL: process.env.STRAPI_URL,
                 collectionTypes: mapPublicationStateToArray([
                     'articles',
+                    'article-series',
                     'client-side-redirects',
                     'projects',
                 ]),

--- a/gatsby-config.prod-new.js
+++ b/gatsby-config.prod-new.js
@@ -32,6 +32,7 @@ module.exports = {
                 apiURL: process.env.STRAPI_URL,
                 collectionTypes: mapPublicationStateToArray([
                     'articles',
+                    'article-series',
                     'client-side-redirects',
                     'projects',
                 ]),

--- a/gatsby-config.prod.js
+++ b/gatsby-config.prod.js
@@ -32,6 +32,7 @@ module.exports = {
                 apiURL: process.env.STRAPI_URL,
                 collectionTypes: mapPublicationStateToArray([
                     'articles',
+                    'article-series',
                     'client-side-redirects',
                     'projects',
                 ]),

--- a/src/classes/strapi-article-series.ts
+++ b/src/classes/strapi-article-series.ts
@@ -1,0 +1,43 @@
+/* 
+  Strapi Article Series can be composed of a mix of Strapi and Snooty article
+  references.
+*/
+import dlv from 'dlv';
+import { ArticleSeries, SeriesArticle } from '../interfaces/article-series';
+import { transformArticleStrapiData } from '../utils/transform-article-strapi-data';
+
+export class StrapiArticleSeries implements ArticleSeries {
+    articles: SeriesArticle[];
+    title: String;
+    constructor(title, entries, snootyTitleMapping) {
+        this.articles = entries.map(article => {
+            const isStrapi = !!article.article;
+            // Strapi's API for articles is different from what Snooty provides
+            return isStrapi
+                ? this.handleStrapiArticle(article.article)
+                : this.handleSnootyArticle(article, snootyTitleMapping);
+        });
+        this.title = title;
+    }
+
+    handleSnootyArticle = (article, snootyTitleMapping) => ({
+        slug: article.slug,
+        title: dlv(
+            snootyTitleMapping,
+            [
+                // Remove any leading/trailing slashes for use with Snooty's provided mapping
+                article.slug.replace(/^\/|\/$/g, ''),
+                'query_fields',
+                'title',
+                0,
+                'value',
+            ],
+            article.slug
+        ),
+    });
+
+    handleStrapiArticle = article => {
+        const { name, slug } = transformArticleStrapiData(article);
+        return { slug, title: name };
+    };
+}

--- a/src/queries/article-series.js
+++ b/src/queries/article-series.js
@@ -1,0 +1,10 @@
+export const articleSeries = `
+  query ArticleSeries {
+    allStrapiArticleSeries {
+      nodes {
+        seriesEntry
+        title
+      }
+    }
+  }
+`;

--- a/src/utils/setup/get-strapi-article-series-from-graphql.js
+++ b/src/utils/setup/get-strapi-article-series-from-graphql.js
@@ -1,0 +1,16 @@
+import dlv from 'dlv';
+import { articleSeries } from '../../queries/article-series';
+import { StrapiArticleSeries } from '../../classes/strapi-article-series';
+
+export const getStrapiArticleSeriesFromGraphql = async (
+    graphql,
+    slugContentMapping
+) => {
+    const allSeries = await graphql(articleSeries);
+    const nodes = dlv(allSeries, 'data.allStrapiArticleSeries.nodes', []) || [];
+    const result = nodes.map(
+        ({ title, seriesEntry }) =>
+            new StrapiArticleSeries(title, seriesEntry, slugContentMapping)
+    );
+    return result;
+};

--- a/src/utils/transform-article-strapi-data.js
+++ b/src/utils/transform-article-strapi-data.js
@@ -12,7 +12,7 @@ const typeMap = {
 // This will get more complicated as we build the pipeline out
 export const transformArticleStrapiData = article => {
     const inferredType = article.type || 'Article';
-    const authors = article.authors;
+    const authors = article.authors || [];
     const transformedAuthors = authors.map(transformAuthorStrapiData);
     const parsedContent = parseMarkdownToAST(article.content);
     const SEOObject = article.SEO || {};
@@ -23,8 +23,10 @@ export const transformArticleStrapiData = article => {
         contentAST: parsedContent,
         image: article.image ? article.image.url : null,
         isFromStrapi: true,
-        languages: article.languages.map(l => l.language),
-        products: article.products.map(p => p.product),
+        languages: article.languages
+            ? article.languages.map(l => l.language)
+            : [],
+        products: article.products ? article.products.map(p => p.product) : [],
         related: article.related_content
             ? article.related_content.map(({ label, url }) => ({
                   name: 'reference',
@@ -53,7 +55,7 @@ export const transformArticleStrapiData = article => {
             },
         },
         slug: fullSlug,
-        tags: article.tags.map(t => t.tag),
+        tags: article.tags ? article.tags.map(t => t.tag) : [],
         type: typeMap[inferredType],
     };
 };


### PR DESCRIPTION
## Links:

-   [Staging Job](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=610bea37382fd7618e25ba75)
-   [Staging Link](http://docs-devhub-staging.s3-website-us-east-1.amazonaws.com/cf33d36/devhub/docsworker-xlarge/strapi-series/)
-   [Release Notes](https://wiki.corp.mongodb.com/display/DEVREL/Developer+Hub+Release+Notes)

## Description:

-   This PR swaps the series logic to pull from Strapi and not Snooty

## Testing

-   Tests should still pass

## What types of outside events need to happen for this PR?

-   [ ] Documentation Updates
-   [ ] Product Review
-   [ ] Design Review
-   [X] Release Note Update (only for deployments)
