### PR TITLE
DEVHUB-848: Use grid sizing to prevent jumpy anchor link

### DIFF
--- a/src/components/dev-hub/consistent-nav.js
+++ b/src/components/dev-hub/consistent-nav.js
@@ -3,6 +3,9 @@ import styled from '@emotion/styled';
 import { UnifiedNav } from '@mdb/consistent-nav';
 import { layer } from '~components/dev-hub/theme';
 
+export const NAV_DESKTOP_HEIGHT = '88px';
+export const NAV_MOBILE_HEIGHT = '55px';
+
 const FrontLayeredNav = styled(UnifiedNav)`
     z-index: ${layer.superFront};
 `;

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -6,6 +6,10 @@ import Layout from '../components/dev-hub/layout';
 import { H2 } from '../components/dev-hub/text';
 import MediaBlock from '../components/dev-hub/media-block';
 import Card from '../components/dev-hub/card';
+import {
+    NAV_DESKTOP_HEIGHT,
+    NAV_MOBILE_HEIGHT,
+} from '../components/dev-hub/consistent-nav';
 import CardList from '../components/dev-hub/card-list';
 import EmptyTextFilterResults from '../components/dev-hub/empty-text-filter-results';
 import FilterBar from '../components/dev-hub/filter-bar';
@@ -21,6 +25,26 @@ const FEATURED_ARTICLE_MAX_WIDTH = '1200px';
 const FEATURED_ARTICLE_CARD_WIDTH = '410px';
 
 const Title = H2.withComponent('h1');
+
+const PrimaryMediaBlock = styled(MediaBlock)`
+    @media ${screenSize.upToMedium} {
+        /*
+        To prevent CLS on the anchor tag, we want to specify a 1:1 aspect
+        ratio by way of vw - padding on either side
+        */
+        grid-template-rows: calc(100vw - ${size.medium} - ${size.medium}) auto;
+    }
+`;
+
+const MainAnchor = styled('div')`
+    display: block;
+    position: relative;
+    top: -${NAV_DESKTOP_HEIGHT};
+    visibility: hidden;
+    @media ${screenSize.upToMedium} {
+        top: -${NAV_MOBILE_HEIGHT};
+    }
+`;
 
 const MainFeatureGrid = styled('div')`
     @media ${screenSize.mediumAndUp} {
@@ -46,6 +70,8 @@ const PrimarySection = styled('div')`
 
 const PrimaryImage = styled('img')`
     border-radius: ${size.small};
+    height: 100%;
+    width: 100%;
 `;
 
 const SecondArticle = styled(Card)`
@@ -160,9 +186,20 @@ const FeaturedArticles = ({ articles }) => {
     );
     return (
         <MainFeatureGrid data-test="featured-articles">
-            <PrimarySection data-test="primary-featured-article">
-                <MediaBlock
-                    mediaComponent={<PrimaryImage src={image} alt="" />}
+            <PrimarySection
+                data-test="primary-featured-article"
+                height="100%"
+                width="100%"
+            >
+                <PrimaryMediaBlock
+                    mediaComponent={
+                        <PrimaryImage
+                            height="100%"
+                            width="100%"
+                            src={image}
+                            alt=""
+                        />
+                    }
                     mediaWidth="360px"
                 >
                     <Card
@@ -172,7 +209,7 @@ const FeaturedArticles = ({ articles }) => {
                         description={description}
                         tags={tags}
                     />
-                </MediaBlock>
+                </PrimaryMediaBlock>
             </PrimarySection>
             <SecondaryFeaturedArticle
                 article={articles[1]}
@@ -333,9 +370,10 @@ const LearnPage = ({
                 </HeaderContent>
             </Header>
 
+            {/* ID used specifically for anchor links */}
+            <MainAnchor id="main" />
+
             <TabBar
-                // ID used specifically for anchor links
-                id="main"
                 handleClick={updateActiveFilter}
                 leftTabs={leftTabs}
                 rightTabs={rightTabs}


### PR DESCRIPTION
## Links:

-   [JIRA Ticket](https://jira.mongodb.org/browse/DEVHUB-848)
-   [Staging Link](http://developer-hub-staging.s3-website-us-east-1.amazonaws.com/master/devhub/jordanstapinski/DEVHUB-848/learn/#main)

## Description:

-   When people search with the new nav, because it is sticky we need to move the element with `id="main"` so that the options are not being cut off by the sticky nav.

## Testing

-   Staging link should go to the right place

## What types of outside events need to happen for this PR?

-   [ ] Documentation Updates
-   [ ] Product Review
-   [ ] Design Review
-   [ ] Release Note Update (only for deployments)
