### PR TITLE
DEVHUB-921: Move excluded learn page articles to CMS

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -42,6 +42,7 @@ module.exports = {
                 ]),
                 queryLimit: 0,
                 singleTypes: mapPublicationStateToArray([
+                    'excluded-learn-page-articles',
                     'feedback-rating-flow',
                     'home-page-featured-articles',
                     'learn-page-featured-articles',

--- a/gatsby-config.prod.js
+++ b/gatsby-config.prod.js
@@ -39,6 +39,7 @@ module.exports = {
                 ]),
                 queryLimit: 0,
                 singleTypes: mapPublicationStateToArray([
+                    'excluded-learn-page-articles',
                     'feedback-rating-flow',
                     'home-page-featured-articles',
                     'learn-page-featured-articles',

--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -20,6 +20,7 @@ import {
     METADATA_COLLECTION,
 } from './src/build-constants';
 import { createArticlePage } from './src/utils/setup/create-article-page';
+import { getExcludedLearnPageArticlesFromGraphql } from './src/utils/setup/get-excluded-learn-page-articles-from-graphql';
 import { getFeaturedArticlesFromGraphql } from './src/utils/setup/get-featured-articles-from-graphql';
 import { getStrapiArticleListFromGraphql } from './src/utils/setup/get-strapi-article-list-from-graphql';
 import { schemaCustomization } from './src/utils/setup/schema-customization';
@@ -128,11 +129,6 @@ export const onCreateNode = async ({ node }) => {
     }
 };
 
-const filterPageGroups = allSeries => {
-    // also remove a group of excluded articles
-    excludedLearnPageArticles = allSeries.learnPageExclude;
-};
-
 export const createPages = async ({ actions, graphql }) => {
     const { createPage, createRedirect } = actions;
     let saveImages = () => {};
@@ -159,7 +155,6 @@ export const createPages = async ({ actions, graphql }) => {
         throw new Error(`Page build error: ${result.error}`);
     }
 
-    filterPageGroups(metadataDocument.pageGroups);
     const articleSeries = await getStrapiArticleSeriesFromGraphql(
         graphql,
         slugContentMapping
@@ -230,6 +225,10 @@ export const createPages = async ({ actions, graphql }) => {
         await getFeaturedArticlesFromGraphql(graphql);
     homeFeaturedArticles = homePageFeaturedArticles;
     learnFeaturedArticles = learnPageFeaturedArticles;
+
+    excludedLearnPageArticles = await getExcludedLearnPageArticlesFromGraphql(
+        graphql
+    );
 };
 
 // Prevent errors when running gatsby build caused by browser packages run in a node environment.

--- a/src/queries/excluded-learn-page-articles.js
+++ b/src/queries/excluded-learn-page-articles.js
@@ -1,0 +1,7 @@
+export const excludedLearnPageArticles = `
+  query ExcludedLearnPageArticles {
+    strapiExcludedLearnPageArticles {
+      articles
+    }
+  }
+`;

--- a/src/utils/setup/get-excluded-learn-page-articles-from-graphql.js
+++ b/src/utils/setup/get-excluded-learn-page-articles-from-graphql.js
@@ -4,7 +4,7 @@ import { transformArticleStrapiData } from '../transform-article-strapi-data';
 
 const STRAPI_COMPONENT_TYPE = 'article-info.strapi-article';
 
-const mapFeaturedArticle = article =>
+const mapExcludedArticle = article =>
     article.strapi_component === STRAPI_COMPONENT_TYPE
         ? article.article
             ? transformArticleStrapiData(article.article).slug
@@ -21,7 +21,7 @@ export const getExcludedLearnPageArticlesFromGraphql = async graphql => {
         // type since it is redundant with the type field
         // The case is snooty first and then Strapi second
     )
-        .map(mapFeaturedArticle)
+        .map(mapExcludedArticle)
         .filter(a => !!a);
     return excludedArticles;
 };

--- a/src/utils/setup/get-excluded-learn-page-articles-from-graphql.js
+++ b/src/utils/setup/get-excluded-learn-page-articles-from-graphql.js
@@ -1,0 +1,27 @@
+import dlv from 'dlv';
+import { excludedLearnPageArticles } from '../../queries/excluded-learn-page-articles';
+import { transformArticleStrapiData } from '../transform-article-strapi-data';
+
+const STRAPI_COMPONENT_TYPE = 'article-info.strapi-article';
+
+const mapFeaturedArticle = article =>
+    article.strapi_component === STRAPI_COMPONENT_TYPE
+        ? article.article
+            ? transformArticleStrapiData(article.article).slug
+            : null
+        : article.slug;
+
+export const getExcludedLearnPageArticlesFromGraphql = async graphql => {
+    const data = await graphql(excludedLearnPageArticles);
+    const excludedArticles = dlv(
+        data,
+        'data.strapiExcludedLearnPageArticles.articles',
+        []
+        // This isn't quite polymorphic, since for Strapi a slug by default excludes the
+        // type since it is redundant with the type field
+        // The case is snooty first and then Strapi second
+    )
+        .map(mapFeaturedArticle)
+        .filter(a => !!a);
+    return excludedArticles;
+};

--- a/src/utils/setup/remove-excluded-articles.js
+++ b/src/utils/setup/remove-excluded-articles.js
@@ -5,8 +5,8 @@ export const removeExcludedArticles = (
     if (excludedLearnPageArticles && excludedLearnPageArticles.length) {
         const filteredArticles = allArticles.filter(
             article =>
-                !excludedLearnPageArticles.find(excludedArticle =>
-                    article.slug.match(new RegExp(`^/?${excludedArticle}$`))
+                !excludedLearnPageArticles.find(
+                    excludedArticle => article.slug === excludedArticle
                 )
         );
         // Warn writers if not all excludes were found

--- a/src/utils/setup/remove-excluded-articles.js
+++ b/src/utils/setup/remove-excluded-articles.js
@@ -1,3 +1,5 @@
+import { fuzzySlugMatch } from '../fuzzy-slug-match';
+
 export const removeExcludedArticles = (
     allArticles,
     excludedLearnPageArticles
@@ -5,8 +7,8 @@ export const removeExcludedArticles = (
     if (excludedLearnPageArticles && excludedLearnPageArticles.length) {
         const filteredArticles = allArticles.filter(
             article =>
-                !excludedLearnPageArticles.find(
-                    excludedArticle => article.slug === excludedArticle
+                !excludedLearnPageArticles.find(excludedArticle =>
+                    fuzzySlugMatch(article.slug, excludedArticle)
                 )
         );
         // Warn writers if not all excludes were found

--- a/src/utils/setup/schema-customization.js
+++ b/src/utils/setup/schema-customization.js
@@ -79,6 +79,9 @@ export const schemaCustomization = ({ actions }) => {
         youtubeUrl: String
         twitchUrl: String
     }
+    type StrapiExcludedLearnPageArticles implements Node {
+        articles: JSON
+    }
     type StrapiHomePageFeaturedArticles implements Node {
         articles: JSON
     }


### PR DESCRIPTION
## Links:

-   [JIRA Ticket](https://jira.mongodb.org/browse/DEVHUB-921)

## Description:

-   Combined with the CMS PR, this moves the last rST functionality into the DevHub CMS - excluding showing several articles on the learn page

## What types of outside events need to happen for this PR?

-   [ ] Documentation Updates
-   [ ] Product Review
-   [ ] Design Review
-   [ ] Release Note Update (only for deployments)
