### PR TITLE
DRAFT DEVHUB-108: Conditionally add sublist spacing

### DIFF
--- a/src/components/List.js
+++ b/src/components/List.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import ComponentFactory from './ComponentFactory';
 import { colorMap, size } from './dev-hub/theme';
@@ -11,10 +12,14 @@ const enumtypeMap = {
     upperroman: 'I',
 };
 
+const removeBottomMargin = css`
+    margin-bottom: 0;
+`;
+
 const UnorderedList = styled('ul')`
     list-style: none;
     margin-bottom: ${size.articleContent};
-    margin-top: -${size.xsmall};
+    margin-top: 0;
     padding-left: ${size.medium};
     li:before {
         content: '○';
@@ -27,10 +32,12 @@ const UnorderedList = styled('ul')`
     li {
         display: flex;
     }
+    ${({ isSublist }) => isSublist && removeBottomMargin};
 `;
 
 const List = ({
     nodeData: { children, enumtype, ordered, startat },
+    parentNode,
     ...rest
 }) => {
     const isUnorderedInSnooty = enumtype === 'unordered';
@@ -45,8 +52,12 @@ const List = ({
     if (startat) {
         attributes.start = startat;
     }
+    let isSublist = false;
+    if (parentNode && parentNode === 'listItem') {
+        isSublist = true;
+    }
     return (
-        <ListTag {...attributes}>
+        <ListTag isSublist={isSublist} {...attributes}>
             {children.map((listChild, index) => (
                 <ComponentFactory {...rest} nodeData={listChild} key={index} />
             ))}

--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import dlv from 'dlv';
 import PropTypes from 'prop-types';
 import ComponentFactory from './ComponentFactory';
 
@@ -6,17 +7,23 @@ const ListItem = ({ nodeData, ...rest }) => (
     <li>
         {/* div provides flex alignment with preceding bullet */}
         <div>
-            {nodeData.children.map((child, index) => (
-                <ComponentFactory
-                    {...rest}
-                    nodeData={child}
-                    key={index}
-                    // Include <p> tags in <li> if there is more than one paragraph
-                    parentNode={
-                        nodeData.children.length === 1 ? 'listItem' : undefined
-                    }
-                />
-            ))}
+            {nodeData.children.map((child, index) => {
+                const hasSublist =
+                    dlv(nodeData, 'children.1.type', '') === 'list';
+                const parentNode =
+                    nodeData.children.length === 1 || hasSublist
+                        ? 'listItem'
+                        : undefined;
+                return (
+                    <ComponentFactory
+                        {...rest}
+                        nodeData={child}
+                        key={index}
+                        // Include <p> tags in <li> if there is more than one paragraph
+                        parentNode={parentNode}
+                    />
+                );
+            })}
         </div>
     </li>
 );


### PR DESCRIPTION
## Links:

-   [JIRA Ticket](https://jira.mongodb.org/browse/DEVHUB-108)
-   [Staging Link](https://developer-hub-staging.s3-website-us-east-1.amazonaws.com/master/devhub/jordanstapinski/DEVHUB-108/how-to/build-ci-cd-pipelines-realm-apps-github-actions/)

## Description:

-   This PR updates the rules for when we apply bottom margins on lists
   -   If we have a sublist, don't apply bottom margin to that sublist (the parent bottom margin applies as a larger block)
   -   Don't apply `p` styling to the element leading a sublist
   
See the ticket for more on this, but [this article](https://developer-hub-staging.s3-website-us-east-1.amazonaws.com/master/devhub/jordanstapinski/DEVHUB-108/how-to/build-ci-cd-pipelines-realm-apps-github-actions/) has a ton of sublists.

## Testing

-   We will need some more validation that the different potential list cases work as anticipated. This is TBD.

## What types of outside events need to happen for this PR?

-   [ ] Documentation Updates
-   [X] Product Review
-   [X] Design Review --> Mike gave verbal sign-off but we want to look at more cases
-   [ ] Release Note Update (only for deployments)
