### PR TITLE
DEVHUB-939 Fixing ordering for snooty original articles

### DIFF
--- a/cypress/integration/article.js
+++ b/cypress/integration/article.js
@@ -47,7 +47,7 @@ describe('Sample Article Page', () => {
                 // Check title
                 cy.contains(ARTICLE_TITLE);
                 // Check pubdate
-                cy.contains('Published: Apr 01, 2020');
+                cy.contains('Published: Dec 01, 2021');
                 // Check tags
                 cy.checkTagListProperties();
                 // Check author

--- a/cypress/integration/learn.js
+++ b/cypress/integration/learn.js
@@ -1,8 +1,8 @@
 const CANONICAL_URL = 'https://www.mongodb.com/developer/learn/';
 const FIRST_ARTICLE_IN_ORDERING =
     '/article/3-things-to-know-switch-from-sql-mongodb/';
-const FIRST_ARTICLE_UPDATED_DATE = 'Dec 01, 2021';
-const FIRST_ARTICLE_PUBLISHED_DATE = 'Apr 01, 2020';
+const FIRST_ARTICLE_UPDATED_DATE = 'Jan 18, 2022';
+const FIRST_ARTICLE_PUBLISHED_DATE = 'Dec 01, 2021';
 const SECOND_ARTICLE_TITLE = 'Active-Active';
 
 describe('Learn Page', () => {

--- a/src/classes/strapi-article.ts
+++ b/src/classes/strapi-article.ts
@@ -25,6 +25,7 @@ export class StrapiArticle implements Article {
     title: String;
     type: ArticleCategory;
     updatedDate: String;
+    isOriginallySnooty: boolean;
     constructor(article) {
         const mappedArticle = transformArticleStrapiData(article);
         this._id = mappedArticle.id;
@@ -59,5 +60,6 @@ export class StrapiArticle implements Article {
         this.title = mappedArticle.name;
         this.type = mappedArticle.type;
         this.updatedDate = toISODate(mappedArticle.updatedAt);
+        this.isOriginallySnooty = mappedArticle.originalPublishDate ? true : false;
     }
 }

--- a/src/components/dev-hub/active-card-list-filter.js
+++ b/src/components/dev-hub/active-card-list-filter.js
@@ -5,13 +5,13 @@ import { LearnPageTabs } from '../../utils/learn-page-tabs';
 const ActiveCardListFilter = ({ activeContentTab, textFilterResults }) => {
     switch (activeContentTab) {
         case LearnPageTabs.articles:
-            return <CardList articles={textFilterResults} />;
+            return <CardList articles={textFilterResults} shouldSort />;
         case LearnPageTabs.videos:
-            return <CardList videos={textFilterResults} />;
+            return <CardList videos={textFilterResults} shouldSort />;
         case LearnPageTabs.podcasts:
-            return <CardList podcasts={textFilterResults} />;
+            return <CardList podcasts={textFilterResults} shouldSort />;
         default:
-            return <CardList all={textFilterResults} />;
+            return <CardList all={textFilterResults} shouldSort />;
     }
 };
 

--- a/src/components/dev-hub/card-list.js
+++ b/src/components/dev-hub/card-list.js
@@ -23,11 +23,17 @@ const getThumbnailUrl = media => {
 
 // publishDate is for videos. TODO is to have this follow articles
 const sortCardsByDate = contentList =>
-    contentList.sort(
-        (a, b) =>
-            new Date(b.updatedDate || b.publishedDate || b.publishDate) -
-            new Date(a.updatedDate || a.publishedDate || a.publishDate)
-    );
+    contentList.sort((a, b) => {
+        const date1 =
+            b.isOriginallySnooty != true
+                ? b.updatedDate || b.publishedDate || b.publishDate
+                : b.publishedDate || b.publishDate || b.updatedDate;
+        const date2 =
+            a.isOriginallySnooty != true
+                ? a.updatedDate || a.publishedDate || a.publishDate
+                : a.publishedDate || a.publishDate || a.updatedDate;
+        return new Date(date1) - new Date(date2);
+    });
 
 const renderArticle = article => (
     <ArticleCard

--- a/src/interfaces/article.ts
+++ b/src/interfaces/article.ts
@@ -17,4 +17,5 @@ export interface Article {
     title: String;
     type: ArticleCategory;
     updatedDate?: String;
+    isOriginallySnooty?: boolean;
 }


### PR DESCRIPTION
 Previously we used to sort cards by update date. With the migration of RST articles into CMS a lot of old articles are being surfaced in the front pages due to their latest update dates. This PR adds the logic to use Published Date instead of Update date while sorting the articles migrated from RST.