### PR TITLE
WIP DEVHUB-911: Create Discourse Embed UI Component

### DIFF
--- a/.github/workflows/devhub-ci-test.yaml
+++ b/.github/workflows/devhub-ci-test.yaml
@@ -42,6 +42,7 @@ jobs:
             - name: Build Gatsby
               run: npm run buildTest
               env:
+                  DISCOURSE_URL: ${{ secrets.STAGING_DISCOURSE_URL }}
                   NPM_BASE_64_AUTH: ${{ secrets.ARTIFACTORY_NPM_AUTH }}
                   NPM_EMAIL: ${{ secrets.ARTIFACTORY_NPM_EMAIL }}
             - name: Cypress run
@@ -51,6 +52,7 @@ jobs:
                   start: npm run serveTest
                   wait-on: 'http://localhost:9000'
               env:
+                  DISCOURSE_URL: ${{ secrets.STAGING_DISCOURSE_URL }}
                   NPM_BASE_64_AUTH: ${{ secrets.ARTIFACTORY_NPM_AUTH }}
                   NPM_EMAIL: ${{ secrets.ARTIFACTORY_NPM_EMAIL }}
             - name: Generate artifacts on failure

--- a/src/components/dev-hub/forum-embed.js
+++ b/src/components/dev-hub/forum-embed.js
@@ -1,0 +1,37 @@
+import React, { useEffect } from 'react';
+
+/**
+ * Component to embed a Discourse community forums thread on a page. Uses the
+ * canonical URL to identify which thread in Discourse to use. If no thread
+ * exists, loading this page for the first-time will create such thread.
+ *
+ * Discourse Embed API: https://meta.discourse.org/t/embedding-discourse-comments-via-javascript/31963
+ *
+ * @param {string} canonicalUrl The Canonical URL of the page to embed forums on
+ * This canonical url will be used to sync with a forums thread
+ * @returns div with an id to be used by Discourse to populate
+ */
+const ForumEmbed = ({ canonicalUrl }) => {
+    useEffect(() => {
+        window.DiscourseEmbed = {
+            discourseUrl: process.env.DISCOURSE_URL,
+            discourseEmbedUrl: canonicalUrl,
+        };
+
+        (function () {
+            var d = document.createElement('script');
+            d.type = 'text/javascript';
+            d.async = true;
+            d.src = window.DiscourseEmbed.discourseUrl + 'javascripts/embed.js';
+            (
+                document.getElementsByTagName('head')[0] ||
+                document.getElementsByTagName('body')[0]
+            ).appendChild(d);
+        })();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return <div id="discourse-comments"></div>;
+};
+
+export default ForumEmbed;

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -18,6 +18,7 @@ import ArticleSchema from '../components/dev-hub/article-schema';
 import BlogShareLinks from '../components/dev-hub/blog-share-links';
 import ArticleRating from '~components/ArticleRating';
 import { ArticleRatingProvider } from '~components/ArticleRatingContext';
+import ForumEmbed from '~components/dev-hub/forum-embed';
 
 const allowTextWrapping = css`
     /* Wrap words/content across lines */
@@ -239,6 +240,7 @@ const Article = props => {
                     related={related}
                     slugTitleMapping={slugTitleMapping}
                 />
+                <ForumEmbed />
             </Layout>
         </ArticleRatingProvider>
     );


### PR DESCRIPTION
## Links:

-   [JIRA Ticket](https://jira.mongodb.org/browse/DEVHUB-911)
-   Staging Link TBD

## Description:

-   This PR adds the Discourse Embed API code to the front-end in a reusable component. Once the component mounts, it runs code to fetch Discourse data (and create a thread if it does not yet exist). 
-   This PR is still awaiting Forums config of our development URLs

## Testing

-   Tests likely will fail at this point because the staging forums site needs authentication. Unless this can be done via a URL (instead of modal popup) it likely will block interaction on the page

## What types of outside events need to happen for this PR?

-   [ ] Documentation Updates
-   [ ] Product Review
-   [ ] Design Review
-   [ ] Release Note Update (only for deployments)
