### PR TITLE
DEVHUB-925 Adds a new field original publish date to strapi articles

### DIFF
--- a/cypress/integration/learn.js
+++ b/cypress/integration/learn.js
@@ -1,7 +1,7 @@
 const CANONICAL_URL = 'https://www.mongodb.com/developer/learn/';
 const FIRST_ARTICLE_IN_ORDERING =
     '/article/3-things-to-know-switch-from-sql-mongodb/';
-const FIRST_ARTICLE_UPDATED_DATE = 'Nov 17, 2021';
+const FIRST_ARTICLE_UPDATED_DATE = 'Dec 01, 2021';
 const FIRST_ARTICLE_PUBLISHED_DATE = 'Apr 01, 2020';
 const SECOND_ARTICLE_TITLE = 'Active-Active';
 

--- a/src/classes/strapi-article.ts
+++ b/src/classes/strapi-article.ts
@@ -51,7 +51,7 @@ export class StrapiArticle implements Article {
             'product',
             true
         );
-        this.publishedDate = toISODate(mappedArticle.published_at);
+        this.publishedDate = toISODate(mappedArticle.originalPublishDate ? mappedArticle.originalPublishDate : mappedArticle.published_at);
         this.related = mappedArticle.related;
         this.SEO = mappedArticle.SEO;
         this.slug = mappedArticle.slug;

--- a/src/queries/articles.js
+++ b/src/queries/articles.js
@@ -40,6 +40,7 @@ query Articles {
         }
         name
         published_at
+        originalPublishDate
         updatedAt
         related_content {
           label


### PR DESCRIPTION
When articles are imported from either Rst or medium or any other frame work we want it to carry original date of the post as its published date, instead of the date it is published from strapi. This PR addresses that issue and original Publish date takes precedence over strapi's pubhished at.
