### PR TITLE
Fix row gap in "Meet the Champions" section

### DIFF
--- a/src/components/pages/community-champions/meet-the-champions.js
+++ b/src/components/pages/community-champions/meet-the-champions.js
@@ -16,22 +16,25 @@ const PROFILE_PICTURE_GRADIENT_OFFSET = 8;
 const LOCATION_CONTAINER_TOP_MARGIN = '4px';
 const LOCATION_CONTAINER_MOBILE_TOP_MARGIN = '2px';
 const PIN_LOCATION_IMAGE_RIGHT_MARGIN = '4px';
+const CHAMPION_MOBILE_VERTICAL_MARGIN = '4px';
 
 const Title = styled(H1)`
-    margin-bottom: ${size.xlarge};
+    margin-bottom: calc(${size.xlarge} - ${size.xsmall});
     text-align: center;
     @media ${screenSize.upToLarge} {
-        margin-bottom: ${size.mediumLarge};
+        margin-bottom: ${size.medium};
     }
 `;
 
 const Container = styled('div')`
     background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
     margin: ${size.xlarge} -${size.xxlarge};
-    padding: ${size.xlarge} ${size.xxlarge};
+    padding: ${size.xlarge} ${size.xxlarge}
+        calc(${size.xlarge} - ${size.xsmall});
     @media ${screenSize.upToLarge} {
         margin: ${size.large} -${size.default};
-        padding: ${size.large} ${size.default};
+        padding: ${size.large} ${size.default}
+            calc(${size.large} - ${CHAMPION_MOBILE_VERTICAL_MARGIN});
     }
 `;
 
@@ -39,10 +42,6 @@ const ChampionsContainer = styled('div')`
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
-    row-gap: ${size.default};
-    @media ${screenSize.upToLarge} {
-        row-gap: ${size.xsmall};
-    }
 `;
 
 const ChampionLink = styled(Link)`
@@ -50,10 +49,14 @@ const ChampionLink = styled(Link)`
     border-radius: ${size.xsmall};
     display: flex;
     flex-direction: column;
+    margin: ${size.xsmall} 0;
     padding: ${size.default};
     text-align: center;
     text-decoration: none;
     width: ${CHAMPION_CONTAINER_WIDTH};
