### PR TITLE
DEVHUB-583: Fix Directive Warnings (Break, Delete, Golang)

### DIFF
--- a/src/components/Break.js
+++ b/src/components/Break.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Break = () => <br />;
+
+export default Break;

--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { ADMONITIONS } from '../constants';
 import Admonition from './Admonition';
 import BlockQuote from './dev-hub/blockquote';
+import Break from './Break';
 import CardGroup from './CardGroup';
 import CodeBlock from './dev-hub/codeblock';
 import Chart from './dev-hub/chart';
@@ -77,6 +78,7 @@ export default class ComponentFactory extends Component {
         this.componentMap = {
             admonition: Admonition,
             blockquote: BlockQuote,
+            break: Break,
             'card-group': CardGroup,
             chart: Chart,
             charts: Chart,

--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -13,6 +13,7 @@ import Container from './Container';
 import CSSClass from './CSSClass';
 import DefinitionList from './DefinitionList';
 import DefinitionListItem from './DefinitionListItem';
+import Delete from './Delete';
 import Deprecated from './Deprecated';
 import Emphasis from './Emphasis';
 import Extract from './Extract';
@@ -90,6 +91,7 @@ export default class ComponentFactory extends Component {
             cssclass: CSSClass,
             definitionList: DefinitionList,
             definitionListItem: DefinitionListItem,
+            delete: Delete,
             deprecated: Deprecated,
             emphasis: Emphasis,
             extract: Extract,

--- a/src/components/Delete.js
+++ b/src/components/Delete.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import ComponentFactory from './ComponentFactory';
+
+// Screenreaders typically do not handle strikethrough text well
+// This gives us some additional callouts for screenreaders to read around the
+// text --> https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s
+const S = styled('s')`
+    /* Create some empty objects to be picked up as before/after */
+    ::before,
+    ::after {
+        clip-path: inset(100%);
+        clip: rect(1px, 1px, 1px, 1px);
+        height: 1px;
+        overflow: hidden;
+        position: absolute;
+        white-space: nowrap;
+        width: 1px;
+    }
+
+    ::before {
+        content: ' [start of strikethrough text] ';
+    }
+
+    ::after {
+        content: ' [end of strikethrough text] ';
+    }
+`;
+
+const Delete = ({ nodeData }) => (
+    <S>
+        {nodeData.children.map((child, index) => (
+            <ComponentFactory nodeData={child} key={index} />
+        ))}
+    </S>
+);
+
+export default Delete;

--- a/src/utils/determine-correct-leafygreen-language.js
+++ b/src/utils/determine-correct-leafygreen-language.js
@@ -12,6 +12,8 @@ export const determineCorrectLeafygreenLanguage = inputLang => {
         language = 'cs';
     } else if (language === 'sh') {
         language = 'shell';
+    } else if (language === 'golang') {
+        language = 'go';
     } else if (!SUPPORTED_LANGUAGES.has(language)) {
         // Language is not supported formally by LG, set to none to avoid errors
         const warningMessage = `Warning: Language ${language} is not supported. Defaulting to "none"`;


### PR DESCRIPTION
## Links:

-   [JIRA Ticket](https://jira.mongodb.org/browse/DEVHUB-583)
-   [Staging Link Strikethrough Example](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-583/how-to/adding-realm-as-dependency-ios-framework/#the-problem)
-   [Staging Link Break Example](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-583/project/hostels-kenya/#why-mongodb-)
-   [Staging Link golang example](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-583/how-to/get-hyped-using-docker-go-mongodb/)

## Description:

-   This PR resolves three warnings that would show at build-time:
1. Resolves a warning for `undefined (break) not implemented`. This occurred one time in the `/projects/hostels-kenya` page where someone wanted to use a Markdown `break` which should just render a `<br />` tag to move to a new line.
2. Resolves a warning for `undefined (delete) not implemented`. This occurred one time in `how-to/adding-realm-as-dependency-ios-framework/` in which someone wanted to use strikethrough text. We now support that directive.
3. Resolves a warning for `golang syntax not being recognized`. We now map `golang` to `go` when highlighting so it is picked up properly. This is from Strapi's code block options.

## Testing

-   These articles should render with these fixes

## What types of outside events need to happen for this PR?

-   [ ] Documentation Updates
-   [ ] Product Review
-   [ ] Design Review
-   [ ] Release Note Update (only for deployments)
