### PR TITLE
DEVHUB-801: Filter Draft Series Articles from Prod Platform Builds

### DIFF
--- a/src/classes/strapi-article-series.ts
+++ b/src/classes/strapi-article-series.ts
@@ -5,8 +5,7 @@
 import dlv from 'dlv';
 import { ArticleSeries, SeriesArticle } from '../interfaces/article-series';
 import { transformArticleStrapiData } from '../utils/transform-article-strapi-data';
-
-const STRAPI_COMPONENT_TYPE = 'article-info.strapi-article';
+import { isStrapiArticle } from '../utils/setup/is-strapi-article';
 
 export class StrapiArticleSeries implements ArticleSeries {
     articles: SeriesArticle[];
@@ -15,8 +14,7 @@ export class StrapiArticleSeries implements ArticleSeries {
         this.articles = entries
             .map(article => {
                 if (!article) return null;
-                const isStrapi =
-                    article.strapi_component === STRAPI_COMPONENT_TYPE;
+                const isStrapi = isStrapiArticle(article);
                 // Strapi's API for articles is different from what Snooty provides
                 return isStrapi
                     ? this.handleStrapiArticle(article.article)
@@ -47,7 +45,7 @@ export class StrapiArticleSeries implements ArticleSeries {
     };
 
     handleStrapiArticle = article => {
-        if (!article.article) return null;
+        if (!article) return null;
         const { name, slug } = transformArticleStrapiData(article);
         return { slug, title: name };
     };

--- a/src/classes/strapi-article-series.ts
+++ b/src/classes/strapi-article-series.ts
@@ -6,37 +6,48 @@ import dlv from 'dlv';
 import { ArticleSeries, SeriesArticle } from '../interfaces/article-series';
 import { transformArticleStrapiData } from '../utils/transform-article-strapi-data';
 
+const STRAPI_COMPONENT_TYPE = 'article-info.strapi-article';
+
 export class StrapiArticleSeries implements ArticleSeries {
     articles: SeriesArticle[];
     title: String;
     constructor(title, entries, snootyTitleMapping) {
-        this.articles = entries.map(article => {
-            const isStrapi = !!article.article;
-            // Strapi's API for articles is different from what Snooty provides
-            return isStrapi
-                ? this.handleStrapiArticle(article.article)
-                : this.handleSnootyArticle(article, snootyTitleMapping);
-        });
+        this.articles = entries
+            .map(article => {
+                if (!article) return null;
+                const isStrapi =
+                    article.strapi_component === STRAPI_COMPONENT_TYPE;
+                // Strapi's API for articles is different from what Snooty provides
+                return isStrapi
+                    ? this.handleStrapiArticle(article.article)
+                    : this.handleSnootyArticle(article, snootyTitleMapping);
+            })
+            // Remove nulls
+            .filter(entry => !!entry);
         this.title = title;
     }
 
-    handleSnootyArticle = (article, snootyTitleMapping) => ({
-        slug: article.slug,
-        title: dlv(
-            snootyTitleMapping,
-            [
-                // Remove any leading/trailing slashes for use with Snooty's provided mapping
-                article.slug.replace(/^\/|\/$/g, ''),
-                'query_fields',
-                'title',
-                0,
-                'value',
-            ],
-            article.slug
-        ),
-    });
+    handleSnootyArticle = (article, snootyTitleMapping) => {
+        if (!article.slug) return null;
+        return {
+            slug: article.slug,
+            title: dlv(
+                snootyTitleMapping,
+                [
+                    // Remove any leading/trailing slashes for use with Snooty's provided mapping
+                    article.slug.replace(/^\/|\/$/g, ''),
+                    'query_fields',
+                    'title',
+                    0,
+                    'value',
+                ],
+                article.slug
+            ),
+        };
+    };
 
     handleStrapiArticle = article => {
+        if (!article.article) return null;
         const { name, slug } = transformArticleStrapiData(article);
         return { slug, title: name };
     };

--- a/src/utils/setup/is-strapi-article.js
+++ b/src/utils/setup/is-strapi-article.js
@@ -1,0 +1,4 @@
+const STRAPI_COMPONENT_TYPE = 'article-info.strapi-article';
+
+export const isStrapiArticle = articleObj =>
+    articleObj.strapi_component === STRAPI_COMPONENT_TYPE;


### PR DESCRIPTION
## Links:

-   [JIRA Ticket](https://jira.mongodb.org/browse/DEVHUB-801)
-   [Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-801/)

## Description:

-   This PR fixes an issue where DAs could add draft articles to a series (which is fine) but this would break on prod builds (which is not fine). This broke prod builds since the article coming back when pulling in the article was `null` if it is still in draft. The raw data looks like this:

```
    "seriesEntry": [
// Published article
      {
        "__component": "article-info.strapi-article",
        "_id": "61005e9fd1dcc8c72258c14e",
        "__v": 0,
        "article": {
          "type": "Article",
          "awaiting_editorial_review": false,
          "awaiting_technical_review": false,
          "editorial_review_LGTM": false,
          "technical_review_LGTM": false,
          "authors": [],
          "_id": "6079d96f6cd1a73ee7b45fa0",
          "published_at": "2021-04-15T15:57:50.644Z",
          "content": "This year for skunkworks, our team worked on two main projects: **Time to Read (TTR)** and **Article Associations**\n\n",
          "slug": "/devhub-skunkworks-2021",
          "description": "A look back at the awesome work done for Skunkworks 2021",
          "name": "Skunkworks - April 2021 Recap",
          "__v": 4,
          "SEO": "607862a65f09901d11e0f216",
          "languages": [
            "607861d35f09901d11e0f209"
          ],
          "products": [
            "607861d35f09901d11e0f20b",
            "607861d35f09901d11e0f20c"
          ],
          "tags": [
            "607861d45f09901d11e0f20f"
          ],
          "related_content": [],
          "createdAt": "2021-04-16T18:37:35.985Z",
          "updatedAt": "2021-04-16T18:37:36.442Z",
          "id": "6079d96f6cd1a73ee7b45fa0"
        },
        "id": "61005e9fd1dcc8c72258c14e"
      },
// Prod snooty article (slug)
      {
        "__component": "article-info.snooty-article",
        "_id": "61005e9fd1dcc8c72258c14f",
        "slug": "/quickstart/golang-multi-document-acid-transactions/",
        "__v": 0,
        "id": "61005e9fd1dcc8c72258c14f"
      },
// Draft strapi article
      {
        "__component": "article-info.strapi-article",
        "_id": "611589ea7211b86e9c8e36e0",
        "__v": 0,
        "article": null,
        "id": "611589ea7211b86e9c8e36e0"
      }
    ],
```

## Testing

-   Series should continue to function as expected
-   Will update CI tests to catch this case

## What types of outside events need to happen for this PR?

-   [ ] Documentation Updates
-   [ ] Product Review
-   [ ] Design Review
-   [ ] Release Note Update (only for deployments)