+    @media ${screenSize.upToLarge} {
+        margin: ${CHAMPION_MOBILE_VERTICAL_MARGIN} 0;
+    }
     @media ${screenSize.upToMedium} {
         padding: ${size.default} 0;
         width: ${CHAMPION_CONTAINER_MOBILE_WIDTH};

--- a/src/components/pages/community-champions/meet-the-champions.js
+++ b/src/components/pages/community-champions/meet-the-champions.js
@@ -1,0 +1,177 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import dlv from 'dlv';
+import { useStaticQuery, graphql } from 'gatsby';
+import Link from '~components/dev-hub/link';
+import ProfileImage from '~components/dev-hub/profile-image';
+import { H1, H6, P3, P4 } from '~components/dev-hub/text';
+import { screenSize, size } from '~components/dev-hub/theme';
+import LocationPinIcon from '~images/community-champions/location-pin-grey.svg';
+import ChampionPlaceholderImage from '~images/community-champions/champion-placeholder.svg';
+
+const CHAMPION_CONTAINER_WIDTH = '200px';
+const CHAMPION_CONTAINER_MOBILE_WIDTH = '170px';
+const PROFILE_PICTURE_SIZE = 112;
+const PROFILE_PICTURE_GRADIENT_OFFSET = 8;
+const LOCATION_CONTAINER_TOP_MARGIN = '4px';
+const LOCATION_CONTAINER_MOBILE_TOP_MARGIN = '2px';
+const PIN_LOCATION_IMAGE_RIGHT_MARGIN = '4px';
+
+const Title = styled(H1)`
+    margin-bottom: ${size.xlarge};
+    text-align: center;
+    @media ${screenSize.upToLarge} {
+        margin-bottom: ${size.mediumLarge};
+    }
+`;
+
+const Container = styled('div')`
+    background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
+    margin: ${size.xlarge} -${size.xxlarge};
+    padding: ${size.xlarge} ${size.xxlarge};
+    @media ${screenSize.upToLarge} {
+        margin: ${size.large} -${size.default};
+        padding: ${size.large} ${size.default};
+    }
+`;
+
+const ChampionsContainer = styled('div')`
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    row-gap: ${size.default};
+    @media ${screenSize.upToLarge} {
+        row-gap: ${size.xsmall};
+    }
+`;
+
+const ChampionLink = styled(Link)`
+    align-items: center;
+    border-radius: ${size.xsmall};
+    display: flex;
+    flex-direction: column;
+    padding: ${size.default};
+    text-align: center;
+    text-decoration: none;
+    width: ${CHAMPION_CONTAINER_WIDTH};
+    @media ${screenSize.upToMedium} {
+        padding: ${size.default} 0;
+        width: ${CHAMPION_CONTAINER_MOBILE_WIDTH};
+    }
+    &:hover,
+    &:focus {
+        background-color: ${({ theme }) => theme.colorMap.greyDarkTwo};
+        color: inherit;
+        cursor: pointer;
+    }
+`;
+
+const LocationPinImage = styled('img')`
+    margin-right: ${PIN_LOCATION_IMAGE_RIGHT_MARGIN};
+    vertical-align: text-top;
+`;
+
+const LocationText = styled(P4)`
+    color: ${({ theme }) => theme.colorMap.greyLightTwo};
+    margin-top: ${LOCATION_CONTAINER_TOP_MARGIN};
+    @media ${screenSize.upToMedium} {
+        margin-top: ${LOCATION_CONTAINER_MOBILE_TOP_MARGIN};
+    }
+`;
+
+const Location = ({ location }) => (
+    <LocationText collapse>
+        <LocationPinImage src={LocationPinIcon} alt="Location pin" />
+        {location}
+    </LocationText>
+);
+
+const Occupation = styled(P3)`
+    color: ${({ theme }) => theme.colorMap.greyLightTwo};
+`;
+
+const ProfilePicture = styled(ProfileImage)`
+    margin-bottom: ${size.default};
+    div {
+        ${props =>
+            props.image
+                ? `background-color: ${props.theme.colorMap.devWhite};`
+                : ''}
+        background-size: cover;
+    }
+`;
+
+const Champion = ({ imageUrl, location, name, title, to }) => (
+    <ChampionLink to={to}>
+        <ProfilePicture
+            defaultImage={ChampionPlaceholderImage}
+            gradientOffset={PROFILE_PICTURE_GRADIENT_OFFSET}
+            hideOnMobile={false}
+            image={imageUrl}
+            key={name}
+            height={PROFILE_PICTURE_SIZE}
+            width={PROFILE_PICTURE_SIZE}
+        />
+        <H6 collapse>{name}</H6>
+        <Occupation collapse>{title}</Occupation>
+        <Location location={location} />
+    </ChampionLink>
+);
+
+const communityChampions = graphql`
+    query CommunityChampions {
+        allStrapiCommunityChampions(
+            sort: { fields: [firstName, middleName, lastName] }
+        ) {
+            nodes {
+                id
+                firstName
+                middleName
+                lastName
+                location
+                title
+                image {
+                    url
+                }
+            }
+        }
+    }
+`;
+
+const List = () => {
+    const data = useStaticQuery(communityChampions);
+    const champions = dlv(data, ['allStrapiCommunityChampions', 'nodes'], []);
+    return (
+        <ChampionsContainer>
+            {champions.map(
+                ({
+                    firstName,
+                    id,
+                    image,
+                    lastName,
+                    location,
+                    middleName,
+                    title,
+                }) => (
+                    <Champion
+                        imageUrl={image ? image.url : null}
+                        key={id}
+                        location={location}
+                        name={[firstName, middleName, lastName].join(' ')}
+                        title={title}
+                        to={`/community-champions/${firstName.toLowerCase()}-${lastName.toLowerCase()}`}
+                    />
+                )
+            )}
+        </ChampionsContainer>
+    );
+};
+
+const MeetTheChampions = () => (
+    <Container>
+        <Title>Meet the Champions</Title>
+        <List />
+    </Container>
+);
+
+export default MeetTheChampions;

--- a/src/components/pages/community-champions/meet-the-champions.js
+++ b/src/components/pages/community-champions/meet-the-champions.js
@@ -97,7 +97,7 @@ const ProfilePicture = styled(ProfileImage)`
     margin-bottom: ${size.default};
     div {
         ${({ image, theme }) =>
-            image ? `background-color: ${theme.colorMap.devWhite};` : ''};
+            image ? `background-color: ${theme.colorMap.devWhite};` : ''}
         background-size: cover;
     }
 `;

--- a/src/components/pages/community-champions/meet-the-champions.js
+++ b/src/components/pages/community-champions/meet-the-champions.js
@@ -96,10 +96,8 @@ const Occupation = styled(P3)`
 const ProfilePicture = styled(ProfileImage)`
     margin-bottom: ${size.default};
     div {
-        ${props =>
-            props.image
-                ? `background-color: ${props.theme.colorMap.devWhite};`
-                : ''}
+        ${({ image, theme }) =>
+            image ? `background-color: ${theme.colorMap.devWhite};` : ''};
         background-size: cover;
     }
 `;

--- a/src/pages/community-champions.js
+++ b/src/pages/community-champions.js
@@ -1,7 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import dlv from 'dlv';
-import { useStaticQuery, graphql } from 'gatsby';
 import Button from '~components/dev-hub/button';
 import CommunityChampionApplication from '~components/dev-hub/community-champion-application';
 import GreenBulletedList from '~components/dev-hub/green-bulleted-list';
@@ -9,20 +7,8 @@ import HeroBanner from '~components/dev-hub/hero-banner';
 import Layout from '~components/dev-hub/layout';
 import Link from '~components/dev-hub/link';
 import MediaBlock from '~components/dev-hub/media-block';
-import ProfileImage from '~components/dev-hub/profile-image';
 import SEO from '~components/dev-hub/SEO';
-import {
-    H1,
-    H2,
-    H3,
-    H4,
-    H5,
-    H6,
-    P,
-    P2,
-    P3,
-    P4,
-} from '~components/dev-hub/text';
+import { H1, H2, H3, H4, H5, H6, P, P2 } from '~components/dev-hub/text';
 import {
     fontSize,
     lineHeight,
@@ -49,10 +35,9 @@ import GroupImage from '~images/community-champions/group.svg';
 import RocketShipImage from '~images/community-champions/rocket-ship.svg';
 import StackSquaresImage from '~images/community-champions/stack-squares.svg';
 import PaperAndPencilImage from '~images/community-champions/paper-and-pencil.svg';
-import LocationPinIcon from '~images/community-champions/location-pin-grey.svg';
-import ChampionPlaceholderImage from '~images/community-champions/champion-placeholder.svg';
 import useMedia from '~hooks/use-media';
 import { removePathPrefixFromUrl } from '~utils/remove-path-prefix-from-url';
+import MeetTheChampions from '~components/pages/community-champions/meet-the-champions';
 
 const APPLY_BUTTON_BOTTOM_MARGIN = '14px';
 const APPLY_BUTTON_MOBILE_BOTTOM_MARGIN = '12px';
@@ -75,13 +60,6 @@ const OTHER_DETAILS_AND_REQUIREMENTS_IMAGE_SIZE = '30%';
 const OTHER_DETAILS_AND_REQUIREMENTS_IMAGE_WIDTH = '70%';
 const OTHER_DETAILS_AND_REQUIREMENTS_DESCRIPTION_MAX_WIDTH = '690px';
 const OTHER_DETAILS_AND_REQUIREMENTS_LIST_MAX_WIDTH = '480px';
-const CHAMPION_ITEM_CONTAINER_WIDTH = '200px';
-const CHAMPION_ITEM_CONTAINER_MOBILE_WIDTH = '170px';
-const CHAMPION_PROFILE_PICTURE_SIZE = 112;
-const CHAMPION_PROFILE_PICTURE_GRADIENT_OFFSET = 8;
-const LOCATION_CONTAINER_TOP_MARGIN = '4px';
-const LOCATION_CONTAINER_MOBILE_TOP_MARGIN = '2px';
-const PIN_LOCATION_IMAGE_RIGHT_MARGIN = '4px';
 const FOR_THE_FUTURE_APPLY_BUTTON_TOP_MARGIN = '48px';
 const FOR_THE_FUTURE_DESCRIPTION_MAX_WIDTH = '760px';
 const OG_IMAGE = '/public/images/champions-badge.jpg';
@@ -510,148 +488,6 @@ const OtherDetailsAndRequirements = () => (
     </OtherDetailsAndRequirementsContainer>
 );
 
-const MeetTheChampionsContainer = styled('div')`
-    background-color: ${({ theme }) => theme.colorMap.greyDarkThree};
-    margin: ${size.xlarge} -${size.xxlarge};
-    padding: ${size.xlarge} ${size.xxlarge};
-    @media ${screenSize.upToLarge} {
-        margin: ${size.large} -${size.default};
-        padding: ${size.large} ${size.default};
-    }
-`;
-
-const ChampionsContainer = styled('div')`
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    row-gap: ${size.default};
-    @media ${screenSize.upToLarge} {
-        row-gap: ${size.xsmall};
-    } ;
-`;
-
-const ChampionLink = styled(Link)`
-    align-items: center;
-    border-radius: ${size.xsmall};
-    display: flex;
-    flex-direction: column;
-    padding: ${size.default};
-    text-align: center;
-    text-decoration: none;
-    width: ${CHAMPION_ITEM_CONTAINER_WIDTH};
-    @media ${screenSize.upToMedium} {
-        padding: ${size.default} 0;
-        width: ${CHAMPION_ITEM_CONTAINER_MOBILE_WIDTH};
-    }
-    &:hover,
-    &:focus {
-        background-color: ${({ theme }) => theme.colorMap.greyDarkTwo};
-        color: inherit;
-        cursor: pointer;
-    }
-`;
-
-const LocationPinImage = styled('img')`
-    margin-right: ${PIN_LOCATION_IMAGE_RIGHT_MARGIN};
-    vertical-align: text-top;
-`;
-
-const LocationText = styled(P4)`
-    color: ${({ theme }) => theme.colorMap.greyLightTwo};
-    margin-top: ${LOCATION_CONTAINER_TOP_MARGIN};
-    @media ${screenSize.upToMedium} {
-        margin-top: ${LOCATION_CONTAINER_MOBILE_TOP_MARGIN};
-    }
-`;
-
-const ChampionLocation = ({ location }) => (
-    <LocationText collapse>
-        <LocationPinImage src={LocationPinIcon} alt="Location pin" />
-        {location}
-    </LocationText>
-);
-
-const ChampionTitleText = styled(P3)`
-    color: ${({ theme }) => theme.colorMap.greyLightTwo};
-`;
-
-const ChampionProfilePicture = styled(ProfileImage)`
-    margin-bottom: ${size.default};
-    div {
-        ${props =>
-            props.image
-                ? `background-color: ${props.theme.colorMap.devWhite};`
-                : ''}
-        background-size: cover;
-    }
-`;
-
-const ChampionItem = ({ imageUrl, location, name, title, to }) => (
-    <ChampionLink to={to}>
-        <ChampionProfilePicture
-            defaultImage={ChampionPlaceholderImage}
-            gradientOffset={CHAMPION_PROFILE_PICTURE_GRADIENT_OFFSET}
-            hideOnMobile={false}
-            image={imageUrl}
-            key={name}
-            height={CHAMPION_PROFILE_PICTURE_SIZE}
-            width={CHAMPION_PROFILE_PICTURE_SIZE}
-        />
-        <H6 collapse>{name}</H6>
-        <ChampionTitleText collapse>{title}</ChampionTitleText>
-        <ChampionLocation location={location} />
-    </ChampionLink>
-);
-
-const communityChampions = graphql`
-    query CommunityChampions {
-        allStrapiCommunityChampions(
-            sort: { fields: [firstName, middleName, lastName] }
-        ) {
-            nodes {
-                id
-                firstName
-                middleName
-                lastName
-                location
-                title
-                image {
-                    url
-                }
-            }
-        }
-    }
-`;
-
-const ChampionList = () => {
-    const data = useStaticQuery(communityChampions);
-    const champions = dlv(data, ['allStrapiCommunityChampions', 'nodes'], []);
-    return (
-        <ChampionsContainer>
-            {champions.map(
-                ({
-                    firstName,
-                    id,
-                    image,
-                    lastName,
-                    location,
-                    middleName,
-                    title,
-                }) => (
-                    <ChampionItem
-                        imageUrl={image ? image.url : null}
-                        key={id}
-                        location={location}
-                        name={[firstName, middleName, lastName].join(' ')}
-                        title={title}
-                        to={`/community-champions/${firstName.toLowerCase()}-${lastName.toLowerCase()}`}
-                    />
-                )
-            )}
-        </ChampionsContainer>
-    );
-};
-
 const ForTheFutureTitle = styled(H1)`
     margin-bottom: ${size.large};
     text-align: center;
@@ -991,10 +827,7 @@ const CommunityChampions = () => {
                 </HowToQualifyContainer>
                 <Line />
                 <OtherDetailsAndRequirements />
-                <MeetTheChampionsContainer>
-                    <Title>Meet the Champions</Title>
-                    <ChampionList />
-                </MeetTheChampionsContainer>
+                <MeetTheChampions />
                 <ForTheFutureContainer>
                     <ForTheFutureTitle>For the Future</ForTheFutureTitle>
                     <ForTheFutureDescription collapse>


### PR DESCRIPTION
## Links:

-   ~~JIRA Ticket~~
-   [Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/CI/devhub/sophia.li/fix-safari-community-champions-row-gap/community-champions)

## Description:

-   Safari versions < 14.1 don't support flexbox gaps, so the row gaps in the "Meet the Champions" section don't show up. This PR replaces use of row gaps with vertical margins, and updates the title's bottom margin and container's bottom padding to make the spacing look the same as it was before. 
- I also moved this component into a separate file!

## Testing

- Go to the staging link on Safari and verify that there is spacing between the rows 
- Verify that nothing looks different on Chrome, you can use prod site to check!

## What types of outside events need to happen for this PR?

-   [ ] Documentation Updates
-   [ ] Product Review
-   [ ] Design Review
-   [ ] Release Note Update (only for deployments)
