### PR TITLE
DEVHUB-888: Add developWithHostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ $ npm run buildTest
 $ npm run serveTest
 ```
 
-This will then serve the site at `localhost:9000`
+This will then serve the site at `localhost:9000`.
+
+For using `developWithHostname`, see the [wiki](https://wiki.corp.mongodb.com/display/DEVREL/DevHub+Front-End+Guide) for more instructions.
 
 ## Staging
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "buildTest": "gatsby build",
     "clean": "gatsby clean",
     "develop": "gatsby develop",
+    "developWithHostname": "gatsby develop --host=devhub-local.mongodb.com --https",
     "format": "prettier --write",
     "lint": "eslint --fix",
     "preview": "webpack-dev-server --open --config ./webpack.config.js --env.PREVIEW_MODE='cli'",


### PR DESCRIPTION
## Links:

-   [JIRA Ticket](https://jira.mongodb.org/browse/DEVHUB-888)

## Description:

-   This PR adds configuration for a new command `developWithHostname`. This allows us to spin up a development server at a local Fully-Qualified Domain Name.

## Testing

-   Try to follow the steps in the wiki to setup /etc/hosts and see if you can spin it up!

## What types of outside events need to happen for this PR?

-   [ ] Documentation Updates
-   [ ] Product Review
-   [ ] Design Review
-   [ ] Release Note Update (only for deployments)
