### PR TITLE
Don't make community forum links internal

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -36,5 +36,5 @@ export const FEEDBACK_APP_ID = 'feedback-ihion';
 
 export const OLD_SITE_URL = 'https://developer.mongodb.com';
 export const SITE_URL = 'https://www.mongodb.com/developer';
-export const OLD_SUBDOMAIN_FORUMS_URL = `${SITE_URL}/community/forums/`;
+export const OLD_SUBDOMAIN_FORUMS_URL = `${OLD_SITE_URL}/community/forums/`;
 export const FORUMS_URL = `https://www.mongodb.com/community/forums/`;

--- a/tests/utils/make-link-internal-if-applicable.test.js
+++ b/tests/utils/make-link-internal-if-applicable.test.js
@@ -9,7 +9,8 @@ it('should parse internal links and add a trailing slash if needed', () => {
     const internalArticleSlugTrailingSlash = `${internalArticleSlug}/`;
     const fullArticleLink = `${SITE_URL}${internalArticleSlug}`;
 
-    const forumsLink = `${OLD_SUBDOMAIN_FORUMS_URL}/u/foo`;
+    const forumsLink = `https://developer.mongodb.com/community/forums/u/foo`;
+    const newForumsLink = `https://www.mongodb.com/community/forums/u/foo`;
     const externalLink = 'https://google.com';
 
     // Check common case
@@ -29,6 +30,7 @@ it('should parse internal links and add a trailing slash if needed', () => {
 
     // Check the forums are not internal
     expect(makeLinkInternalIfApplicable(forumsLink)).toBe(forumsLink);
+    expect(makeLinkInternalIfApplicable(newForumsLink)).toBe(newForumsLink);
 
     // Check a random outside link that it is untouched
     expect(makeLinkInternalIfApplicable(externalLink)).toBe(externalLink);

--- a/tests/utils/make-link-internal-if-applicable.test.js
+++ b/tests/utils/make-link-internal-if-applicable.test.js
@@ -1,5 +1,5 @@
 import { makeLinkInternalIfApplicable } from '~utils/make-link-internal-if-applicable';
-import { OLD_SUBDOMAIN_FORUMS_URL, SITE_URL } from '~src/constants';
+import { SITE_URL } from '~src/constants';
 
 it('should parse internal links and add a trailing slash if needed', () => {
     expect(makeLinkInternalIfApplicable(null)).toBe(null);


### PR DESCRIPTION
## Links:

-   No JIRA Ticket
-   [Staging Link article fixed](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/fix-old-community-url/article/introduction-to-modern-databases-mongodb-academia/?tck=feathome)
-   [Same article on prod with issue](https://www.mongodb.com/developer/article/introduction-to-modern-databases-mongodb-academia/?tck=feathome)

## Description:

-   This PR fixes a bug related to the subdomain swap in which we incorrectly parsed old links to the forums and made links internal. We should have not changed these links and leave the href as it was. The bug was that the `OLD_SUBDOMAIN_FORUMS_URL` pointed to `https://www.mongodb.com/developer/community/forums` and not `https://developer.mongodb.com/community/forums`

## Testing

-   I updated our unit test to be a bit stronger and check for absolute domains instead of assuming consts were correct being imported, which they were not.
-   I put an article with the issue as well as a staging link of the same article above. At the end both have a link to the forums, but only in the fixed one does it not 404

## What types of outside events need to happen for this PR?

-   [ ] Documentation Updates
-   [ ] Product Review
-   [ ] Design Review
-   [ ] Release Note Update (only for deployments)
