### PR TITLE
Remove GTM from cypress CI builds

### DIFF
--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -34,6 +34,7 @@ jobs:
                   echo "GATSBY_PARSER_USER=jordanstapinski" >> .env.production; \
                   echo "GATSBY_PARSER_BRANCH=CI" >> .env.production; \
                   echo "GATSBY_SNOOTY_DEV=true" >> .env.production; \
+                  echo "DISABLE_GTM=true" >> .env.production; \
                   echo "STRAPI_URL=http://18.144.177.6:1337" >> .env.production
             - name: Build Gatsby
               run: npm run buildTest

--- a/cypress/integration/search.js
+++ b/cypress/integration/search.js
@@ -29,6 +29,9 @@ const checkSearchResults = page => {
 };
 
 const checkCondensedSearchbar = () => {
+    // TODO: Fix potential re-render on this button causing cypress to have issues
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(1000);
     cy.get(SEARCHBAR).should('not.exist');
     cy.get("[data-test='Closed Searchbar Button']")
         .should('exist')

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -89,6 +89,9 @@ module.exports = {
                 resolveSiteUrl: () => 'https://developer.mongodb.com/',
             },
         },
+        // We want to omit GTM for testing purposes (not on any production builds)
+        // This process of using the spread operator lets us simply add nothing to the
+        // plugins array if we don't want to use this plugin
         ...(process.env.DISABLE_GTM
             ? []
             : [

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -89,15 +89,17 @@ module.exports = {
                 resolveSiteUrl: () => 'https://developer.mongodb.com/',
             },
         },
-        process.env.DISABLE_GTM
-            ? null
-            : {
-                  resolve: 'gatsby-plugin-google-tagmanager',
-                  options: {
-                      id: 'GTM-GDFN',
-                      includeInDevelopment: false,
+        ...(process.env.DISABLE_GTM
+            ? []
+            : [
+                  {
+                      resolve: 'gatsby-plugin-google-tagmanager',
+                      options: {
+                          id: 'GTM-GDFN',
+                          includeInDevelopment: false,
+                      },
                   },
-              },
+              ]),
         {
             resolve: 'gatsby-plugin-feed',
             options: {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -89,13 +89,15 @@ module.exports = {
                 resolveSiteUrl: () => 'https://developer.mongodb.com/',
             },
         },
-        {
-            resolve: 'gatsby-plugin-google-tagmanager',
-            options: {
-                id: 'GTM-GDFN',
-                includeInDevelopment: false,
-            },
-        },
+        process.env.DISABLE_GTM
+            ? null
+            : {
+                  resolve: 'gatsby-plugin-google-tagmanager',
+                  options: {
+                      id: 'GTM-GDFN',
+                      includeInDevelopment: false,
+                  },
+              },
         {
             resolve: 'gatsby-plugin-feed',
             options: {


### PR DESCRIPTION
## Links:

-   [Staging Link without GTM](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/remove-gtm-testing/)

## Description:

-   This PR adds an opt-in way of disabling GTM for testing, etc. as a result of GTM issues causing CI failures

## Testing

-   Tests should pass

## What types of outside events need to happen for this PR?

-   [ ] Documentation Updates
-   [ ] Product Review
-   [ ] Design Review
-   [ ] Release Note Update (only for deployments)
