### PR TITLE
DEVHUB-923: Add community type for articles

### DIFF
--- a/src/utils/setup/serialize-rss-data.js
+++ b/src/utils/setup/serialize-rss-data.js
@@ -1,5 +1,6 @@
 const typeMap = {
     Article: 'article',
+    Community: 'community',
     HowTo: 'how-to',
     Quickstart: 'quickstart',
 };

--- a/src/utils/setup/serialize-search-rss-data.js
+++ b/src/utils/setup/serialize-search-rss-data.js
@@ -1,5 +1,6 @@
 const typeMap = {
     Article: 'article',
+    Community: 'community',
     HowTo: 'how-to',
     Quickstart: 'quickstart',
 };

--- a/src/utils/transform-article-strapi-data.js
+++ b/src/utils/transform-article-strapi-data.js
@@ -5,6 +5,7 @@ import { addTrailingSlashIfMissing } from '../utils/add-trailing-slash-if-missin
 
 const typeMap = {
     Article: 'article',
+    Community: 'community',
     HowTo: 'how-to',
     Quickstart: 'quickstart',
 };


### PR DESCRIPTION
## Links:

-   [JIRA Ticket](https://jira.mongodb.org/browse/DEVHUB-923)

## Description:

-   There is a 4th type of article which is not used often called `community`. This PR prepares to parse it as a new article type coming from the CMS.
-   [These are the only rST articles that use it](https://github.com/10gen/devhub-content/tree/master/source/community)

## What types of outside events need to happen for this PR?

-   [ ] Documentation Updates
-   [ ] Product Review
-   [ ] Design Review
-   [ ] Release Note Update (only for deployments)
