### PR TITLE
DEVHUB-798: Remove hyphens auto

### DIFF
--- a/src/components/Literal.js
+++ b/src/components/Literal.js
@@ -16,10 +16,6 @@ const StyledLiteral = styled('code')`
     background: ${({ theme }) => theme.colorMap.greyDarkThree};
     border-radius: 4px;
     color: ${({ theme }) => theme.colorMap.greyLightTwo};
-    overflow-wrap: break-word;
-    /* Disable hyphens for code */
-    --webkit-hyphens: none;
-    hyphens: none;
     ${tabletPadding};
     @media ${screenSize.mediumAndUp} {
         ${desktopPadding};

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -20,10 +20,6 @@ import ArticleRating from '~components/ArticleRating';
 import { ArticleRatingProvider } from '~components/ArticleRatingContext';
 
 const allowTextWrapping = css`
-    /* Use hyphens where available on content */
-    -webkit-hyphens: auto;
-    hyphens: auto;
-
     /* Wrap words/content across lines */
     /* word-wrap and overflow-wrap are identical aside from CSS2/3 renaming */
     overflow-wrap: break-word;

--- a/tests/unit/__snapshots__/DefinitionList.test.js.snap
+++ b/tests/unit/__snapshots__/DefinitionList.test.js.snap
@@ -6,7 +6,7 @@ exports[`DefinitionList renders correctly 1`] = `
 >
   <dt>
     <code
-      class="css-f3yzc6-StyledLiteral-tabletPadding-desktopPadding es3mzt60"
+      class="css-1xbrcdo-StyledLiteral-tabletPadding-desktopPadding es3mzt60"
     >
       MongoDefaultPartitioner
     </code>


### PR DESCRIPTION
## Links:

-   [JIRA Ticket](https://jira.mongodb.org/browse/DEVHUB-798)
-   [Staging Link](https://docs-mongodborg-staging.corp.mongodb.com/master/devhub/jordanstapinski/DEVHUB-798/)

## Description:

-   This PR removes the `hyphens: auto` css from articles. It also removes some related logic in the `literal` (inline code) component which was added to disable hyphens there, as we no longer need this change

## Testing

-   Articles should still render properly
-   Articles should still be mobile-responsive

## What types of outside events need to happen for this PR?

-   [ ] Documentation Updates
-   [ ] Product Review
-   [ ] Design Review
-   [ ] Release Note Update (only for deployments)
