### PR TITLE
Handle plus symbol in decodeURI

### DIFF
--- a/src/utils/query-string.js
+++ b/src/utils/query-string.js
@@ -9,6 +9,14 @@ export function buildQueryString(params) {
     return string.length === 0 ? '' : '?' + string;
 }
 
+/**
+ * decodeURIComponent doesn't handle parsing the plus symbol to a space
+ * This function allows us to handle this special case
+ * https://chromium.googlesource.com/chromium/src.git/+/62.0.3178.1/third_party/google_input_tools/third_party/closure_library/closure/goog/string/string.js?autodive=0%2F%2F%2F%2F#486
+ */
+const decodeURIComponentWithPlus = component =>
+    decodeURIComponent(component.replace(/\+/g, ' '));
+
 export function parseQueryString(querystring) {
     if (querystring.slice(0, 1) === '?') {
         querystring = querystring.slice(1);
@@ -24,7 +32,7 @@ export function parseQueryString(querystring) {
 
     const result = {};
     entries.forEach(entry => {
-        const [key, value] = entry.split('=').map(decodeURIComponent);
+        const [key, value] = entry.split('=').map(decodeURIComponentWithPlus);
         result[key] = value;
     });
     return result;


### PR DESCRIPTION
## Links:

-   No JIRA Ticket
-   [Staging Link](https://docs-mongodbcom-staging.corp.mongodb.com/master/devhub/jordanstapinski/decode-search-uri/)

## Description:

-   This PR fixes a potential issue with the incoming consistent nav. The incoming nav has a search bar which redirects people to DevHub's learn page. The issue is the encoding the nav is using does not URIencode `+` (for indicating a space) to `%20`, meaning we would render a search of `hello world` and `hello+world`. This PR swaps our logic to also decode this character as a space.
- Although the current search does not encode a `+` as `%3B` for example, the incoming one will and is releasing next week.

## Testing

-   Searching for `hello+world` off of the learn page (or URL directly) should bring someone to the learn page with the query of `hello world` with the `+` escaped

## What types of outside events need to happen for this PR?

-   [ ] Documentation Updates
-   [ ] Product Review
-   [ ] Design Review
-   [ ] Release Note Update (only for deployments)
