### PR TITLE
Properly Await Snooty Image Upload

### DIFF
--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -138,10 +138,12 @@ const filterPageGroups = allSeries => {
 
 export const createPages = async ({ actions, graphql }) => {
     const { createPage, createRedirect } = actions;
+    let saveImages = () => {};
     if (!Boolean(process.env.GATSBY_PREVIEW_MODE)) {
-        saveAssetFiles(assets, stitchClient);
+        saveImages = async () => saveAssetFiles(assets, stitchClient);
     }
-    const [metadataDocument, result] = await Promise.all([
+    const [, metadataDocument, result] = await Promise.all([
+        saveImages(),
         stitchClient.callFunction('fetchDocument', [
             DB,
             METADATA_COLLECTION,


### PR DESCRIPTION
## Links:

-   [Staging Link](http://developer-hub-staging.s3-website-us-east-1.amazonaws.com/master/devhub/jordanstapinski/await-images/)

## Description:

This PR fixes a race condition where snooty images may not always be uploaded to S3 on a deploy

## What types of outside events need to happen for this PR?

-   [ ] Documentation Updates
-   [ ] Product Review
-   [ ] Design Review
-   [ ] Release Note Update (only for deployments)
