### PR TITLE
DEVHUB-872: Remove old subdomain from sitemap settings

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -85,8 +85,6 @@ module.exports = {
                     '/quickstart/nodejs-change-streams-triggers/',
                     '/quickstart/nodejs-change-streams-triggers-3-3-2/',
                 ],
-                // We don't want the old sitemap pointing to the new domain yet, remove this when implementing 301 redirects.
-                resolveSiteUrl: () => 'https://developer.mongodb.com/',
             },
         },
         // We want to omit GTM for testing purposes (not on any production builds)

--- a/gatsby-config.prod.js
+++ b/gatsby-config.prod.js
@@ -82,8 +82,6 @@ module.exports = {
                     '/quickstart/nodejs-change-streams-triggers/',
                     '/quickstart/nodejs-change-streams-triggers-3-3-2/',
                 ],
-                // We don't want the old sitemap pointing to the new domain yet, remove this when implementing 301 redirects.
-                resolveSiteUrl: () => 'https://developer.mongodb.com/',
             },
         },
         {


### PR DESCRIPTION
## Links:

-   [JIRA Ticket](https://jira.mongodb.org/browse/DEVHUB-872)
-   [Staging Link](http://developer-hub-staging.s3-website-us-east-1.amazonaws.com/master/devhub/jordanstapinski/DEVHUB-872/sitemap/sitemap-index.xml)

## Description:

-   This PR fixes a bug where the sitemaps were constructing to the old domain with a /developer prefix. The desired behavior is to now direct to the new domain. This PR removes a line intended to be removed right after the subdomain consolidation.

## Testing

-   Check the sitemap linked, it should link to mongodb.com/PATH_PREFIX_FOR_BUILD/...
-   PATH_PREFIX_FOR_BUILD comes from [here](https://github.com/mongodb/devhub/blob/staging/src/utils/generate-path-prefix.js#L3)

## What types of outside events need to happen for this PR?

-   [ ] Documentation Updates
-   [ ] Product Review
-   [ ] Design Review
-   [ ] Release Note Update (only for deployments)
